### PR TITLE
feat(checkbox): accept children as an alternative to the label prop

### DIFF
--- a/src/Checkbox/Icon.js
+++ b/src/Checkbox/Icon.js
@@ -11,6 +11,7 @@ const icons = resolve`
         height: 24px;
         width: 24px;
         fill: ${theme.default};
+        cursor: pointer;
     }
 
     .checked {
@@ -19,6 +20,7 @@ const icons = resolve`
 
     .disabled {
         fill: ${theme.disabled};
+        cursor: not-allowed;
     }
 
     .error {

--- a/src/Checkbox/Label.js
+++ b/src/Checkbox/Label.js
@@ -5,16 +5,15 @@ import cx from 'classnames'
 
 import { colors, theme } from '../theme'
 
-export const Label = ({ disabled, required, children }) => {
+export const Label = ({ htmlFor, disabled, required, children }) => {
     const className = cx('label', { disabled, required })
 
     return (
-        <span className={className}>
+        <label className={className}>
             {children}
 
             <style jsx>{`
                 .label {
-                    margin: 0 0 0 8px;
                     color: ${colors.grey900};
                     cursor: pointer;
                 }
@@ -29,11 +28,12 @@ export const Label = ({ disabled, required, children }) => {
                     color: ${theme.disabled};
                 }
             `}</style>
-        </span>
+        </label>
     )
 }
 
 Label.propTypes = {
+    htmlFor: propTypes.string.isRequired,
     disabled: propTypes.bool,
     required: propTypes.bool,
 }

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -21,8 +21,9 @@ const Checkbox = ({
     valid,
     warning,
     error,
+    children,
 }) => (
-    <label
+    <div
         className={cx('base', className, {
             disabled,
         })}
@@ -43,17 +44,29 @@ const Checkbox = ({
             indeterminate={indeterminate}
         />
 
-        <Label required={required}>{label}</Label>
+        <span class={cx('label')}>
+            {children ? (
+                children
+            ) : (
+                <Label htmlFor={name} required={required} disabled={disabled}>
+                    {label}
+                </Label>
+            )}
+        </span>
 
         <style jsx>{`
-            label {
+            div {
                 display: flex;
                 flex-direction: row;
-                align-items: center;
+                align-items: top;
                 justify-content: flex-start;
-                cursor: pointer;
                 pointer-events: all;
                 user-select: none;
+            }
+
+            span {
+                padding-top: 3px;
+                margin: 0 0 0 8px;
             }
 
             .disabled {
@@ -61,15 +74,15 @@ const Checkbox = ({
                 color: ${theme.disabled};
             }
         `}</style>
-    </label>
+    </div>
 )
 
 Checkbox.propTypes = {
     onChange: propTypes.func.isRequired,
 
     name: propTypes.string.isRequired,
-    label: propTypes.string.isRequired,
 
+    label: propTypes.string,
     className: propTypes.string,
 
     indeterminate: propTypes.bool,
@@ -80,5 +93,7 @@ Checkbox.propTypes = {
     warning: propTypes.bool,
     error: propTypes.bool,
 }
+
+Checkbox.Label = Label
 
 export { Checkbox }

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -62,3 +62,14 @@ storiesOf('Checkbox', module)
     .add('Status: Error', () => (
         <Checkbox name="Ex" label="Checkbox" error checked onChange={logger} />
     ))
+
+    .add('With children', () => (
+        <Checkbox name="Ex" onChange={logger}>
+            <div>
+                <div>
+                    <Checkbox.Label>Checkbox label</Checkbox.Label>
+                </div>
+                <div>Some additional content</div>
+            </div>
+        </Checkbox>
+    ))


### PR DESCRIPTION
This PR prepares the checkbox component to be used for the org unit tree widget.
The `Checkbox` component now accepts contents either via label prop or via children, by exposing the `Label` component as `Checkbox.Label`.

This way, more items can be added that are aligned with the label text automatically, which do not trigger the checkbox to be (de-)selected when interacted with.

In order to achieve this, I changed the container element from `label` to `div`, changed the `Label`'s element from `span` to `label` and added the `htmlFor` property which uses the name that's provided to the Checkbox component.

A story to demonstrate this way of constructing a checkbox has been added as well.