### PR TITLE
feat(drop-menu): compute position relative to anchor element

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -5,48 +5,42 @@ import propTypes from 'prop-types'
 
 import styles from './styles.js'
 
-const Button = React.forwardRef(
-    (
-        {
-            type,
-            children,
-            icon,
-            name,
-            value,
-            disabled,
-            onClick,
-            className,
+const Button = ({
+    type,
+    children,
+    icon,
+    name,
+    value,
+    disabled,
+    onClick,
+    className,
+    primary,
+    secondary,
+    destructive,
+    small,
+    large,
+}) => (
+    <button
+        disabled={disabled}
+        onClick={evt => onClick && onClick(name, value)}
+        className={cx(className, {
             primary,
             secondary,
             destructive,
             small,
             large,
-        },
-        ref
-    ) => (
-        <button
-            disabled={disabled}
-            onClick={evt => onClick && onClick(name, value)}
-            className={cx(className, {
-                primary,
-                secondary,
-                destructive,
-                small,
-                large,
-                'icon-only': icon && !children,
-                icon,
-            })}
-            type={type}
-            name={name}
-            value={value}
-            ref={ref}
-        >
-            {icon && <span className="button-icon">{icon}</span>}
-            {children}
+            'icon-only': icon && !children,
+            icon,
+        })}
+        type={type}
+        name={name}
+        value={value}
+    >
+        {icon && <span className="button-icon">{icon}</span>}
+        {children}
 
-            <style jsx>{styles}</style>
-        </button>
-    )
+        <style jsx>{styles}</style>
+    </button>
 )
 
 Button.defaultProps = {

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -5,44 +5,48 @@ import propTypes from 'prop-types'
 
 import styles from './styles.js'
 
-const Button = ({
-    type,
-    children,
-    icon,
-    name,
-    value,
-    disabled,
-    onClick,
-    className,
-    basic,
-    primary,
-    secondary,
-    destructive,
-    small,
-    medium,
-    large,
-}) => (
-    <button
-        disabled={disabled}
-        onClick={evt => onClick && onClick(name, value)}
-        className={cx(className, {
+const Button = React.forwardRef(
+    (
+        {
+            type,
+            children,
+            icon,
+            name,
+            value,
+            disabled,
+            onClick,
+            className,
             primary,
             secondary,
             destructive,
             small,
             large,
-            'icon-only': icon && !children,
-            icon,
-        })}
-        type={type}
-        name={name}
-        value={value}
-    >
-        {icon && <span className="button-icon">{icon}</span>}
-        {children}
+        },
+        ref
+    ) => (
+        <button
+            disabled={disabled}
+            onClick={evt => onClick && onClick(name, value)}
+            className={cx(className, {
+                primary,
+                secondary,
+                destructive,
+                small,
+                large,
+                'icon-only': icon && !children,
+                icon,
+            })}
+            type={type}
+            name={name}
+            value={value}
+            ref={ref}
+        >
+            {icon && <span className="button-icon">{icon}</span>}
+            {children}
 
-        <style jsx>{styles}</style>
-    </button>
+            <style jsx>{styles}</style>
+        </button>
+    )
 )
 
 Button.defaultProps = {

--- a/src/DropMenu/getPosition.js
+++ b/src/DropMenu/getPosition.js
@@ -1,0 +1,23 @@
+export const getPosition = anchorEl => {
+    if (!anchorEl) {
+        return {
+            top: 'auto',
+            left: 'auto',
+        }
+    }
+
+    const body = document.body
+    const docEl = document.documentElement
+    const rect = anchorEl.getBoundingClientRect()
+    const scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop
+    const scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft
+    const clientTop = docEl.clientTop || body.clientTop || 0
+    const clientLeft = docEl.clientLeft || body.clientLeft || 0
+    const top = rect.bottom + scrollTop - clientTop
+    const left = rect.left + scrollLeft - clientLeft
+
+    return {
+        top: `${top}px`,
+        left: `${left}px`,
+    }
+}

--- a/src/DropMenu/index.js
+++ b/src/DropMenu/index.js
@@ -12,7 +12,7 @@ class DropMenu extends PureComponent {
 
     componentDidMount() {
         document.addEventListener('click', this.onDocClick)
-        this.setState(getPosition(this.props.anchorRef.current))
+        this.setState(getPosition(this.props.anchorEl))
     }
 
     componentWillUnmount() {
@@ -59,8 +59,8 @@ DropMenu.propTypes = {
     onClose: propTypes.func,
     /** Decides if the menu should call the onClose function or not */
     stayOpen: propTypes.bool,
-    /** Ref to DOM node to position itself against */
-    anchorRef: propTypes.shape({ current: propTypes.instanceOf(Element) }),
+    /** DOM node to position itself against */
+    anchorEl: propTypes.instanceOf(Element),
 }
 
 export { DropMenu }

--- a/src/DropMenu/index.js
+++ b/src/DropMenu/index.js
@@ -12,11 +12,17 @@ class DropMenu extends PureComponent {
 
     componentDidMount() {
         document.addEventListener('click', this.onDocClick)
-        this.setState(getPosition(this.props.anchorEl))
+        window.addEventListener('resize', this.updatePosition)
+        this.updatePosition()
     }
 
     componentWillUnmount() {
         document.removeEventListener('click', this.onDocClick)
+        window.removeEventListener('resize', this.updatePosition)
+    }
+
+    updatePosition = () => {
+        this.setState(getPosition(this.props.anchorEl))
     }
 
     onDocClick = evt => {

--- a/src/DropMenu/index.js
+++ b/src/DropMenu/index.js
@@ -1,11 +1,18 @@
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import ReactDOM from 'react-dom'
 import propTypes from 'prop-types'
-import css from 'styled-jsx/css'
+import { getPosition } from './getPosition'
 
-class DropMenu extends Component {
+class DropMenu extends PureComponent {
+    state = {
+        top: 'auto',
+        left: 'auto',
+    }
+    elContainer = React.createRef()
+
     componentDidMount() {
         document.addEventListener('click', this.onDocClick)
+        this.setState(getPosition(this.props.anchorRef.current))
     }
 
     componentWillUnmount() {
@@ -14,8 +21,8 @@ class DropMenu extends Component {
 
     onDocClick = evt => {
         if (
-            this.elContainer &&
-            !this.elContainer.contains(evt.target) &&
+            this.elContainer.current &&
+            !this.elContainer.current.contains(evt.target) &&
             !this.props.stayOpen
         ) {
             this.props.onClose()
@@ -24,14 +31,18 @@ class DropMenu extends Component {
 
     render() {
         const { className, component } = this.props
+        const { top, left } = this.state
+
         return ReactDOM.createPortal(
-            <div className={className} ref={c => (this.elContainer = c)}>
+            <div className={className} ref={this.elContainer}>
                 {component}
 
                 <style jsx>{`
                     div {
                         z-index: 1000;
                         position: absolute;
+                        top: ${top};
+                        left: ${left};
                     }
                 `}</style>
             </div>,
@@ -42,13 +53,14 @@ class DropMenu extends Component {
 
 DropMenu.propTypes = {
     className: propTypes.string,
-
     /** The component to use as the dropdown component */
     component: propTypes.element,
     /** Function to trigger when click happens outside of the DOM element */
     onClose: propTypes.func,
     /** Decides if the menu should call the onClose function or not */
     stayOpen: propTypes.bool,
+    /** Ref to DOM node to position itself against */
+    anchorRef: propTypes.shape({ current: propTypes.instanceOf(Element) }),
 }
 
 export { DropMenu }

--- a/src/DropdownButton/index.js
+++ b/src/DropdownButton/index.js
@@ -22,12 +22,8 @@ class DropdownButton extends Component {
         const ArrowIcon = open ? <ArrowUp /> : <ArrowDown />
 
         return (
-            <div>
-                <Button
-                    ref={this.anchorRef}
-                    onClick={this.onToggle}
-                    {...this.props}
-                >
+            <div ref={this.anchorRef}>
+                <Button onClick={this.onToggle} {...this.props}>
                     {this.props.children}
 
                     {ArrowIcon}

--- a/src/DropdownButton/index.js
+++ b/src/DropdownButton/index.js
@@ -12,6 +12,7 @@ class DropdownButton extends Component {
     state = {
         open: false,
     }
+    anchorRef = React.createRef()
 
     onToggle = () => this.setState({ open: !this.state.open })
 
@@ -22,7 +23,11 @@ class DropdownButton extends Component {
 
         return (
             <div>
-                <Button onClick={this.onToggle} {...this.props}>
+                <Button
+                    ref={this.anchorRef}
+                    onClick={this.onToggle}
+                    {...this.props}
+                >
                     {this.props.children}
 
                     {ArrowIcon}
@@ -32,6 +37,7 @@ class DropdownButton extends Component {
                     <DropMenu
                         component={this.props.component}
                         onClose={() => this.setState({ open: false })}
+                        anchorRef={this.anchorRef}
                     />
                 )}
 

--- a/src/DropdownButton/index.js
+++ b/src/DropdownButton/index.js
@@ -33,7 +33,7 @@ class DropdownButton extends Component {
                     <DropMenu
                         component={this.props.component}
                         onClose={() => this.setState({ open: false })}
-                        anchorRef={this.anchorRef}
+                        anchorEl={this.anchorRef.current}
                     />
                 )}
 

--- a/src/SplitButton/index.js
+++ b/src/SplitButton/index.js
@@ -29,6 +29,7 @@ class SplitButton extends Component {
     state = {
         open: false,
     }
+    anchorRef = React.createRef()
 
     onToggle = () => this.setState({ open: !this.state.open })
 
@@ -45,6 +46,7 @@ class SplitButton extends Component {
                         this.props.onClick(this.props.name, this.props.value)
                     }
                     className={cx(this.props.className, leftButton.className)}
+                    ref={this.anchorRef}
                 >
                     {this.props.children}
                 </Button>
@@ -61,6 +63,7 @@ class SplitButton extends Component {
                     <DropMenu
                         component={this.props.component}
                         onClose={() => this.setState({ open: false })}
+                        anchorRef={this.anchorRef}
                     />
                 )}
 

--- a/src/SplitButton/index.js
+++ b/src/SplitButton/index.js
@@ -39,14 +39,13 @@ class SplitButton extends Component {
         const icon = open ? <ArrowUp /> : <ArrowDown />
 
         return (
-            <div>
+            <div ref={this.anchorRef}>
                 <Button
                     {...this.props}
                     onClick={evt =>
                         this.props.onClick(this.props.name, this.props.value)
                     }
                     className={cx(this.props.className, leftButton.className)}
-                    ref={this.anchorRef}
                 >
                     {this.props.children}
                 </Button>

--- a/src/SplitButton/index.js
+++ b/src/SplitButton/index.js
@@ -62,7 +62,7 @@ class SplitButton extends Component {
                     <DropMenu
                         component={this.props.component}
                         onClose={() => this.setState({ open: false })}
-                        anchorRef={this.anchorRef}
+                        anchorEl={this.anchorRef.current}
                     />
                 )}
 


### PR DESCRIPTION
### Context
This PR ties in to the comment I made here https://github.com/dhis2/ui-core/pull/183#pullrequestreview-224460229:
> SplitButton and DropDownButton use a very simple div with position absolute to render stuff into a “Popover-menu”. This approach is fragile: there are going to be situations where the menu isn’t rendered fully if the container has overflow-y hidden, and also potential z-index problems if parents also have certain z-index properties (a child's z-index is set to the same stacking index as its parent). It would be better to render stuff in a portal (React.createPortal) as the last child of the document body. Stuff does become more complex this way because the position will have to be computed, but it will be more robust.

Based on this comment, the DropMenu was created, which addressed the concerns. However, the position of this component would quite likely be incorrect. In fact the only scenario in which the position would be correct is if the button is the last child of the body without any margin.

### Solution
`DropMenu` now has an additional prop `anchorEl` which represents a DOM node against which the `DropMenu` can position itself, and a function `getPosition` that computes the correct top and left position fro the `DropMenu`.

### Some notes on using refs
In essence, I think that the current implementation (i.e. as last child of the body and absolutely positioned against an anchor) is the mosts robust way of showing a "popover". However, it does mean that every component that uses the `DropMenu` must be able to provide a ref to a DOM node. This means using refs on the anchor element/component. This should always be possible, but there are several scenarios with different solutions:
- If the anchor a regular DOM node: no problem, just add a ref
- If the anchor is a class based React component: you can add a ref to that, but it will just return the component-instance, not a DOM node. To get an actual DOM node, you have two choices:
   - Add a ref for the DOM node to the component instance, so it can be read this way (recommended)
   - Leave the component as is and use `ReactDOM.findDOMNode` (deprecated in StrictMode)
- If the anchor is a stateless/functional component, you can wrap this component in a call to `React.forwardRef` ([see docs](https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-to-dom-components))
- In scenarios where you can't or don't want to change the anchor-component's code, you can always add a wrapper element...

There are several way's of working with refs. For example:
- When using callback refs the value of the ref is a DOM node
- When using `React.createRef()` the value of the ref is an object with a `.current` property, which is the DOM node.

Because of these differences, I decided it would be better that the `DropMenu` got an additional `anchorEl` prop, instead of a `anchorRef` prop. This way the component that renders `DropMenu` can decide how it want to work with refs, as long as it just passes the actual referenced DOM node to the `DropMenu`