### PR TITLE
fix: ship the dev and prod builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+if (process.env.NODE_ENV === 'production') {
+    module.exports = require('./prod/index.js')
+} else {
+    module.exports = require('./dev/index.js')
+}

--- a/package.json
+++ b/package.json
@@ -13,12 +13,25 @@
   },
   "scripts": {
     "prebuild": "rm -rf ./build/*",
-    "build:commonjs": "BABEL_ENV=commonjs babel src --out-dir ./build/cjs --copy-files --verbose",
-    "build:modules": "BABEL_ENV=modules babel src --out-dir ./build/es --copy-files --verbose",
-    "build": "NODE_ENV=production yarn build:commonjs && NODE_ENV=production yarn build:modules",
-    "postbuild": "NODE_ENV=production yarn build-storybook && size-limit",
-    "build-storybook": "build-storybook -c .storybook -o ./build/docs && cp -r ./stories/info/images ./build/docs",
+
+    "build:dev:commonjs": "NODE_ENV=development BABEL_ENV=commonjs babel src --out-dir ./build/cjs/dev --copy-files --verbose",
+    "build:dev:modules": "NODE_ENV=development BABEL_ENV=modules babel src --out-dir ./build/es/dev --copy-files --verbose",
+
+    "build:prod:commonjs": "NODE_ENV=production BABEL_ENV=commonjs babel src --out-dir ./build/cjs/prod --copy-files --verbose",
+    "build:prod:modules": "NODE_ENV=production BABEL_ENV=modules babel src --out-dir ./build/es/prod --copy-files --verbose",
+
+    "build:index:modules": "BABEL_ENV=commonjs babel ./index.js --out-file ./build/cjs/index.js --verbose",
+    "build:index:commonjs": "BABEL_ENV=modules babel ./index.js --out-file ./build/es/index.js --verbose",
+
+    "build:prod": "yarn build:prod:commonjs && yarn build:prod:modules",
+    "build:dev": "yarn build:dev:commonjs && yarn build:dev:modules",
+
+    "build": "yarn build:prod && yarn build:dev && yarn build:index:modules && yarn build:index:commonjs",
+    "postbuild": "yarn build-storybook && size-limit",
+
+    "build-storybook": "NODE_ENV=production build-storybook -c .storybook -o ./build/docs && cp -r ./stories/info/images ./build/docs",
     "start-storybook": "start-storybook --port 5000 -s ./stories/info",
+
     "start": "yarn start-storybook"
   },
   "husky": {


### PR DESCRIPTION
When `ui-widgets` (or another library) loads the production (`optimizeForSpeed=true`) components from `ui-core` that are built with `optimizeForSpeed` before loading the local components (in `ui-widgets`), styled-jsx first sees those speed optimized components and sets the entire styled-jsx singleton to parse all components as `optimizedForSpeed`.

This does not work for local components which are not pre-parsed and requires further string splitting for style declarations.

E.g. `span { display: block; } div { display: flex; }` in `optimizedForSpeed` will be treated as a single CSS rule, which causes the `CSSStyleSheet.insertRule()` to choke, since it expects a single rule at a time.

When styled-jsx is not `optimizedForSpeed`, the same line `span { display: block; } div { display: flex; }` would be split into two rules:

`span { display: block; }` and `div { display: flex; }`, and each would be passed to `insertRule` one at a time.

So when the styled-jsx singleton first sees a `optmizedForSpeed` component, it assumes that all of them are also optimized for speed, and if they are not it will crash when it encounters non-optimized components.

This should not be problem when [styled-jsx/#64](https://github.com/zeit/styled-jsx/issues/64) is resolved, until then, we can work around it by exposing both the development (non-optimized) and production (optimized) builds in the `ui-core` bundle.

This only changes the potential entry-points, everything behind the entry-point is just as it was so nothing should change for the implementations.