### PR TITLE
feat(checkbox & radio): add custom icon prop

### DIFF
--- a/src/Checkbox/Icon.js
+++ b/src/Checkbox/Icon.js
@@ -71,6 +71,7 @@ export const Icon = ({
             <style jsx>{`
                 div {
                     position: relative;
+                    padding: 0 6px 0 0;
                 }
 
                 .focus:before {

--- a/src/Checkbox/Icon.js
+++ b/src/Checkbox/Icon.js
@@ -71,7 +71,7 @@ export const Icon = ({
             <style jsx>{`
                 div {
                     position: relative;
-                    padding: 0 6px 0 0;
+                    margin: 0 6px 0 0;
                 }
 
                 .focus:before {

--- a/src/Checkbox/Label.js
+++ b/src/Checkbox/Label.js
@@ -13,7 +13,7 @@ export const Label = ({ disabled, required, children }) => {
 
             <style jsx>{`
                 .label {
-                    padding: 0 0 0 2px;
+                    margin: 0 0 0 2px;
                     color: ${colors.grey900};
                     cursor: pointer;
                 }

--- a/src/Checkbox/Label.js
+++ b/src/Checkbox/Label.js
@@ -13,7 +13,7 @@ export const Label = ({ disabled, required, children }) => {
 
             <style jsx>{`
                 .label {
-                    margin: 0 0 0 ${spacers.dp8};
+                    padding: 0 0 0 2px;
                     color: ${colors.grey900};
                     cursor: pointer;
                 }

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -34,19 +34,20 @@ class Checkbox extends Component {
 
     render() {
         const {
-            onChange,
-            name,
-            value,
-            label,
-            className,
-            indeterminate,
-            required,
             checked = false,
+            className,
             disabled,
-            valid,
-            warning,
             error,
+            icon,
+            indeterminate,
+            label,
+            name,
+            onChange,
+            required,
             tabIndex,
+            valid,
+            value,
+            warning,
         } = this.props
         const { focus } = this.state
 
@@ -79,6 +80,8 @@ class Checkbox extends Component {
                         warning={warning}
                         indeterminate={indeterminate}
                     />
+
+                    {icon}
 
                     <Label required={required}>{label}</Label>
 
@@ -115,11 +118,12 @@ Checkbox.propTypes = {
     name: propTypes.string.isRequired,
     label: propTypes.string.isRequired,
     tabIndex: propTypes.string,
+    className: propTypes.string,
 
     onFocus: propTypes.func,
     onBlur: propTypes.func,
 
-    className: propTypes.string,
+    icon: propTypes.element,
 
     indeterminate: propTypes.bool,
     required: propTypes.bool,

--- a/src/Radio/index.js
+++ b/src/Radio/index.js
@@ -155,28 +155,12 @@ class Radio extends Component {
                     onBlur={this.onBlur}
                 />
 
-                <div className={cx({ focus })}>{icon}</div>
+                <div className={cx('icon', { focus })}>{icon}</div>
 
                 <span className={cx({ required })}>{label}</span>
 
                 {icons.styles}
                 <style jsx>{styles}</style>
-                <style jsx>{`
-                    div {
-                        position: relative;
-                    }
-
-                    .focus:before {
-                        content: '';
-                        position: absolute;
-                        border: 2px solid ${colors.blue600};
-                        border-radius: 50%;
-                        width: calc(100% + 2px);
-                        height: calc(100% + 2px);
-                        top: -1px;
-                        left: -1px;
-                    }
-                `}</style>
             </label>
         )
     }

--- a/src/Radio/index.js
+++ b/src/Radio/index.js
@@ -107,18 +107,19 @@ class Radio extends Component {
 
     render() {
         const {
-            onChange,
-            name,
-            value,
-            className,
-            label,
-            required,
             checked = false,
+            className,
             disabled,
-            valid,
-            warning,
             error,
+            icon,
+            label,
+            name,
+            onChange,
+            required,
             tabIndex,
+            valid,
+            value,
+            warning,
         } = this.props
         const { focus } = this.state
 
@@ -130,12 +131,6 @@ class Radio extends Component {
             warning,
             focus,
         })
-
-        const icon = checked ? (
-            <Checked className={classes} />
-        ) : (
-            <Unchecked className={classes} />
-        )
 
         return (
             <label
@@ -155,7 +150,15 @@ class Radio extends Component {
                     onBlur={this.onBlur}
                 />
 
-                <div className={cx('icon', { focus })}>{icon}</div>
+                <div className={cx('icon', { focus })}>
+                    {checked ? (
+                        <Checked className={classes} />
+                    ) : (
+                        <Unchecked className={classes} />
+                    )}
+                </div>
+
+                {icon}
 
                 <span className={cx({ required })}>{label}</span>
 
@@ -171,10 +174,11 @@ Radio.propTypes = {
 
     name: propTypes.string.isRequired,
     value: propTypes.string.isRequired,
-
     className: propTypes.string,
     label: propTypes.string,
     tabIndex: propTypes.string,
+
+    icon: propTypes.element,
 
     onFocus: propTypes.func,
     onBlur: propTypes.func,

--- a/src/Radio/styles.js
+++ b/src/Radio/styles.js
@@ -12,7 +12,7 @@ export default css`
         position: absolute;
         border: 2px solid ${colors.blue600};
         border-radius: 50%;
-        width: calc(100%);
+        width: calc(100% + 2px);
         height: calc(100% + 2px);
         top: -1px;
         left: -1px;
@@ -39,11 +39,12 @@ export default css`
     .icon {
         pointer-events: none;
         user-select: none;
-        padding: 0 6px 0 0;
+        margin: 0 6px 0 0;
     }
 
     span {
-        padding: 0 0 0 2px;
+        display: block;
+        margin: 0 0 0 2px;
         cursor: pointer;
     }
 

--- a/src/Radio/styles.js
+++ b/src/Radio/styles.js
@@ -3,6 +3,21 @@ import css from 'styled-jsx/css'
 import { colors, theme, spacers } from '../theme.js'
 
 export default css`
+    div {
+        position: relative;
+    }
+
+    .focus:before {
+        content: '';
+        position: absolute;
+        border: 2px solid ${colors.blue600};
+        border-radius: 50%;
+        width: calc(100%);
+        height: calc(100% + 2px);
+        top: -1px;
+        left: -1px;
+    }
+
     label {
         display: flex;
         flex-direction: row;
@@ -24,10 +39,11 @@ export default css`
     .icon {
         pointer-events: none;
         user-select: none;
+        padding: 0 6px 0 0;
     }
 
     span {
-        margin: 0 0 0 ${spacers.dp8};
+        padding: 0 0 0 2px;
         cursor: pointer;
     }
 

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -1,10 +1,47 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Checkbox, Help } from '../src'
+import css from 'styled-jsx/css'
 
 import markdown from './info/atoms/checkbox.md'
 
 const logger = ({ target }) => console.info(`${target.name}: ${target.checked}`)
+
+export const FolderOpen = () => (
+    <svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1">
+        <g
+            id="icon/folder/open"
+            stroke="none"
+            strokeWidth="1"
+            fill="none"
+            fillRule="evenodd"
+        >
+            <g
+                id="Group"
+                transform="translate(0.000000, 3.000000)"
+                stroke="#6E7A8A"
+            >
+                <path
+                    d="M2,0.5 C1.17157288,0.5 0.5,1.17157288 0.5,2 L0.5,10 C0.5,10.8284271 1.17157288,11.5 2,11.5 L12,11.5 C12.8284271,11.5 13.5,10.8284271 13.5,10 L13.5,4 C13.5,3.17157288 12.8284271,2.5 12,2.5 L6.69098301,2.5 L5.82917961,0.776393202 C5.7444836,0.607001188 5.57135204,0.5 5.38196601,0.5 L2,0.5 Z"
+                    id="Path-2"
+                    fill="#A0ADBA"
+                />
+
+                <path
+                    d="M1.53632259,10.7093809 C1.47575089,10.7941813 1.44318932,10.8957885 1.44318932,11 C1.44318932,11.2761424 1.66704695,11.5 1.94318932,11.5 L12.4853821,11.5 C12.6468577,11.5 12.7983931,11.4220172 12.8922488,11.2906191 L16.4636774,6.2906191 C16.5242491,6.20581872 16.5568107,6.10421149 16.5568107,6 C16.5568107,5.72385763 16.3329531,5.5 16.0568107,5.5 L5.5146179,5.5 C5.35314234,5.5 5.20160692,5.57798284 5.10775116,5.7093809 L1.53632259,10.7093809 Z"
+                    id="Path-3"
+                    fill="#FBFCFD"
+                />
+            </g>
+        </g>
+
+        <style jsx>{`
+            svg {
+                margin: 3px 0;
+            }
+        `}</style>
+    </svg>
+)
 
 storiesOf('Checkbox', module)
     .addParameters({
@@ -82,6 +119,16 @@ storiesOf('Checkbox', module)
             required
             label="Checkbox"
             onChange={logger}
+        />
+    ))
+
+    .add('With icon', () => (
+        <Checkbox
+            value="ex"
+            name="Ex"
+            label="Checkbox"
+            onChange={logger}
+            icon={<FolderOpen />}
         />
     ))
 

--- a/stories/Radio.stories.js
+++ b/stories/Radio.stories.js
@@ -6,6 +6,42 @@ import markdown from './info/atoms/radio.md'
 
 const logger = ({ target }) => console.info(`${target.name}: ${target.value}`)
 
+export const FolderOpen = () => (
+    <svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1">
+        <g
+            id="icon/folder/open"
+            stroke="none"
+            strokeWidth="1"
+            fill="none"
+            fillRule="evenodd"
+        >
+            <g
+                id="Group"
+                transform="translate(0.000000, 3.000000)"
+                stroke="#6E7A8A"
+            >
+                <path
+                    d="M2,0.5 C1.17157288,0.5 0.5,1.17157288 0.5,2 L0.5,10 C0.5,10.8284271 1.17157288,11.5 2,11.5 L12,11.5 C12.8284271,11.5 13.5,10.8284271 13.5,10 L13.5,4 C13.5,3.17157288 12.8284271,2.5 12,2.5 L6.69098301,2.5 L5.82917961,0.776393202 C5.7444836,0.607001188 5.57135204,0.5 5.38196601,0.5 L2,0.5 Z"
+                    id="Path-2"
+                    fill="#A0ADBA"
+                />
+
+                <path
+                    d="M1.53632259,10.7093809 C1.47575089,10.7941813 1.44318932,10.8957885 1.44318932,11 C1.44318932,11.2761424 1.66704695,11.5 1.94318932,11.5 L12.4853821,11.5 C12.6468577,11.5 12.7983931,11.4220172 12.8922488,11.2906191 L16.4636774,6.2906191 C16.5242491,6.20581872 16.5568107,6.10421149 16.5568107,6 C16.5568107,5.72385763 16.3329531,5.5 16.0568107,5.5 L5.5146179,5.5 C5.35314234,5.5 5.20160692,5.57798284 5.10775116,5.7093809 L1.53632259,10.7093809 Z"
+                    id="Path-3"
+                    fill="#FBFCFD"
+                />
+            </g>
+        </g>
+
+        <style jsx>{`
+            svg {
+                margin: 3px 0;
+            }
+        `}</style>
+    </svg>
+)
+
 storiesOf('Radio', module)
     .addParameters({
         notes: {
@@ -76,6 +112,15 @@ storiesOf('Radio', module)
             required
             label="Radio"
             value="required"
+            onChange={logger}
+        />
+    ))
+
+    .add('With icon', () => (
+        <Radio
+            name="Ex"
+            label="Radio"
+            icon={<FolderOpen />}
             onChange={logger}
         />
     ))


### PR DESCRIPTION
Add the `icon` prop to both the `Checkbox` and the `Radio` components to allow icons between the input icon and the label text.

Also splits the margin of the label text of both components into paddings on the input icon and the label text to ensure there's always 8px of empty space between the input icon and the label text, regardless whether there's a custom icon or not.