### PR TITLE
fix: issue with gatsby

### DIFF
--- a/src/DropMenu/index.js
+++ b/src/DropMenu/index.js
@@ -67,7 +67,9 @@ DropMenu.propTypes = {
     /** Decides if the menu should call the onClose function or not */
     stayOpen: propTypes.bool,
     /** DOM node to position itself against */
-    anchorEl: propTypes.instanceOf(Element),
+    anchorEl: propTypes.shape({
+        getBoundingClientRect: propTypes.func.isRequired,
+    }),
 }
 
 export { DropMenu }


### PR DESCRIPTION
Gatsby throws an error if it encounters `Element` during build time. I realize that Gatsby-compliance probably isn't highly prioritized, but this should be a change of little consequence.