### PR TITLE
fix(linearprogress): correct the background color

### DIFF
--- a/src/LinearProgress/index.js
+++ b/src/LinearProgress/index.js
@@ -3,101 +3,29 @@ import propTypes from 'prop-types'
 import cx from 'classnames'
 import { theme } from '../theme.js'
 
-const Progress = ({ indeterminate, amount }) => {
-    const width = amount ? `width: ${amount}%;` : ''
-    const height = '4px'
-
+const Progress = ({ amount }) => {
     return (
-        <div
-            className={cx({
-                determinate: !!width,
-                indeterminate: !width,
-            })}
-        >
+        <div>
             <style jsx>{`
                 div {
-                    ${width}
+                    width: ${amount}%;
                 }
             `}</style>
             <style jsx>{`
                 div {
                     background-color: ${theme.primary600};
                     transition: width 0.3s linear;
-                    height: ${height};
+                    height: 4px;
                 }
 
                 .determinate {
-                    position: absolute;
-                    top: 0;
-                    left: 0;
-                }
-
-                .indeterminate:before {
-                    position: absolute;
-                    height: ${height};
-                    top: 0;
-                    left: 0;
-
-                    background-color: inherit;
-                    animation: anim-indeterminate 2.1s
-                        cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
-                    content: '';
-                    will-change: left, right;
-                }
-
-                .indeterminate:after {
-                    position: absolute;
-                    height: ${height};
-                    top: 0;
-                    left: 0;
-
-                    background-color: inherit;
-                    animation: anim-indeterminate-short 2.1s
-                        cubic-bezier(0.165, 0.84, 0.44, 1) infinite;
-                    animation-delay: 1.15s;
-                    content: '';
-                    will-change: left, right;
-                }
-
-                @keyframes anim-indeterminate {
-                    0% {
-                        right: 100%;
-                        left: -35%;
-                    }
-
-                    60% {
-                        right: -90%;
-                        left: 100%;
-                    }
-
-                    100% {
-                        right: -90%;
-                        left: 100%;
-                    }
-                }
-
-                @keyframes anim-indeterminate-short {
-                    0% {
-                        right: 100%;
-                        left: -200%;
-                    }
-
-                    60% {
-                        right: -8%;
-                        left: 107%;
-                    }
-
-                    100% {
-                        right: -8%;
-                        left: 107%;
-                    }
                 }
             `}</style>
         </div>
     )
 }
 
-const LinearProgress = ({ amount, margin = '10px', className }) => {
+const LinearProgress = ({ amount, width, margin, className }) => {
     return (
         <div role="progressbar" className={className}>
             <Progress amount={amount} />
@@ -105,24 +33,32 @@ const LinearProgress = ({ amount, margin = '10px', className }) => {
             <style jsx>{`
                 div {
                     display: block;
-
                     overflow: hidden;
                     overflow-x: hidden;
                     overflow-y: hidden;
-                    background-color: ${theme.primary050};
+                    background-color: rgba(110, 122, 138, 0.2);
                 }
             `}</style>
             <style jsx>{`
+                width: ${width};
                 margin: ${margin};
             `}</style>
         </div>
     )
 }
 
+LinearProgress.defaultProps = {
+    margin: '10px',
+    width: '300px',
+}
+
 LinearProgress.propTypes = {
     className: propTypes.string,
+    /** set the progression in percentage (without the % suffix) */
     amount: propTypes.number,
     margin: propTypes.string,
+    /** set the width of the entire indicator, e.g. '100%' or '300px'. */
+    width: propTypes.string,
 }
 
 export { LinearProgress }

--- a/src/LinearProgress/index.js
+++ b/src/LinearProgress/index.js
@@ -48,6 +48,7 @@ const LinearProgress = ({ amount, width, margin, className }) => {
 }
 
 LinearProgress.defaultProps = {
+    amount: 0,
     margin: '10px',
     width: '300px',
 }

--- a/stories/LinearProgress.stories.js
+++ b/stories/LinearProgress.stories.js
@@ -3,13 +3,11 @@ import { storiesOf } from '@storybook/react'
 import { LinearProgress, ScreenCover, ComponentCover } from '../src'
 
 storiesOf('LinearProgress', module)
-    .add('Indeterminate', () => <LinearProgress />)
-
     .add('Determinate', () => <LinearProgress amount={60} />)
 
     .add('Overlay page', () => (
         <ScreenCover>
-            <LinearProgress />
+            <LinearProgress amount={60} />
         </ScreenCover>
     ))
 


### PR DESCRIPTION
Resolves #236.
Resolves #238.

Provides a fallback so if this has been used as an indeterminate indicator, then it will fall back to 0% and not break the implementation.

Technically a breaking change. I cannot find any usages of our LinearProgress indicator so would like to sneak this in.