### PR TITLE
docs(missing components): create list of all missing components of d2-ui

### DIFF
--- a/docs/missing-components.md
+++ b/docs/missing-components.md
@@ -1,0 +1,30 @@
+# Missing components
+
+* [Chip](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/chip)
+* [CheckBox](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/form-fields/CheckBox.component.js)
+* [ControlBar](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/control-bar)
+  * Should be in `ui-widgets`
+* [DatePicker](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/form-fields/DatePicker.component.js)
+* [Feedback Snackbar](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/feedback-snackbar)
+* [Heading](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/headings)
+  * Not needed in `ui-core`
+* [Layout Components](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/layout)
+  * Not needed in `ui-core`
+* [ListSelect Components](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/list-select)
+  * Not needed in `ui-core`
+  * The searchable list component could be of interest
+* [LoadingMask](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/loading-mask)
+* [Message](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/messages)
+  * Could be used as the message for form input components as well
+* [MultiToggle](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/form-fields/MultiToggle.js)
+* [Pagination](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/pagination)
+* [PeriodPicker](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/period-picker)
+* [Sidebar](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/sidebar)
+  * Should be in `ui-widgets`
+* [SvgIcon](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/svg-icon)
+  * Wrapper for MUI Icons, which we don't want to use anymore
+  * Should not be part of `ui-core`, could have its own lib (ui-icons?)
+* [Tabs](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/tabs)
+  * Should be in `ui-widgets`
+* [TreeView](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/tree-view)
+  * Should be in `ui-widgets`

--- a/docs/missing-components.md
+++ b/docs/missing-components.md
@@ -1,7 +1,5 @@
 # Missing components
 
-* [Chip](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/chip)
-* [CheckBox](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/form-fields/CheckBox.component.js)
 * [ControlBar](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/control-bar)
   * Should be in `ui-widgets`
 * [DatePicker](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/form-fields/DatePicker.component.js)
@@ -13,7 +11,6 @@
 * [ListSelect Components](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/list-select)
   * Not needed in `ui-core`
   * The searchable list component could be of interest
-* [LoadingMask](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/loading-mask)
 * [Message](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/messages)
   * Could be used as the message for form input components as well
 * [MultiToggle](https://github.com/dhis2/d2-ui/tree/master/packages/core/src/form-fields/MultiToggle.js)


### PR DESCRIPTION
I added a doc with all the components of `d2-ui` which I think are missing.

There are some components that shouldn't be part of `ui-core`, I've added a comment to those.
Furthermore there are also some components of which I think that they're not needed, they either look like components that are only used in one place (`Heading`?) or add unnecessary complexity (like the layout components).

If you agree with my thoughts about which components not to add to `ui-core`, I'll remove them from the list.