### PR TITLE
fix(input-field): add className to container

### DIFF
--- a/src/FieldLabel/Filled/index.js
+++ b/src/FieldLabel/Filled/index.js
@@ -105,9 +105,10 @@ export const Filled = ({
     required,
     label,
     loading,
+    className,
 }) => (
     <div
-        className={cx('label-filled', {
+        className={cx('label-filled', className, {
             disabled,
             focus,
             dense,
@@ -167,4 +168,6 @@ Filled.propTypes = {
     loading: propTypes.bool,
 
     dense: propTypes.bool,
+
+    className: propTypes.string,
 }

--- a/src/FieldLabel/Outlined/index.js
+++ b/src/FieldLabel/Outlined/index.js
@@ -102,9 +102,10 @@ export const Outlined = ({
     required,
     label,
     loading,
+    className,
 }) => (
     <div
-        className={cx('label-outlined', {
+        className={cx('label-outlined', className, {
             disabled,
             focus,
             dense,
@@ -160,4 +161,6 @@ Outlined.propTypes = {
     loading: propTypes.bool,
 
     dense: propTypes.bool,
+
+    className: propTypes.string,
 }

--- a/src/InputField/index.js
+++ b/src/InputField/index.js
@@ -23,6 +23,7 @@ class InputField extends React.Component {
 
     render() {
         const {
+            className,
             onChange,
             type,
             filled,
@@ -55,6 +56,7 @@ class InputField extends React.Component {
                 error={error}
                 loading={loading}
                 dense={dense}
+                className={className}
             >
                 <Input
                     focus={focus}


### PR DESCRIPTION
Now passing the `className` prop down to the `Container`, which can be either the `Filled` or the `Outlined` `FieldLabel`