### PR TITLE
feat: use a portal to overlay the loader

### DIFF
--- a/src/CircularProgress/index.js
+++ b/src/CircularProgress/index.js
@@ -5,66 +5,30 @@ import cx from 'classnames'
 
 import styles from './styles.js'
 
-import { ScreenCover } from '../ScreenCover'
-
-const Overlay = ({ children }) =>
-    createPortal(
-        <div>
-            <ScreenCover />
-
-            {children}
-            <style jsx>{`
-                div {
-                    display: flex;
-                    position: absolute;
-                    top: 0;
-                    right: 0;
-                    bottom: 0;
-                    left: 0;
-                    align-items: center;
-                    justify-content: center;
-                    width: 100%;
-                    height: 100%;
-                }
-            `}</style>
-        </div>,
-        document.body
-    )
-
-function CircularProgress({ small, large, overlay, className }) {
-    const loader = (
-        <div
-            role="progressbar"
-            className={cx(className, {
-                small,
-                large,
-            })}
-        >
-            <svg viewBox="22 22 44 44">
-                <circle
-                    className="circle"
-                    cx="44"
-                    cy="44"
-                    r="20.2"
-                    fill="none"
-                    strokeWidth="3.6"
-                />
-            </svg>
-            <style jsx>{styles}</style>
-        </div>
-    )
-
-    if (overlay) {
-        return <Overlay>{loader}</Overlay>
-    }
-
-    return loader
-}
+const CircularProgress = ({ small, large, className }) => (
+    <div
+        role="progressbar"
+        className={cx(className, {
+            small,
+            large,
+        })}
+    >
+        <svg viewBox="22 22 44 44">
+            <circle
+                className="circle"
+                cx="44"
+                cy="44"
+                r="20.2"
+                fill="none"
+                strokeWidth="3.6"
+            />
+        </svg>
+        <style jsx>{styles}</style>
+    </div>
+)
 
 CircularProgress.propTypes = {
     className: propTypes.string,
-
-    overlay: propTypes.bool,
     small: propTypes.bool,
     large: propTypes.bool,
 }

--- a/src/CircularProgress/index.js
+++ b/src/CircularProgress/index.js
@@ -1,29 +1,35 @@
 import React from 'react'
+import { createPortal } from 'react-dom'
 import propTypes from 'prop-types'
 import cx from 'classnames'
 
 import styles from './styles.js'
 
-const Overlay = ({ children }) => (
-    <div>
-        {children}
-        <style jsx>{`
-            div {
-                display: flex;
-                position: absolute;
-                top: 0;
-                right: 0;
-                bottom: 0;
-                left: 0;
-                align-items: center;
-                justify-content: center;
-                width: 100%;
-                height: 100%;
-                background: rgba(0, 0, 0, 0.08);
-            }
-        `}</style>
-    </div>
-)
+import { ScreenCover } from '../ScreenCover'
+
+const Overlay = ({ children }) =>
+    createPortal(
+        <div>
+            <ScreenCover />
+
+            {children}
+            <style jsx>{`
+                div {
+                    display: flex;
+                    position: absolute;
+                    top: 0;
+                    right: 0;
+                    bottom: 0;
+                    left: 0;
+                    align-items: center;
+                    justify-content: center;
+                    width: 100%;
+                    height: 100%;
+                }
+            `}</style>
+        </div>,
+        document.body
+    )
 
 function CircularProgress({ small, large, overlay, className }) {
     const loader = (

--- a/src/ComponentCover/index.js
+++ b/src/ComponentCover/index.js
@@ -4,7 +4,7 @@ import css from 'styled-jsx/css'
 import cx from 'classnames'
 
 const ComponentCover = ({ children, className }) => (
-    <div className={cx('component-cover', className)}>
+    <div className={className}>
         {children}
         <style jsx>{`
             div {

--- a/src/ComponentCover/index.js
+++ b/src/ComponentCover/index.js
@@ -3,8 +3,8 @@ import propTypes from 'prop-types'
 import css from 'styled-jsx/css'
 import cx from 'classnames'
 
-const ComponentCover = ({ children }) => (
-    <div className="component-cover">
+const ComponentCover = ({ children, className }) => (
+    <div className={cx('component-cover', className)}>
         {children}
         <style jsx>{`
             div {
@@ -12,12 +12,10 @@ const ComponentCover = ({ children }) => (
                 align-items: center;
                 justify-content: center;
 
-                position: relative;
-                left: 0;
-                top: 0;
+                position: absolute;
 
-                height: 100%;
-                width: 100%;
+                height: inherit;
+                width: inherit;
 
                 z-index: 900;
                 background: rgba(200, 200, 200, 0.6);
@@ -28,6 +26,7 @@ const ComponentCover = ({ children }) => (
 
 ComponentCover.propTypes = {
     children: propTypes.node,
+    className: propTypes.string,
 }
 
 export { ComponentCover }

--- a/src/ComponentCover/index.js
+++ b/src/ComponentCover/index.js
@@ -1,0 +1,32 @@
+import React, { Fragment } from 'react'
+import propTypes from 'prop-types'
+import css from 'styled-jsx/css'
+import cx from 'classnames'
+
+const ComponentCover = ({ onClick, children }) => (
+    <div className="component-cover" onClick={onClick}>
+        {children}
+        <style jsx>{`
+            div {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+
+                position: relative;
+                left: 0;
+                top: 0;
+
+                height: 100%;
+                width: 100%;
+
+                background: rgba(200, 200, 200, 0.6);
+            }
+        `}</style>
+    </div>
+)
+
+ComponentCover.propTypes = {
+    onClick: propTypes.func,
+}
+
+export { ComponentCover }

--- a/src/ComponentCover/index.js
+++ b/src/ComponentCover/index.js
@@ -19,6 +19,7 @@ const ComponentCover = ({ children }) => (
                 height: 100%;
                 width: 100%;
 
+                z-index: 900;
                 background: rgba(200, 200, 200, 0.6);
             }
         `}</style>

--- a/src/ComponentCover/index.js
+++ b/src/ComponentCover/index.js
@@ -3,8 +3,8 @@ import propTypes from 'prop-types'
 import css from 'styled-jsx/css'
 import cx from 'classnames'
 
-const ComponentCover = ({ onClick, children }) => (
-    <div className="component-cover" onClick={onClick}>
+const ComponentCover = ({ children }) => (
+    <div className="component-cover">
         {children}
         <style jsx>{`
             div {
@@ -26,7 +26,7 @@ const ComponentCover = ({ onClick, children }) => (
 )
 
 ComponentCover.propTypes = {
-    onClick: propTypes.func,
+    children: propTypes.node,
 }
 
 export { ComponentCover }

--- a/src/LinearProgress/index.js
+++ b/src/LinearProgress/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import propTypes from 'prop-types'
 import cx from 'classnames'
-import styles from './styles'
 import { theme } from '../theme.js'
 
 const Progress = ({ indeterminate, amount }) => {
     const width = amount ? `width: ${amount}%;` : ''
+    const height = '4px'
+
     return (
         <div
             className={cx({
@@ -21,22 +22,22 @@ const Progress = ({ indeterminate, amount }) => {
             <style jsx>{`
                 div {
                     background-color: ${theme.primary600};
-
-                    top: 0;
-                    bottom: 0;
-                    left: 0;
                     transition: width 0.3s linear;
+                    height: ${height};
                 }
 
                 .determinate {
                     position: absolute;
+                    top: 0;
+                    left: 0;
                 }
 
                 .indeterminate:before {
                     position: absolute;
+                    height: ${height};
                     top: 0;
-                    bottom: 0;
                     left: 0;
+
                     background-color: inherit;
                     animation: anim-indeterminate 2.1s
                         cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
@@ -46,9 +47,10 @@ const Progress = ({ indeterminate, amount }) => {
 
                 .indeterminate:after {
                     position: absolute;
+                    height: ${height};
                     top: 0;
-                    bottom: 0;
                     left: 0;
+
                     background-color: inherit;
                     animation: anim-indeterminate-short 2.1s
                         cubic-bezier(0.165, 0.84, 0.44, 1) infinite;
@@ -95,17 +97,15 @@ const Progress = ({ indeterminate, amount }) => {
     )
 }
 
-const LinearProgress = ({ amount, margin = '0px', className }) => {
+const LinearProgress = ({ amount, margin = '10px', className }) => {
     return (
         <div role="progressbar" className={className}>
             <Progress amount={amount} />
+
             <style jsx>{`
                 div {
                     display: block;
-                    position: relative;
 
-                    width: 100%;
-                    height: 4px;
                     overflow: hidden;
                     overflow-x: hidden;
                     overflow-y: hidden;

--- a/src/LinearProgress/styles.js
+++ b/src/LinearProgress/styles.js
@@ -1,5 +1,0 @@
-import css from 'styled-jsx/css'
-
-import { theme } from '../theme.js'
-
-export default css``

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -22,21 +22,15 @@ import { Title } from './Title'
 export const Modal = ({ children, onClose, small, large, open }) => {
     return createPortal(
         <aside className={cx({ open })}>
-            <ScreenCover onClick={onClose} />
-
-            <ModalCard small={small} large={large}>
-                {children}
-            </ModalCard>
+            <ScreenCover onClick={onClose}>
+                <ModalCard small={small} large={large}>
+                    {children}
+                </ModalCard>
+            </ScreenCover>
 
             <style jsx>{`
                 aside {
                     display: none;
-                    height: 100%;
-                    left: 0;
-                    position: fixed;
-                    top: 0;
-                    width: 100%;
-                    z-index: 99999999;
                 }
 
                 .open {

--- a/src/ScreenCover/index.js
+++ b/src/ScreenCover/index.js
@@ -1,54 +1,43 @@
-import React, { Fragment, PureComponent } from 'react'
+import React from 'react'
 import propTypes from 'prop-types'
 import css from 'styled-jsx/css'
 import cx from 'classnames'
 
-class ScreenCover extends PureComponent {
-    elContainer = React.createRef()
+const ScreenCover = ({ children, onClick }) => (
+    <div className="screen-cover">
+        <div className="backdrop" onClick={onClick} />
 
-    componentDidMount() {
-        document.addEventListener('click', this.onDocClick)
-    }
+        <div className="children">{children}</div>
 
-    componentWillUnmount() {
-        document.removeEventListener('click', this.onDocClick)
-    }
+        <style jsx>{`
+            .screen-cover {
+                position: fixed;
+                height: 100%;
+                width: 100%;
 
-    onDocClick = evt => {
-        if (
-            this.elContainer.current &&
-            this.elContainer.current === evt.target
-        ) {
-            this.props.onClick()
-        }
-    }
+                left: 0;
+                top: 0;
 
-    render() {
-        return (
-            <div className="screen-cover" ref={this.elContainer}>
-                <div className="children">{this.props.children}</div>
+                z-index: 10000;
+                background: rgba(200, 200, 200, 0.6);
+            }
 
-                <style jsx>{`
-                    .screen-cover {
-                        display: flex;
-                        align-items: center;
-                        justify-content: center;
+            .backdrop {
+                height: 100%;
+                width: 100%;
+            }
 
-                        position: fixed;
-                        height: 100%;
-                        width: 100%;
-
-                        left: 0;
-                        top: 0;
-
-                        z-index: 10000;
-                        background: rgba(200, 200, 200, 0.6);
-                    }
-                `}</style>
-            </div>
-        )
-    }
-}
+            .children {
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: auto;
+                height: auto;
+                transform-origin: -50% -50%;
+            }
+        `}</style>
+    </div>
+)
 
 ScreenCover.propTypes = {
     onClick: propTypes.func,

--- a/src/ScreenCover/index.js
+++ b/src/ScreenCover/index.js
@@ -3,8 +3,8 @@ import propTypes from 'prop-types'
 import css from 'styled-jsx/css'
 import cx from 'classnames'
 
-const ScreenCover = ({ children, onClick }) => (
-    <div className="screen-cover">
+const ScreenCover = ({ children, onClick, className }) => (
+    <div className={cx('screen-cover', className)}>
         <div className="backdrop" onClick={onClick} />
 
         <div className="children">{children}</div>
@@ -34,7 +34,7 @@ const ScreenCover = ({ children, onClick }) => (
                 left: 50%;
                 width: auto;
                 height: auto;
-                transform: translate(-50% -50%);
+                transform: translate(-50%, -50%);
             }
         `}</style>
     </div>
@@ -42,6 +42,7 @@ const ScreenCover = ({ children, onClick }) => (
 
 ScreenCover.propTypes = {
     onClick: propTypes.func,
+    className: propTypes.string,
 }
 
 export { ScreenCover }

--- a/src/ScreenCover/index.js
+++ b/src/ScreenCover/index.js
@@ -3,7 +3,7 @@ import propTypes from 'prop-types'
 import css from 'styled-jsx/css'
 import cx from 'classnames'
 
-export const ScreenCover = ({ onClick }) => (
+const ScreenCover = ({ onClick }) => (
     <div className="screen-cover" onClick={onClick}>
         <style jsx>{`
             div {
@@ -21,3 +21,5 @@ export const ScreenCover = ({ onClick }) => (
 ScreenCover.propTypes = {
     onClick: propTypes.func,
 }
+
+export { ScreenCover }

--- a/src/ScreenCover/index.js
+++ b/src/ScreenCover/index.js
@@ -1,22 +1,58 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, PureComponent } from 'react'
 import propTypes from 'prop-types'
 import css from 'styled-jsx/css'
 import cx from 'classnames'
 
-const ScreenCover = ({ onClick }) => (
-    <div className="screen-cover" onClick={onClick}>
-        <style jsx>{`
-            div {
-                background: rgba(200, 200, 200, 0.6);
-                height: 100%;
-                left: 0;
-                position: absolute;
-                top: 0;
-                width: 100%;
-            }
-        `}</style>
-    </div>
-)
+class ScreenCover extends PureComponent {
+    elContainer = React.createRef()
+
+    componentDidMount() {
+        document.addEventListener('click', this.onDocClick)
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('click', this.onDocClick)
+    }
+
+    onDocClick = evt => {
+        console.log(this.elContainer, evt)
+        if (
+            this.elContainer.current &&
+            this.elContainer.current === evt.target
+        ) {
+            this.props.onClick()
+        }
+    }
+
+    render() {
+        return (
+            <div className="screen-cover" ref={this.elContainer}>
+                <div className="children">{this.props.children}</div>
+
+                <style jsx>{`
+                    .screen-cover {
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+
+                        position: fixed;
+                        height: 100%;
+                        width: 100%;
+
+                        left: 0;
+                        top: 0;
+
+                        background: rgba(200, 200, 200, 0.6);
+                    }
+
+                    .children {
+                        z-index: 99999999;
+                    }
+                `}</style>
+            </div>
+        )
+    }
+}
 
 ScreenCover.propTypes = {
     onClick: propTypes.func,

--- a/src/ScreenCover/index.js
+++ b/src/ScreenCover/index.js
@@ -41,11 +41,8 @@ class ScreenCover extends PureComponent {
                         left: 0;
                         top: 0;
 
+                        z-index: 10000;
                         background: rgba(200, 200, 200, 0.6);
-                    }
-
-                    .children {
-                        z-index: 99999999;
                     }
                 `}</style>
             </div>

--- a/src/ScreenCover/index.js
+++ b/src/ScreenCover/index.js
@@ -33,7 +33,7 @@ const ScreenCover = ({ children, onClick }) => (
                 left: 50%;
                 width: auto;
                 height: auto;
-                transform-origin: -50% -50%;
+                transform: translate(-50% -50%);
             }
         `}</style>
     </div>

--- a/src/ScreenCover/index.js
+++ b/src/ScreenCover/index.js
@@ -19,12 +19,13 @@ const ScreenCover = ({ children, onClick }) => (
                 top: 0;
 
                 z-index: 10000;
-                background: rgba(200, 200, 200, 0.6);
             }
 
             .backdrop {
                 height: 100%;
                 width: 100%;
+
+                background: rgba(200, 200, 200, 0.6);
             }
 
             .children {

--- a/src/ScreenCover/index.js
+++ b/src/ScreenCover/index.js
@@ -3,32 +3,24 @@ import propTypes from 'prop-types'
 import css from 'styled-jsx/css'
 import cx from 'classnames'
 
-const ScreenCover = ({ children, onClick, className }) => (
-    <div className={cx('screen-cover', className)}>
-        <div className="backdrop" onClick={onClick} />
-
-        <div className="children">{children}</div>
-
+const Backdrop = ({ onClick }) => (
+    <div className="backdrop" onClick={onClick}>
         <style jsx>{`
-            .screen-cover {
-                position: fixed;
-                height: 100%;
-                width: 100%;
-
-                left: 0;
-                top: 0;
-
-                z-index: 10000;
-            }
-
-            .backdrop {
+            div {
                 height: 100%;
                 width: 100%;
 
                 background: rgba(200, 200, 200, 0.6);
             }
+        `}</style>
+    </div>
+)
 
-            .children {
+const Content = ({ children }) => (
+    <div>
+        {children}
+        <style jsx>{`
+            div {
                 position: absolute;
                 top: 50%;
                 left: 50%;
@@ -40,9 +32,30 @@ const ScreenCover = ({ children, onClick, className }) => (
     </div>
 )
 
+const ScreenCover = ({ children, onClick, className }) => (
+    <div className={className}>
+        <Backdrop onClick={onClick} />
+        <Content>{children}</Content>
+
+        <style jsx>{`
+            div {
+                position: fixed;
+                height: 100%;
+                width: 100%;
+
+                left: 0;
+                top: 0;
+
+                z-index: 10000;
+            }
+        `}</style>
+    </div>
+)
+
 ScreenCover.propTypes = {
     onClick: propTypes.func,
     className: propTypes.string,
+    children: propTypes.node,
 }
 
 export { ScreenCover }

--- a/src/ScreenCover/index.js
+++ b/src/ScreenCover/index.js
@@ -15,7 +15,6 @@ class ScreenCover extends PureComponent {
     }
 
     onDocClick = evt => {
-        console.log(this.elContainer, evt)
         if (
             this.elContainer.current &&
             this.elContainer.current === evt.target

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ export { MenuItem } from './MenuItem'
 export { Modal } from './Modal'
 
 export { Radio } from './Radio'
-export { ScreenCover } from './ScreenCover'
 export { SelectField } from './SelectField'
 export { SplitButton } from './SplitButton'
 export { Switch } from './Switch'
@@ -25,6 +24,9 @@ export { Switch } from './Switch'
 export { CssReset } from './CssReset'
 
 export { theme, colors } from './theme.js'
+
+export { ComponentCover } from './ComponentCover'
+export { ScreenCover } from './ScreenCover'
 
 /*
  * Components below are internal and may be exposed at some point, but

--- a/stories/CircularProgress.stories.js
+++ b/stories/CircularProgress.stories.js
@@ -1,11 +1,23 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { CircularProgress } from '../src'
+import { CircularProgress, ScreenCover, ComponentCover } from '../src'
 
 storiesOf('CircularProgress', module)
     .add('Default', () => <CircularProgress />)
 
-    .add('Overlay page', () => <CircularProgress overlay />)
+    .add('Overlay page', () => (
+        <ScreenCover>
+            <CircularProgress />
+        </ScreenCover>
+    ))
+
+    .add('Overlay component', () => (
+        <div style={{ width: '400px', height: '400px' }}>
+            <ComponentCover>
+                <CircularProgress />
+            </ComponentCover>
+        </div>
+    ))
 
     .add('Small', () => <CircularProgress small />)
 

--- a/stories/CircularProgress.stories.js
+++ b/stories/CircularProgress.stories.js
@@ -5,12 +5,6 @@ import { CircularProgress } from '../src'
 storiesOf('CircularProgress', module)
     .add('Default', () => <CircularProgress />)
 
-    .add('Overlay component', () => (
-        <div style={{ width: '358px', height: '358px', position: 'relative' }}>
-            <CircularProgress overlay />
-        </div>
-    ))
-
     .add('Overlay page', () => <CircularProgress overlay />)
 
     .add('Small', () => <CircularProgress small />)

--- a/stories/CircularProgress.stories.js
+++ b/stories/CircularProgress.stories.js
@@ -1,23 +1,9 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { CircularProgress, ScreenCover, ComponentCover } from '../src'
+import { CircularProgress } from '../src'
 
 storiesOf('CircularProgress', module)
     .add('Default', () => <CircularProgress />)
-
-    .add('Overlay page', () => (
-        <ScreenCover>
-            <CircularProgress />
-        </ScreenCover>
-    ))
-
-    .add('Overlay component', () => (
-        <div style={{ width: '400px', height: '400px' }}>
-            <ComponentCover>
-                <CircularProgress />
-            </ComponentCover>
-        </div>
-    ))
 
     .add('Small', () => <CircularProgress small />)
 

--- a/stories/ComponentCover.stories.js
+++ b/stories/ComponentCover.stories.js
@@ -8,6 +8,9 @@ storiesOf('ComponentCover', module)
             <ComponentCover>
                 <CircularProgress />
             </ComponentCover>
+
+            <h1>Text behind the cover</h1>
+            <p>Lorem ipsum</p>
         </div>
     ))
 

--- a/stories/ComponentCover.stories.js
+++ b/stories/ComponentCover.stories.js
@@ -18,5 +18,8 @@ storiesOf('ComponentCover', module)
                     <Card>Some text.</Card>
                 </div>
             </ComponentCover>
+
+            <h1>Text behind the cover</h1>
+            <p>Lorem ipsum</p>
         </div>
     ))

--- a/stories/ComponentCover.stories.js
+++ b/stories/ComponentCover.stories.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { CircularProgress, ComponentCover, Card } from '../src'
+
+storiesOf('ComponentCover', module)
+    .add('CircularProgress', () => (
+        <div style={{ width: '400px', height: '400px' }}>
+            <ComponentCover>
+                <CircularProgress />
+            </ComponentCover>
+        </div>
+    ))
+
+    .add('Modal', () => (
+        <div style={{ width: '400px', height: '400px', background: 'purple' }}>
+            <ComponentCover>
+                <div style={{ width: '200px', height: '200px' }}>
+                    <Card>Some text.</Card>
+                </div>
+            </ComponentCover>
+        </div>
+    ))

--- a/stories/LinearProgress.stories.js
+++ b/stories/LinearProgress.stories.js
@@ -1,8 +1,22 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { LinearProgress } from '../src'
+import { LinearProgress, ScreenCover, ComponentCover } from '../src'
 
 storiesOf('LinearProgress', module)
     .add('Indeterminate', () => <LinearProgress />)
 
     .add('Determinate', () => <LinearProgress amount={60} />)
+
+    .add('Overlay page', () => (
+        <ScreenCover>
+            <LinearProgress />
+        </ScreenCover>
+    ))
+
+    .add('Overlay component', () => (
+        <div style={{ width: '400px', height: '400px' }}>
+            <ComponentCover>
+                <LinearProgress amount={80} />
+            </ComponentCover>
+        </div>
+    ))

--- a/stories/ScreenCover.stories.js
+++ b/stories/ScreenCover.stories.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { CircularProgress, ScreenCover, Menu, MenuItem, Divider } from '../src'
+
+const onClick = () => alert('Clicked the backdrop')
+
+storiesOf('ScreenCover', module)
+    .add('Default', () => <ScreenCover onClick={onClick} />)
+
+    .add('CircularProgress', () => (
+        <ScreenCover onClick={onClick}>
+            <CircularProgress />
+        </ScreenCover>
+    ))
+
+    .add('Menu', () => (
+        <ScreenCover onClick={onClick}>
+            <Menu>
+                <MenuItem label="One" value="one">
+                    <Menu>
+                        <MenuItem label="Sub One" value="subone">
+                            <Menu>
+                                <MenuItem label="Sub One-One" value="suboneone">
+                                    <Menu>
+                                        <MenuItem
+                                            label="Sub One-One-One"
+                                            value="suboneoneone"
+                                            onClick={val => {
+                                                alert(`this is ${val}`)
+                                            }}
+                                        />
+                                    </Menu>
+                                </MenuItem>
+                            </Menu>
+                        </MenuItem>
+                    </Menu>
+                </MenuItem>
+
+                <Divider />
+                <MenuItem
+                    label="Two"
+                    value="two"
+                    onClick={val => {
+                        alert(`this is ${val}`)
+                    }}
+                />
+                <MenuItem
+                    label="Three"
+                    value="three"
+                    onClick={val => {
+                        alert(`this is ${val}`)
+                    }}
+                />
+            </Menu>
+        </ScreenCover>
+    ))


### PR DESCRIPTION
Adds a Portal to the Overlay so its always rendered on top of the other components.

Removes the "overlay a single component" for now. It's not used anywhere and the app can easily build this using the component as is.

Fixes #217.