### PR TITLE
fix: styled-jsx needs to be a peer dep for all libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "size-limit": "^1.0.0",
     "storybook-addon-jsx": "^7.0.0",
     "storybook-addon-react-docgen": "^1.2.1",
-    "typeface-roboto": "^0.0.54"
+    "typeface-roboto": "^0.0.54",
+    "styled-jsx": "^3.2.1"
   },
   "peerDependencies": {
     "prop-types": "^15.x.x",

--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
     "typeface-roboto": "^0.0.54"
   },
   "peerDependencies": {
-    "prop-types": "^15",
-    "react": "^16.3",
-    "react-dom": "^16.3"
+    "prop-types": "^15.x.x",
+    "react": "^16.3.x",
+    "react-dom": "^16.3.x",
+    "styled-jsx": "^3.2.1"
   },
   "dependencies": {
-    "classnames": "^2.2.6",
-    "styled-jsx": "^3.2.1"
+    "classnames": "^2.2.6"
   },
   "files": [
     "build"


### PR DESCRIPTION
Because of https://github.com/zeit/styled-jsx/issues/64 styled-jsx needs
to be a peer dependency for all libraries, and pulled in once by the
App, so the instance can be shared.