### PR TITLE
refactor: style frame instead & set body to full height

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,13 +1,15 @@
 import { configure, addDecorator } from '@storybook/react'
 import { jsxDecorator } from 'storybook-addon-jsx'
 import { withPropsTable } from 'storybook-addon-react-docgen'
-import { CssResetWrapper } from './reset-decorator'
+import { CssResetWrapper } from './css-reset-decorator'
+import { FrameStylesWrapper } from './frame-styles-decorator'
 
 import 'typeface-roboto'
 
 addDecorator(jsxDecorator)
 addDecorator(withPropsTable)
 addDecorator(CssResetWrapper)
+addDecorator(FrameStylesWrapper)
 
 function loadStories() {
     const req = require.context('../stories', true, /\.stories\.js$/)

--- a/.storybook/css-reset-decorator.js
+++ b/.storybook/css-reset-decorator.js
@@ -1,12 +1,12 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 
 import { CssReset } from '../src'
 
 const CssResetWrapper = fn => (
-    <div style={{ margin: 16 }}>
+    <Fragment>
         <CssReset />
         {fn()}
-    </div>
+    </Fragment>
 )
 
 export { CssResetWrapper }

--- a/.storybook/frame-styles-decorator.js
+++ b/.storybook/frame-styles-decorator.js
@@ -1,0 +1,24 @@
+import React, { Fragment } from 'react'
+import css from 'styled-jsx/css'
+
+const FrameStylesWrapper = fn => (
+    <Fragment>
+        {fn()}
+
+        <style jsx>{`
+            :global(html) {
+                height: 100%;
+            }
+            :global(body) {
+                height: 100%;
+                min-height: 100%;
+            }
+            :global(#root) {
+                height: 100%;
+                padding: 16px;
+            }
+        `}</style>
+    </Fragment>
+)
+
+export { FrameStylesWrapper }


### PR DESCRIPTION
This PR

* removes the unnecessary div around the story contents
* Add the spacing to #root
* replaces the margin with padding (so there can't be collapsing margin)
* Set's the html/body height to use at least the viewport space (so stories can use `height: 100%`)