### PR TITLE
Table header labels in context

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -1,7 +1,12 @@
 import React from 'react'
 import css from 'styled-jsx/css'
+import propTypes from 'prop-types'
 
 import { Consumer } from './tableContext'
+import { TableBody } from './TableBody'
+import { TableFoot } from './TableFoot'
+import { TableHead } from './TableHead'
+import { instanceOfComponent } from '../prop-validators/instanceOfComponent'
 
 const tableStyles = css`
     table {
@@ -48,3 +53,16 @@ export const Table = ({ children }) => (
         }}
     </Consumer>
 )
+
+const childPropType = propTypes.oneOfType([
+    instanceOfComponent(TableHead),
+    instanceOfComponent(TableBody),
+    instanceOfComponent(TableFoot),
+])
+
+Table.propTypes = {
+    children: propTypes.oneOfType([
+        childPropType,
+        propTypes.arrayOf(childPropType),
+    ]).isRequired,
+}

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import css from 'styled-jsx/css'
+import propTypes from 'prop-types'
 
 import { Consumer } from './tableContext'
+import { TableRow } from './TableRow'
+import { instanceOfComponent } from '../prop-validators/instanceOfComponent'
 
 const tableBodyStylesResponsive = css`
     @media (max-width: 768px) {
@@ -28,3 +31,12 @@ export const TableBody = ({ children }) => (
         }}
     </Consumer>
 )
+
+const childPropType = instanceOfComponent(TableRow)
+
+TableBody.propTypes = {
+    children: propTypes.oneOfType([
+        childPropType,
+        propTypes.arrayOf(childPropType),
+    ]).isRequired,
+}

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -87,13 +87,18 @@ const TableCellResponsive = ({ children, colSpan, rowSpan, title }) => (
 export const TableCell = ({ children, title, colSpan, rowSpan }) => (
     <Consumer>
         {({ staticLayout }) => {
-            const TableCell = staticLayout
-                ? TableCellStatic
-                : TableCellResponsive
+            const TableCellComponent = staticLayout
+                ? TableCellComponentStatic
+                : TableCellComponentResponsive
+
             return (
-                <TableCell colSpan={colSpan} rowSpan={rowSpan} title={title}>
+                <TableCellComponent
+                    colSpan={colSpan}
+                    rowSpan={rowSpan}
+                    title={title}
+                >
                     <div>{children}</div>
-                </TableCell>
+                </TableCellComponent>
             )
         }}
     </Consumer>

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -24,13 +24,7 @@ const tableCellStyles = css`
 const tableCellStylesResponsive = css`
     @media (max-width: 768px) {
         td {
-            display: table-row;
             width: 100%;
-        }
-    }
-
-    @media (max-width: 400px) {
-        td {
             display: block;
         }
     }
@@ -45,11 +39,8 @@ const TableCellStatic = ({ children, colSpan, rowSpan }) => (
 
 const ContentWithTitle = ({ title, children }) => (
     <Fragment>
-        {title && <td className="title">{title}</td>}
-
-        <td className="content" colSpan={title ? '1' : '2'}>
-            {children}
-        </td>
+        {title && <span className="title">{title}</span>}
+        <span className="content">{children}</span>
 
         <style jsx>{`
             .title {
@@ -61,35 +52,14 @@ const ContentWithTitle = ({ title, children }) => (
             }
 
             @media (max-width: 768px) {
-                .title,
-                .content {
-                    display: table-cell;
-                }
-
-                .title {
-                    white-space: nowrap;
-                    padding: 0 16px;
-                    font-weight: bold;
-                }
-
-                :global(tfoot) .title {
-                    display: none;
-                }
-
-                .content {
-                    display: table-cell;
-                    width: 100%;
-                    padding: 0 16px;
-                }
-            }
-
-            @media (max-width: 400px) {
                 .title {
                     display: block;
                     white-space: normal;
                     min-height: 24px;
                     line-height: 18px;
                     padding: 8px 0 0 0;
+                    font-weight: bold;
+                    white-space: nowrap;
                 }
 
                 .content {
@@ -116,21 +86,24 @@ const TableCellResponsive = ({ children, colSpan, rowSpan, title }) => (
     </td>
 )
 
-export const TableCell = ({ children, noTitle, colSpan, rowSpan, column }) => (
+// Leveraging on being able to return before creating the text component
+// If not extracted, TableCellText will be created on every render
+// and throw a warning as children is not a string
+const getContent = children => {
+    if (typeof children !== 'string') return children
+    return <TableCellText label={children} />
+}
+
+export const TableCell = ({ children, colSpan, rowSpan, column }) => (
     <Consumer>
         {({ staticLayout, headerLabels }) => {
-            const title = noTitle || staticLayout ? '' : headerLabels[column]
+            const title = staticLayout ? '' : headerLabels[column]
 
             const TableCellComponent = staticLayout
                 ? TableCellStatic
                 : TableCellResponsive
 
-            const content =
-                typeof children === 'string' ? (
-                    <TableCellText label={children} />
-                ) : (
-                    children
-                )
+            const content = getContent(children)
 
             return (
                 <TableCellComponent
@@ -139,7 +112,7 @@ export const TableCell = ({ children, noTitle, colSpan, rowSpan, column }) => (
                     rowSpan={rowSpan}
                     title={title}
                 >
-                    <div>{content}</div>
+                    {content}
                 </TableCellComponent>
             )
         }}
@@ -147,7 +120,6 @@ export const TableCell = ({ children, noTitle, colSpan, rowSpan, column }) => (
 )
 
 TableCell.propTypes = {
-    noTitle: propTypes.bool,
     colSpan: propTypes.string,
     rowSpan: propTypes.string,
     column: propTypes.number,

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import propTypes from 'prop-types'
 import css from 'styled-jsx/css'
 
@@ -20,6 +20,21 @@ const tableCellStyles = css`
     }
 `
 
+const tableCellStylesResponsive = css`
+    @media (max-width: 768px) {
+        td {
+            display: table-row;
+            width: 100%;
+        }
+    }
+
+    @media (max-width: 400px) {
+        td {
+            display: block;
+        }
+    }
+`
+
 const TableCellStatic = ({ children, colSpan, rowSpan }) => (
     <td colSpan={colSpan} rowSpan={rowSpan}>
         <div>{children}</div>
@@ -27,30 +42,40 @@ const TableCellStatic = ({ children, colSpan, rowSpan }) => (
     </td>
 )
 
-const TableCellResponsive = ({ children, colSpan, rowSpan, title }) => (
-    <td colSpan={colSpan} rowSpan={rowSpan}>
-        <div>{children}</div>
-        <style jsx>{tableCellStyles}</style>
+const ContentWithTitle = ({ title, children }) => (
+    <Fragment>
+        {title && <td className="title">{title}</td>}
+
+        <td className="content" colSpan={title ? '1' : '2'}>
+            {children}
+        </td>
+
         <style jsx>{`
+            .title {
+                display: none;
+            }
+
+            .content {
+                display: block;
+            }
+
             @media (max-width: 768px) {
-                td {
-                    display: table-row;
-                    width: 100%;
+                .title,
+                .content {
+                    display: table-cell;
                 }
 
-                td:before {
-                    content: '${title}:';
-                    display: table-cell;
+                .title {
                     white-space: nowrap;
                     padding: 0 16px;
                     font-weight: bold;
                 }
 
-                :global(tfoot) td:before {
+                :global(tfoot) .title {
                     display: none;
                 }
 
-                div {
+                .content {
                     display: table-cell;
                     width: 100%;
                     padding: 0 16px;
@@ -58,15 +83,7 @@ const TableCellResponsive = ({ children, colSpan, rowSpan, title }) => (
             }
 
             @media (max-width: 400px) {
-                td {
-                    display: block;
-                }
-
-                td:first-child {
-                    margin-top: 0;
-                }
-
-                td:before {
+                .title {
                     display: block;
                     white-space: normal;
                     min-height: 24px;
@@ -74,25 +91,42 @@ const TableCellResponsive = ({ children, colSpan, rowSpan, title }) => (
                     padding: 8px 0 0 0;
                 }
 
-                div {
+                .content {
                     display: block;
                     padding: 0;
-                    min-height:32px;
+                    min-height: 32px;
+                }
+
+                .content:first-child {
+                    padding-top: 8px;
+                    padding-bottom: 8px;
                 }
             }
         `}</style>
+    </Fragment>
+)
+
+const TableCellResponsive = ({ children, colSpan, rowSpan, title }) => (
+    <td colSpan={colSpan} rowSpan={rowSpan}>
+        <ContentWithTitle title={title}>{children}</ContentWithTitle>
+
+        <style jsx>{tableCellStyles}</style>
+        <style jsx>{tableCellStylesResponsive}</style>
     </td>
 )
 
-export const TableCell = ({ children, title, colSpan, rowSpan }) => (
+export const TableCell = ({ children, noTitle, colSpan, rowSpan, column }) => (
     <Consumer>
-        {({ staticLayout }) => {
+        {({ staticLayout, headerLabels }) => {
+            const title = noTitle || staticLayout ? '' : headerLabels[column]
+
             const TableCellComponent = staticLayout
                 ? TableCellStatic
                 : TableCellResponsive
 
             return (
                 <TableCellComponent
+                    column={column}
                     colSpan={colSpan}
                     rowSpan={rowSpan}
                     title={title}
@@ -105,7 +139,8 @@ export const TableCell = ({ children, title, colSpan, rowSpan }) => (
 )
 
 TableCell.propTypes = {
-    title: propTypes.string,
+    noTitle: propTypes.bool,
     colSpan: propTypes.string,
     rowSpan: propTypes.string,
+    column: propTypes.number,
 }

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -88,8 +88,8 @@ export const TableCell = ({ children, title, colSpan, rowSpan }) => (
     <Consumer>
         {({ staticLayout }) => {
             const TableCellComponent = staticLayout
-                ? TableCellComponentStatic
-                : TableCellComponentResponsive
+                ? TableCellStatic
+                : TableCellResponsive
 
             return (
                 <TableCellComponent

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -1,8 +1,9 @@
 import React, { Fragment } from 'react'
-import propTypes from 'prop-types'
 import css from 'styled-jsx/css'
+import propTypes from 'prop-types'
 
 import { Consumer } from './tableContext'
+import { TableCellText } from './TableCellText'
 
 const tableCellStyles = css`
     td {
@@ -124,6 +125,13 @@ export const TableCell = ({ children, noTitle, colSpan, rowSpan, column }) => (
                 ? TableCellStatic
                 : TableCellResponsive
 
+            const content =
+                typeof children === 'string' ? (
+                    <TableCellText label={children} />
+                ) : (
+                    children
+                )
+
             return (
                 <TableCellComponent
                     column={column}
@@ -131,7 +139,7 @@ export const TableCell = ({ children, noTitle, colSpan, rowSpan, column }) => (
                     rowSpan={rowSpan}
                     title={title}
                 >
-                    <div>{children}</div>
+                    <div>{content}</div>
                 </TableCellComponent>
             )
         }}

--- a/src/Table/TableCellHead.js
+++ b/src/Table/TableCellHead.js
@@ -33,5 +33,5 @@ TableCellHead.propTypes = {
     colSpan: propTypes.string,
     rowSpan: propTypes.string,
     label: propTypes.string,
-    hideLabel: propTypes.bool,
+    noTitle: propTypes.bool,
 }

--- a/src/Table/TableCellHead.js
+++ b/src/Table/TableCellHead.js
@@ -1,10 +1,20 @@
 import React from 'react'
-import propTypes from 'prop-types'
 import css from 'styled-jsx/css'
+import propTypes from 'prop-types'
 
-export const TableCellHead = ({ children, colSpan, rowSpan }) => (
+import { TableCellText } from './TableCellText'
+
+export const TableCellHead = ({
+    children,
+    colSpan,
+    rowSpan,
+    label,
+    hideLabel,
+}) => (
     <th colSpan={colSpan} rowSpan={rowSpan}>
-        <div>{children}</div>
+        {!hideLabel && (
+            <div>{children ? children : <TableCellText label={label} />}</div>
+        )}
 
         <style jsx>{`
             th {
@@ -22,4 +32,6 @@ export const TableCellHead = ({ children, colSpan, rowSpan }) => (
 TableCellHead.propTypes = {
     colSpan: propTypes.string,
     rowSpan: propTypes.string,
+    label: propTypes.string,
+    hideLabel: propTypes.bool,
 }

--- a/src/Table/TableCellHead.js
+++ b/src/Table/TableCellHead.js
@@ -33,5 +33,5 @@ TableCellHead.propTypes = {
     colSpan: propTypes.string,
     rowSpan: propTypes.string,
     label: propTypes.string,
-    noTitle: propTypes.bool,
+    hideResponsiveLabel: propTypes.bool,
 }

--- a/src/Table/TableCellText.js
+++ b/src/Table/TableCellText.js
@@ -18,7 +18,7 @@ const tableCellTextStyles = css`
 `
 
 const tableCellTextStylesResponsive = css`
-    @media (max-width: 400px) {
+    @media (max-width: 768px) {
         :global(tbody) span {
             padding: 3px 0;
         }

--- a/src/Table/TableFoot.js
+++ b/src/Table/TableFoot.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import css from 'styled-jsx/css'
+import propTypes from 'prop-types'
 
 import { Consumer } from './tableContext'
+import { TableRow } from './TableRow'
+import { instanceOfComponent } from '../prop-validators/instanceOfComponent'
 
 const tableFootStylesResponsive = css`
     @media (max-width: 768px) {
@@ -35,3 +38,12 @@ export const TableFoot = ({ children }) => (
         }}
     </Consumer>
 )
+
+const childPropType = instanceOfComponent(TableRow)
+
+TableFoot.propTypes = {
+    children: propTypes.oneOfType([
+        childPropType,
+        propTypes.arrayOf(childPropType),
+    ]).isRequired,
+}

--- a/src/Table/TableFoot.js
+++ b/src/Table/TableFoot.js
@@ -10,12 +10,6 @@ const tableFootStylesResponsive = css`
     @media (max-width: 768px) {
         tfoot {
             display: block;
-            margin-top: 16px;
-        }
-    }
-
-    @media (max-width: 400px) {
-        tfoot {
             margin-top: 32px;
         }
     }

--- a/src/Table/TableHead.js
+++ b/src/Table/TableHead.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import css from 'styled-jsx/css'
+import propTypes from 'prop-types'
 
 import { Consumer } from './tableContext'
+import { TableRowHead } from './TableRowHead'
+import { instanceOfComponent } from '../prop-validators/instanceOfComponent'
 
 const tableHeadStylesResponsive = css`
     @media (max-width: 768px) {
@@ -28,3 +31,12 @@ export const TableHead = ({ children }) => (
         }}
     </Consumer>
 )
+
+const childPropType = instanceOfComponent(TableRowHead)
+
+TableHead.propTypes = {
+    children: propTypes.oneOfType([
+        childPropType,
+        propTypes.arrayOf(childPropType),
+    ]).isRequired,
+}

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -40,19 +40,8 @@ const tableRowStyles = css`
 const tableRowStylesResponsive = css`
     @media (max-width: 768px) {
         tr {
-            display: table;
-            width: 100%;
-            border: 1px solid #e8edf2;
-        }
-
-        tr + tr {
-            margin-top: 16px;
-        }
-    }
-
-    @media (max-width: 400px) {
-        tr {
             display: block;
+            border: 1px solid #e8edf2;
         }
 
         tr:nth-child(even) {

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -1,7 +1,26 @@
 import React from 'react'
 import css from 'styled-jsx/css'
+import propTypes from 'prop-types'
 
 import { Consumer } from './tableContext'
+import { TableCell } from './TableCell'
+import { TableCellHead } from './TableCellHead'
+import { instanceOfComponent } from '../prop-validators/instanceOfComponent'
+
+const addColNumToChildren = children => {
+    let curCol = 0
+
+    return React.Children.map(children, child => {
+        const column = curCol
+        const colSpan = child.props.colSpan
+            ? parseInt(child.props.colSpan, 10)
+            : 1
+
+        curCol += colSpan
+
+        return React.cloneElement(child, { column })
+    })
+}
 
 const tableRowStyles = css`
     tr {
@@ -65,13 +84,29 @@ const TableRowResponsive = ({ children }) => (
     </tr>
 )
 
-export const TableRow = ({ children }) => (
+export const TableRow = ({ children, headerRow }) => (
     <Consumer>
         {({ staticLayout }) => {
             const TableRowComponent = staticLayout
                 ? TableRowStatic
                 : TableRowResponsive
-            return <TableRowComponent>{children}</TableRowComponent>
+            return (
+                <TableRowComponent>
+                    {addColNumToChildren(children)}
+                </TableRowComponent>
+            )
         }}
     </Consumer>
 )
+
+const childPropType = propTypes.oneOfType([
+    instanceOfComponent(TableCell),
+    instanceOfComponent(TableCellHead),
+])
+
+TableRow.propTypes = {
+    children: propTypes.oneOfType([
+        childPropType,
+        propTypes.arrayOf(childPropType),
+    ]).isRequired,
+}

--- a/src/Table/TableRowHead.js
+++ b/src/Table/TableRowHead.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import propTypes from 'prop-types'
+
+import { TableCellHead } from './TableCellHead'
+import { TableRow } from './TableRow'
+import { instanceOfComponent } from '../prop-validators/instanceOfComponent'
+
+export const TableRowHead = props => <TableRow {...props} />
+
+const childPropType = instanceOfComponent(TableCellHead)
+
+TableRowHead.propTypes = {
+    children: propTypes.oneOfType([
+        childPropType,
+        propTypes.arrayOf(childPropType),
+    ]).isRequired,
+}

--- a/src/Table/extractHeaderLabels.js
+++ b/src/Table/extractHeaderLabels.js
@@ -41,9 +41,8 @@ const mapCellsToLabels = row => {
     return labels
 }
 
-const extractLabelFromCell = cell => {
-    return cell.props.label
-}
+const extractLabelFromCell = cell =>
+    !cell.props.noTitle ? cell.props.label : ''
 
 const combineRowLables = (columnCount, rowCount, headerLabels) =>
     Array(columnCount)

--- a/src/Table/extractHeaderLabels.js
+++ b/src/Table/extractHeaderLabels.js
@@ -42,7 +42,7 @@ const mapCellsToLabels = row => {
 }
 
 const extractLabelFromCell = cell =>
-    !cell.props.noTitle ? cell.props.label : ''
+    !cell.props.hideResponsiveLabel ? cell.props.label : ''
 
 const combineRowLables = (columnCount, rowCount, headerLabels) =>
     Array(columnCount)

--- a/src/Table/extractHeaderLabels.js
+++ b/src/Table/extractHeaderLabels.js
@@ -61,6 +61,9 @@ export const extractHeaderLabels = children => {
     if (React.Children.count(children) === 0) return []
 
     const rows = extractRowsFromTableChildren(children)
+
+    if (!rows.length) return []
+
     const rowCount = rows.length
     const columnCount = calculateColumnCount(rows[0])
     const headerLabels = rows.map(mapCellsToLabels)

--- a/src/Table/extractHeaderLabels.js
+++ b/src/Table/extractHeaderLabels.js
@@ -1,0 +1,69 @@
+import React from 'react'
+
+import { TableHead } from './TableHead'
+import { TableRow } from './TableRow'
+import { TableCellHead } from './TableCellHead'
+
+const extractRowsFromTableChildren = children =>
+    React.Children.toArray(children)
+        // extract theads
+        .filter(child => child.type === TableHead)
+
+        // flatten rows
+        .map(({ props }) => props.children)
+        .reduce((flattened, row) => [...flattened, ...row], [])
+
+        // map row to array of cell components
+        .map(({ props }) => props.children)
+
+const calculateColumnCount = row =>
+    row.reduce(
+        (total, col) =>
+            col.props.colSpan
+                ? total + parseInt(col.props.colSpan, 10)
+                : total + 1,
+        0
+    )
+
+const mapCellsToLabels = row => {
+    let labels = []
+
+    for (let i = 0, count = row.length; i < count; ++i) {
+        const cell = row[i]
+        const colSpan = cell.props.colSpan
+            ? parseInt(cell.props.colSpan, 10)
+            : 1
+        const label = extractLabelFromCell(cell)
+
+        labels = [...labels, ...Array(colSpan).fill(label)]
+    }
+
+    return labels
+}
+
+const extractLabelFromCell = cell => {
+    return cell.props.label
+}
+
+const combineRowLables = (columnCount, rowCount, headerLabels) =>
+    Array(columnCount)
+        .fill('')
+        .reduce((labels, _, colIndex) => {
+            const colLabels = Array(rowCount)
+                .fill('')
+                .map((__, rowIndex) => headerLabels[rowIndex][colIndex])
+                .filter(val => val) // remove empty ones
+
+            return [...labels, colLabels.join(' / ')]
+        }, [])
+
+export const extractHeaderLabels = children => {
+    if (React.Children.count(children) === 0) return []
+
+    const rows = extractRowsFromTableChildren(children)
+    const rowCount = rows.length
+    const columnCount = calculateColumnCount(rows[0])
+    const headerLabels = rows.map(mapCellsToLabels)
+
+    return combineRowLables(columnCount, rowCount, headerLabels)
+}

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -2,28 +2,33 @@ import React from 'react'
 import propTypes from 'prop-types'
 
 import { Provider } from './tableContext'
-import { Table as TableComponent } from './Table'
-import { TableHead } from './TableHead'
 import { TableBody } from './TableBody'
-import { TableFoot } from './TableFoot'
-import { TableRow } from './TableRow'
 import { TableCell } from './TableCell'
 import { TableCellHead } from './TableCellHead'
 import { TableCellText } from './TableCellText'
+import { Table as TableComponent } from './Table'
+import { TableFoot } from './TableFoot'
+import { TableHead } from './TableHead'
+import { TableRow } from './TableRow'
+import { extractHeaderLabels } from './extractHeaderLabels'
 
-const Table = ({ children, staticLayout }) => (
-    <div>
-        <Provider value={{ staticLayout }}>
-            <TableComponent>{children}</TableComponent>
-        </Provider>
+const Table = ({ children, staticLayout }) => {
+    const headerLabels = staticLayout ? null : extractHeaderLabels(children)
 
-        <style jsx>{`
-            div {
-                overflow-x: auto;
-            }
-        `}</style>
-    </div>
-)
+    return (
+        <div>
+            <Provider value={{ staticLayout, headerLabels }}>
+                <TableComponent>{children}</TableComponent>
+            </Provider>
+
+            <style jsx>{`
+                div {
+                    overflow-x: auto;
+                }
+            `}</style>
+        </div>
+    )
+}
 
 Table.propTypes = {
     staticLayout: propTypes.bool,

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -10,6 +10,7 @@ import { Table as TableComponent } from './Table'
 import { TableFoot } from './TableFoot'
 import { TableHead } from './TableHead'
 import { TableRow } from './TableRow'
+import { TableRowHead } from './TableRowHead'
 import { extractHeaderLabels } from './extractHeaderLabels'
 
 const Table = ({ children, staticLayout }) => {
@@ -37,6 +38,7 @@ Table.propTypes = {
 export {
     Table,
     TableRow,
+    TableRowHead,
     TableHead,
     TableBody,
     TableFoot,

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -97,264 +97,104 @@ storiesOf('Table', module)
             </TableHead>
             <TableBody>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Onyekachukwu" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Kariuki" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="02/06/2007" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="05/25/1972" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="66" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Jawi" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Sofie Hubert" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Onyekachukwu</TableCell>
+                    <TableCell>Kariuki</TableCell>
+                    <TableCell>02/06/2007</TableCell>
+                    <TableCell>05/25/1972</TableCell>
+                    <TableCell>66</TableCell>
+                    <TableCell>Jawi</TableCell>
+                    <TableCell>Sofie Hubert</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Kwasi" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okafor" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="08/11/2010" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="02/26/1991" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="38" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Mokassie MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Dashonte Clarke" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Kwasi</TableCell>
+                    <TableCell>Okafor</TableCell>
+                    <TableCell>08/11/2010</TableCell>
+                    <TableCell>02/26/1991</TableCell>
+                    <TableCell>38</TableCell>
+                    <TableCell>Mokassie MCHP</TableCell>
+                    <TableCell>Dashonte Clarke</TableCell>
+                    <TableCell>Complete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Siyabonga" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Abiodun" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="07/21/1981" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="02/06/2007" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="98" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Bathurst MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Unassigned" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Siyabonga</TableCell>
+                    <TableCell>Abiodun</TableCell>
+                    <TableCell>07/21/1981</TableCell>
+                    <TableCell>02/06/2007</TableCell>
+                    <TableCell>98</TableCell>
+                    <TableCell>Bathurst MCHP</TableCell>
+                    <TableCell>Unassigned</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Chiyembekezo" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okeke" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/23/1982" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="07/15/2003" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="2" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Mayolla MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Wan Gengxin" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Chiyembekezo</TableCell>
+                    <TableCell>Okeke</TableCell>
+                    <TableCell>01/23/1982</TableCell>
+                    <TableCell>07/15/2003</TableCell>
+                    <TableCell>2</TableCell>
+                    <TableCell>Mayolla MCHP</TableCell>
+                    <TableCell>Wan Gengxin</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Mtendere" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Afolayan" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="08/12/1994" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="05/12/1972" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="37" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Gbangadu MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Gvozden Boskovsky" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Mtendere</TableCell>
+                    <TableCell>Afolayan</TableCell>
+                    <TableCell>08/12/1994</TableCell>
+                    <TableCell>05/12/1972</TableCell>
+                    <TableCell>37</TableCell>
+                    <TableCell>Gbangadu MCHP</TableCell>
+                    <TableCell>Gvozden Boskovsky</TableCell>
+                    <TableCell>Complete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Inyene" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okonkwo" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="04/01/1971" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="03/16/2000" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="70" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Kunike Barina" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Oscar de la Cavallería" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Inyene</TableCell>
+                    <TableCell>Okonkwo</TableCell>
+                    <TableCell>04/01/1971</TableCell>
+                    <TableCell>03/16/2000</TableCell>
+                    <TableCell>70</TableCell>
+                    <TableCell>Kunike Barina</TableCell>
+                    <TableCell>Oscar de la Cavallería</TableCell>
+                    <TableCell>Complete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Amaka" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Pretorius" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/25/1996" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="09/15/1986" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="32" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Bargbo" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Alberto Raya" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Amaka</TableCell>
+                    <TableCell>Pretorius</TableCell>
+                    <TableCell>01/25/1996</TableCell>
+                    <TableCell>09/15/1986</TableCell>
+                    <TableCell>32</TableCell>
+                    <TableCell>Bargbo</TableCell>
+                    <TableCell>Alberto Raya</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Meti" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Abiodun" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="10/24/2010" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="07/26/1989" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="8" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Majihun MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Unassigned" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Meti</TableCell>
+                    <TableCell>Abiodun</TableCell>
+                    <TableCell>10/24/2010</TableCell>
+                    <TableCell>07/26/1989</TableCell>
+                    <TableCell>8</TableCell>
+                    <TableCell>Majihun MCHP</TableCell>
+                    <TableCell>Unassigned</TableCell>
+                    <TableCell>Complete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Eshe" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okeke" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/31/1995" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/31/1995" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="63" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Mambiama CHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Shadrias Pearson" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Eshe</TableCell>
+                    <TableCell>Okeke</TableCell>
+                    <TableCell>01/31/1995</TableCell>
+                    <TableCell>01/31/1995</TableCell>
+                    <TableCell>63</TableCell>
+                    <TableCell>Mambiama CHP</TableCell>
+                    <TableCell>Shadrias Pearson</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Obi" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okafor" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="06/07/1990" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/03/2006" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="28" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Dalakuru CHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Anatoliy Shcherbatykh" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Obi</TableCell>
+                    <TableCell>Okafor</TableCell>
+                    <TableCell>06/07/1990</TableCell>
+                    <TableCell>01/03/2006</TableCell>
+                    <TableCell>28</TableCell>
+                    <TableCell>Dalakuru CHP</TableCell>
+                    <TableCell>Anatoliy Shcherbatykh</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
             </TableBody>
             <TableFoot>
@@ -387,291 +227,131 @@ storiesOf('Table', module)
             </TableHead>
             <TableBody>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Onyekachukwu" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Kariuki" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="02/06/2007" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="05/25/1972" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="66" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Jawi" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Sofie Hubert" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Onyekachukwu</TableCell>
+                    <TableCell>Kariuki</TableCell>
+                    <TableCell>02/06/2007</TableCell>
+                    <TableCell>05/25/1972</TableCell>
+                    <TableCell>66</TableCell>
+                    <TableCell>Jawi</TableCell>
+                    <TableCell>Sofie Hubert</TableCell>
+                    <TableCell>Incomplete</TableCell>
                     <TableCell noTitle>
                         <Actions />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Kwasi" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okafor" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="08/11/2010" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="02/26/1991" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="38" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Mokassie MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Dashonte Clarke" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Kwasi</TableCell>
+                    <TableCell>Okafor</TableCell>
+                    <TableCell>08/11/2010</TableCell>
+                    <TableCell>02/26/1991</TableCell>
+                    <TableCell>38</TableCell>
+                    <TableCell>Mokassie MCHP</TableCell>
+                    <TableCell>Dashonte Clarke</TableCell>
+                    <TableCell>Complete</TableCell>
                     <TableCell noTitle>
                         <Actions />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Siyabonga" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Abiodun" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="07/21/1981" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="02/06/2007" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="98" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Bathurst MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Unassigned" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Siyabonga</TableCell>
+                    <TableCell>Abiodun</TableCell>
+                    <TableCell>07/21/1981</TableCell>
+                    <TableCell>02/06/2007</TableCell>
+                    <TableCell>98</TableCell>
+                    <TableCell>Bathurst MCHP</TableCell>
+                    <TableCell>Unassigned</TableCell>
+                    <TableCell>Incomplete</TableCell>
                     <TableCell noTitle>
                         <Actions />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Chiyembekezo" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okeke" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/23/1982" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="07/15/2003" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="2" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Mayolla MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Wan Gengxin" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Chiyembekezo</TableCell>
+                    <TableCell>Okeke</TableCell>
+                    <TableCell>01/23/1982</TableCell>
+                    <TableCell>07/15/2003</TableCell>
+                    <TableCell>2</TableCell>
+                    <TableCell>Mayolla MCHP</TableCell>
+                    <TableCell>Wan Gengxin</TableCell>
+                    <TableCell>Incomplete</TableCell>
                     <TableCell noTitle>
                         <Actions />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Mtendere" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Afolayan" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="08/12/1994" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="05/12/1972" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="37" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Gbangadu MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Gvozden Boskovsky" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Mtendere</TableCell>
+                    <TableCell>Afolayan</TableCell>
+                    <TableCell>08/12/1994</TableCell>
+                    <TableCell>05/12/1972</TableCell>
+                    <TableCell>37</TableCell>
+                    <TableCell>Gbangadu MCHP</TableCell>
+                    <TableCell>Gvozden Boskovsky</TableCell>
+                    <TableCell>Complete</TableCell>
                     <TableCell noTitle>
                         <Actions />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Inyene" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okonkwo" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="04/01/1971" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="03/16/2000" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="70" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Kunike Barina" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Oscar de la Cavallería" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Inyene</TableCell>
+                    <TableCell>Okonkwo</TableCell>
+                    <TableCell>04/01/1971</TableCell>
+                    <TableCell>03/16/2000</TableCell>
+                    <TableCell>70</TableCell>
+                    <TableCell>Kunike Barina</TableCell>
+                    <TableCell>Oscar de la Cavallería</TableCell>
+                    <TableCell>Complete</TableCell>
                     <TableCell noTitle>
                         <Actions />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Amaka" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Pretorius" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/25/1996" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="09/15/1986" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="32" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Bargbo" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Alberto Raya" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Amaka</TableCell>
+                    <TableCell>Pretorius</TableCell>
+                    <TableCell>01/25/1996</TableCell>
+                    <TableCell>09/15/1986</TableCell>
+                    <TableCell>32</TableCell>
+                    <TableCell>Bargbo</TableCell>
+                    <TableCell>Alberto Raya</TableCell>
+                    <TableCell>Incomplete</TableCell>
                     <TableCell noTitle>
                         <Actions />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Meti" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Abiodun" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="10/24/2010" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="07/26/1989" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="8" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Majihun MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Unassigned" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Meti</TableCell>
+                    <TableCell>Abiodun</TableCell>
+                    <TableCell>10/24/2010</TableCell>
+                    <TableCell>07/26/1989</TableCell>
+                    <TableCell>8</TableCell>
+                    <TableCell>Majihun MCHP</TableCell>
+                    <TableCell>Unassigned</TableCell>
+                    <TableCell>Complete</TableCell>
                     <TableCell noTitle>
                         <Actions />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Eshe" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okeke" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/31/1995" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/31/1995" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="63" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Mambiama CHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Shadrias Pearson" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Eshe</TableCell>
+                    <TableCell>Okeke</TableCell>
+                    <TableCell>01/31/1995</TableCell>
+                    <TableCell>01/31/1995</TableCell>
+                    <TableCell>63</TableCell>
+                    <TableCell>Mambiama CHP</TableCell>
+                    <TableCell>Shadrias Pearson</TableCell>
+                    <TableCell>Incomplete</TableCell>
                     <TableCell noTitle>
                         <Actions />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Obi" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okafor" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="06/07/1990" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/03/2006" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="28" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Dalakuru CHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Anatoliy Shcherbatykh" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Obi</TableCell>
+                    <TableCell>Okafor</TableCell>
+                    <TableCell>06/07/1990</TableCell>
+                    <TableCell>01/03/2006</TableCell>
+                    <TableCell>28</TableCell>
+                    <TableCell>Dalakuru CHP</TableCell>
+                    <TableCell>Anatoliy Shcherbatykh</TableCell>
+                    <TableCell>Incomplete</TableCell>
                     <TableCell noTitle>
                         <Actions />
                     </TableCell>
@@ -702,264 +382,104 @@ storiesOf('Table', module)
             </TableHead>
             <TableBody>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Onyekachukwu" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Kariuki" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="02/06/2007" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="05/25/1972" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="66" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Jawi" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Sofie Hubert" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Onyekachukwu</TableCell>
+                    <TableCell>Kariuki</TableCell>
+                    <TableCell>02/06/2007</TableCell>
+                    <TableCell>05/25/1972</TableCell>
+                    <TableCell>66</TableCell>
+                    <TableCell>Jawi</TableCell>
+                    <TableCell>Sofie Hubert</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Kwasi" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okafor" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="08/11/2010" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="02/26/1991" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="38" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Mokassie MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Dashonte Clarke" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Kwasi</TableCell>
+                    <TableCell>Okafor</TableCell>
+                    <TableCell>08/11/2010</TableCell>
+                    <TableCell>02/26/1991</TableCell>
+                    <TableCell>38</TableCell>
+                    <TableCell>Mokassie MCHP</TableCell>
+                    <TableCell>Dashonte Clarke</TableCell>
+                    <TableCell>Complete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Siyabonga" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Abiodun" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="07/21/1981" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="02/06/2007" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="98" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Bathurst MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Unassigned" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Siyabonga</TableCell>
+                    <TableCell>Abiodun</TableCell>
+                    <TableCell>07/21/1981</TableCell>
+                    <TableCell>02/06/2007</TableCell>
+                    <TableCell>98</TableCell>
+                    <TableCell>Bathurst MCHP</TableCell>
+                    <TableCell>Unassigned</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Chiyembekezo" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okeke" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/23/1982" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="07/15/2003" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="2" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Mayolla MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Wan Gengxin" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Chiyembekezo</TableCell>
+                    <TableCell>Okeke</TableCell>
+                    <TableCell>01/23/1982</TableCell>
+                    <TableCell>07/15/2003</TableCell>
+                    <TableCell>2</TableCell>
+                    <TableCell>Mayolla MCHP</TableCell>
+                    <TableCell>Wan Gengxin</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Mtendere" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Afolayan" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="08/12/1994" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="05/12/1972" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="37" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Gbangadu MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Gvozden Boskovsky" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Mtendere</TableCell>
+                    <TableCell>Afolayan</TableCell>
+                    <TableCell>08/12/1994</TableCell>
+                    <TableCell>05/12/1972</TableCell>
+                    <TableCell>37</TableCell>
+                    <TableCell>Gbangadu MCHP</TableCell>
+                    <TableCell>Gvozden Boskovsky</TableCell>
+                    <TableCell>Complete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Inyene" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okonkwo" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="04/01/1971" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="03/16/2000" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="70" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Kunike Barina" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Oscar de la Cavallería" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Inyene</TableCell>
+                    <TableCell>Okonkwo</TableCell>
+                    <TableCell>04/01/1971</TableCell>
+                    <TableCell>03/16/2000</TableCell>
+                    <TableCell>70</TableCell>
+                    <TableCell>Kunike Barina</TableCell>
+                    <TableCell>Oscar de la Cavallería</TableCell>
+                    <TableCell>Complete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Amaka" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Pretorius" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/25/1996" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="09/15/1986" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="32" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Bargbo" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Alberto Raya" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Amaka</TableCell>
+                    <TableCell>Pretorius</TableCell>
+                    <TableCell>01/25/1996</TableCell>
+                    <TableCell>09/15/1986</TableCell>
+                    <TableCell>32</TableCell>
+                    <TableCell>Bargbo</TableCell>
+                    <TableCell>Alberto Raya</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Meti" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Abiodun" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="10/24/2010" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="07/26/1989" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="8" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Majihun MCHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Unassigned" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Complete" />
-                    </TableCell>
+                    <TableCell>Meti</TableCell>
+                    <TableCell>Abiodun</TableCell>
+                    <TableCell>10/24/2010</TableCell>
+                    <TableCell>07/26/1989</TableCell>
+                    <TableCell>8</TableCell>
+                    <TableCell>Majihun MCHP</TableCell>
+                    <TableCell>Unassigned</TableCell>
+                    <TableCell>Complete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Eshe" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okeke" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/31/1995" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/31/1995" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="63" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Mambiama CHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Shadrias Pearson" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Eshe</TableCell>
+                    <TableCell>Okeke</TableCell>
+                    <TableCell>01/31/1995</TableCell>
+                    <TableCell>01/31/1995</TableCell>
+                    <TableCell>63</TableCell>
+                    <TableCell>Mambiama CHP</TableCell>
+                    <TableCell>Shadrias Pearson</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell>
-                        <TableCellText label="Obi" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Okafor" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="06/07/1990" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="01/03/2006" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="28" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Dalakuru CHP" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Anatoliy Shcherbatykh" />
-                    </TableCell>
-                    <TableCell>
-                        <TableCellText label="Incomplete" />
-                    </TableCell>
+                    <TableCell>Obi</TableCell>
+                    <TableCell>Okafor</TableCell>
+                    <TableCell>06/07/1990</TableCell>
+                    <TableCell>01/03/2006</TableCell>
+                    <TableCell>28</TableCell>
+                    <TableCell>Dalakuru CHP</TableCell>
+                    <TableCell>Anatoliy Shcherbatykh</TableCell>
+                    <TableCell>Incomplete</TableCell>
                 </TableRow>
             </TableBody>
             <TableFoot>

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -366,6 +366,119 @@ storiesOf('Table', module)
             </TableFoot>
         </Table>
     ))
+    .add('No head', () => (
+        <Table>
+            <TableBody>
+                <TableRow>
+                    <TableCell>Onyekachukwu</TableCell>
+                    <TableCell>Kariuki</TableCell>
+                    <TableCell>02/06/2007</TableCell>
+                    <TableCell>05/25/1972</TableCell>
+                    <TableCell>66</TableCell>
+                    <TableCell>Jawi</TableCell>
+                    <TableCell>Sofie Hubert</TableCell>
+                    <TableCell>Incomplete</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Kwasi</TableCell>
+                    <TableCell>Okafor</TableCell>
+                    <TableCell>08/11/2010</TableCell>
+                    <TableCell>02/26/1991</TableCell>
+                    <TableCell>38</TableCell>
+                    <TableCell>Mokassie MCHP</TableCell>
+                    <TableCell>Dashonte Clarke</TableCell>
+                    <TableCell>Complete</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Siyabonga</TableCell>
+                    <TableCell>Abiodun</TableCell>
+                    <TableCell>07/21/1981</TableCell>
+                    <TableCell>02/06/2007</TableCell>
+                    <TableCell>98</TableCell>
+                    <TableCell>Bathurst MCHP</TableCell>
+                    <TableCell>Unassigned</TableCell>
+                    <TableCell>Incomplete</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Chiyembekezo</TableCell>
+                    <TableCell>Okeke</TableCell>
+                    <TableCell>01/23/1982</TableCell>
+                    <TableCell>07/15/2003</TableCell>
+                    <TableCell>2</TableCell>
+                    <TableCell>Mayolla MCHP</TableCell>
+                    <TableCell>Wan Gengxin</TableCell>
+                    <TableCell>Incomplete</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Mtendere</TableCell>
+                    <TableCell>Afolayan</TableCell>
+                    <TableCell>08/12/1994</TableCell>
+                    <TableCell>05/12/1972</TableCell>
+                    <TableCell>37</TableCell>
+                    <TableCell>Gbangadu MCHP</TableCell>
+                    <TableCell>Gvozden Boskovsky</TableCell>
+                    <TableCell>Complete</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Inyene</TableCell>
+                    <TableCell>Okonkwo</TableCell>
+                    <TableCell>04/01/1971</TableCell>
+                    <TableCell>03/16/2000</TableCell>
+                    <TableCell>70</TableCell>
+                    <TableCell>Kunike Barina</TableCell>
+                    <TableCell>Oscar de la Cavallería</TableCell>
+                    <TableCell>Complete</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Amaka</TableCell>
+                    <TableCell>Pretorius</TableCell>
+                    <TableCell>01/25/1996</TableCell>
+                    <TableCell>09/15/1986</TableCell>
+                    <TableCell>32</TableCell>
+                    <TableCell>Bargbo</TableCell>
+                    <TableCell>Alberto Raya</TableCell>
+                    <TableCell>Incomplete</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Meti</TableCell>
+                    <TableCell>Abiodun</TableCell>
+                    <TableCell>10/24/2010</TableCell>
+                    <TableCell>07/26/1989</TableCell>
+                    <TableCell>8</TableCell>
+                    <TableCell>Majihun MCHP</TableCell>
+                    <TableCell>Unassigned</TableCell>
+                    <TableCell>Complete</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Eshe</TableCell>
+                    <TableCell>Okeke</TableCell>
+                    <TableCell>01/31/1995</TableCell>
+                    <TableCell>01/31/1995</TableCell>
+                    <TableCell>63</TableCell>
+                    <TableCell>Mambiama CHP</TableCell>
+                    <TableCell>Shadrias Pearson</TableCell>
+                    <TableCell>Incomplete</TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Obi</TableCell>
+                    <TableCell>Okafor</TableCell>
+                    <TableCell>06/07/1990</TableCell>
+                    <TableCell>01/03/2006</TableCell>
+                    <TableCell>28</TableCell>
+                    <TableCell>Dalakuru CHP</TableCell>
+                    <TableCell>Anatoliy Shcherbatykh</TableCell>
+                    <TableCell>Incomplete</TableCell>
+                </TableRow>
+            </TableBody>
+            <TableFoot>
+                <TableRow>
+                    <TableCell colSpan="8">
+                        <TableFooterButton />
+                    </TableCell>
+                </TableRow>
+            </TableFoot>
+        </Table>
+    ))
     .add('Static layout', () => (
         <Table staticLayout>
             <TableHead>

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -27,30 +27,23 @@ storiesOf('Table', module)
         <Table>
             <TableHead>
                 <TableRow>
-                    <TableCellHead>
-                        <TableCellText label="First name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
+                    <TableCellHead colSpan="2" label="Name" />
+                    <TableCellHead label="Incident date" />
+                    <TableCellHead label="Last updated" />
+                    <TableCellHead label="Age" />
+                    <TableCellHead label="Registering unit" />
+                    <TableCellHead label="Assigned user" />
+                    <TableCellHead label="Status" />
+                </TableRow>
+                <TableRow>
+                    <TableCellHead label="First name" />
+                    <TableCellHead label="Last name" />
+                    <TableCellHead label="" />
+                    <TableCellHead label="" />
+                    <TableCellHead label="" />
+                    <TableCellHead label="" />
+                    <TableCellHead label="" />
+                    <TableCellHead label="" />
                 </TableRow>
             </TableHead>
             <TableBody>
@@ -328,30 +321,14 @@ storiesOf('Table', module)
         <Table staticLayout>
             <TableHead>
                 <TableRow>
-                    <TableCellHead>
-                        <TableCellText label="First name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
-                    <TableCellHead>
-                        <TableCellText label="Last name" />
-                    </TableCellHead>
+                    <TableCellHead label="First name" />
+                    <TableCellHead label="Last name" />
+                    <TableCellHead label="Incident date" />
+                    <TableCellHead label="Last updated" />
+                    <TableCellHead label="Age" />
+                    <TableCellHead label="Registering unit" />
+                    <TableCellHead label="Assigned user" />
+                    <TableCellHead label="Status" />
                 </TableRow>
             </TableHead>
             <TableBody>

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -25,12 +25,63 @@ const TableFooterButton = () => (
         `}</style>
     </div>
 )
+
+const Actions = () => (
+    <div>
+        <a className="icon" href="#">
+            ...
+        </a>
+
+        <div className="content">
+            <p>
+                <b>Actions:</b>
+            </p>
+            <ul>
+                <li>
+                    <a href="#">Show</a>
+                </li>
+                <li>
+                    <a href="#">Edit</a>
+                </li>
+                <li>
+                    <a href="#">Delete</a>
+                </li>
+            </ul>
+        </div>
+
+        <style jsx>{`
+            .content {
+                display: none;
+            }
+
+            ul {
+                padding: 0;
+            }
+
+            li {
+                font-size: 14px;
+                padding: 9px 0;
+            }
+
+            @media (max-width: 768px) {
+                .icon {
+                    display: none;
+                }
+                .content {
+                    display: block;
+                }
+                list-style: inside;
+            }
+        `}</style>
+    </div>
+)
+
 storiesOf('Table', module)
     .add('Default', () => (
         <Table>
             <TableHead>
                 <TableRowHead>
-                    <TableCellHead colSpan="2" label="Name" />
+                    <TableCellHead label="Name" colSpan="2" />
                     <TableCellHead label="Incident date" />
                     <TableCellHead label="Last updated" />
                     <TableCellHead label="Age" />
@@ -41,272 +92,267 @@ storiesOf('Table', module)
                 <TableRowHead>
                     <TableCellHead label="First name" />
                     <TableCellHead label="Last name" />
-                    <TableCellHead label="" />
-                    <TableCellHead label="" />
-                    <TableCellHead label="" />
-                    <TableCellHead label="" />
-                    <TableCellHead label="" />
-                    <TableCellHead label="" />
+                    <TableCellHead label="" colSpan="6" />
                 </TableRowHead>
             </TableHead>
             <TableBody>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Onyekachukwu" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Kariuki" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="02/06/2007" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="05/25/1972" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="66" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Jawi" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Sofie Hubert" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Kwasi" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Okafor" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="08/11/2010" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="02/26/1991" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="38" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Mokassie MCHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Dashonte Clarke" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Complete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Siyabonga" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Abiodun" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="07/21/1981" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="02/06/2007" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="98" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Bathurst MCHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Unassigned" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Chiyembekezo" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Okeke" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="01/23/1982" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="07/15/2003" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="2" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Mayolla MCHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Wan Gengxin" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Mtendere" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Afolayan" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="08/12/1994" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="05/12/1972" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="37" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Gbangadu MCHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Gvozden Boskovsky" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Complete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Inyene" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Okonkwo" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="04/01/1971" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="03/16/2000" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="70" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Kunike Barina" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Oscar de la Cavallería" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Complete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Amaka" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Pretorius" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="01/25/1996" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="09/15/1986" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="32" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Bargbo" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Alberto Raya" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Meti" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Abiodun" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="10/24/2010" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="07/26/1989" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="8" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Majihun MCHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Unassigned" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Complete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Eshe" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Okeke" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="01/31/1995" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="01/31/1995" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="63" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Mambiama CHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Shadrias Pearson" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Obi" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Okafor" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="06/07/1990" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="01/03/2006" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="28" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Dalakuru CHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Anatoliy Shcherbatykh" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
@@ -314,6 +360,326 @@ storiesOf('Table', module)
             <TableFoot>
                 <TableRow>
                     <TableCell colSpan="8">
+                        <TableFooterButton />
+                    </TableCell>
+                </TableRow>
+            </TableFoot>
+        </Table>
+    ))
+    .add('Some without title', () => (
+        <Table>
+            <TableHead>
+                <TableRowHead>
+                    <TableCellHead label="Name" colSpan="2" />
+                    <TableCellHead label="Incident date" />
+                    <TableCellHead label="Last updated" />
+                    <TableCellHead label="Age" />
+                    <TableCellHead label="Registering unit" />
+                    <TableCellHead label="Assigned user" />
+                    <TableCellHead label="Status" />
+                    <TableCellHead label="Actions" />
+                </TableRowHead>
+                <TableRowHead>
+                    <TableCellHead label="First name" />
+                    <TableCellHead label="Last name" />
+                    <TableCellHead label="" colSpan="7" />
+                </TableRowHead>
+            </TableHead>
+            <TableBody>
+                <TableRow>
+                    <TableCell>
+                        <TableCellText label="Onyekachukwu" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Kariuki" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="02/06/2007" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="05/25/1972" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="66" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Jawi" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Sofie Hubert" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Incomplete" />
+                    </TableCell>
+                    <TableCell noTitle>
+                        <Actions />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>
+                        <TableCellText label="Kwasi" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Okafor" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="08/11/2010" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="02/26/1991" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="38" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Mokassie MCHP" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Dashonte Clarke" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Complete" />
+                    </TableCell>
+                    <TableCell noTitle>
+                        <Actions />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>
+                        <TableCellText label="Siyabonga" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Abiodun" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="07/21/1981" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="02/06/2007" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="98" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Bathurst MCHP" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Unassigned" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Incomplete" />
+                    </TableCell>
+                    <TableCell noTitle>
+                        <Actions />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>
+                        <TableCellText label="Chiyembekezo" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Okeke" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="01/23/1982" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="07/15/2003" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="2" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Mayolla MCHP" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Wan Gengxin" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Incomplete" />
+                    </TableCell>
+                    <TableCell noTitle>
+                        <Actions />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>
+                        <TableCellText label="Mtendere" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Afolayan" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="08/12/1994" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="05/12/1972" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="37" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Gbangadu MCHP" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Gvozden Boskovsky" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Complete" />
+                    </TableCell>
+                    <TableCell noTitle>
+                        <Actions />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>
+                        <TableCellText label="Inyene" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Okonkwo" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="04/01/1971" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="03/16/2000" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="70" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Kunike Barina" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Oscar de la Cavallería" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Complete" />
+                    </TableCell>
+                    <TableCell noTitle>
+                        <Actions />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>
+                        <TableCellText label="Amaka" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Pretorius" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="01/25/1996" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="09/15/1986" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="32" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Bargbo" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Alberto Raya" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Incomplete" />
+                    </TableCell>
+                    <TableCell noTitle>
+                        <Actions />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>
+                        <TableCellText label="Meti" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Abiodun" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="10/24/2010" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="07/26/1989" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="8" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Majihun MCHP" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Unassigned" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Complete" />
+                    </TableCell>
+                    <TableCell noTitle>
+                        <Actions />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>
+                        <TableCellText label="Eshe" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Okeke" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="01/31/1995" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="01/31/1995" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="63" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Mambiama CHP" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Shadrias Pearson" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Incomplete" />
+                    </TableCell>
+                    <TableCell noTitle>
+                        <Actions />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>
+                        <TableCellText label="Obi" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Okafor" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="06/07/1990" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="01/03/2006" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="28" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Dalakuru CHP" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Anatoliy Shcherbatykh" />
+                    </TableCell>
+                    <TableCell>
+                        <TableCellText label="Incomplete" />
+                    </TableCell>
+                    <TableCell noTitle>
+                        <Actions />
+                    </TableCell>
+                </TableRow>
+            </TableBody>
+            <TableFoot>
+                <TableRow>
+                    <TableCell colSpan="9">
                         <TableFooterButton />
                     </TableCell>
                 </TableRow>
@@ -336,262 +702,262 @@ storiesOf('Table', module)
             </TableHead>
             <TableBody>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Onyekachukwu" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Kariuki" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="02/06/2007" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="05/25/1972" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="66" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Jawi" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Sofie Hubert" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Kwasi" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Okafor" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="08/11/2010" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="02/26/1991" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="38" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Mokassie MCHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Dashonte Clarke" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Complete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Siyabonga" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Abiodun" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="07/21/1981" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="02/06/2007" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="98" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Bathurst MCHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Unassigned" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Chiyembekezo" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Okeke" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="01/23/1982" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="07/15/2003" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="2" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Mayolla MCHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Wan Gengxin" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Mtendere" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Afolayan" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="08/12/1994" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="05/12/1972" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="37" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Gbangadu MCHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Gvozden Boskovsky" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Complete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Inyene" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Okonkwo" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="04/01/1971" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="03/16/2000" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="70" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Kunike Barina" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Oscar de la Cavallería" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Complete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Amaka" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Pretorius" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="01/25/1996" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="09/15/1986" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="32" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Bargbo" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Alberto Raya" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Meti" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Abiodun" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="10/24/2010" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="07/26/1989" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="8" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Majihun MCHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Unassigned" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Complete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Eshe" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Okeke" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="01/31/1995" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="01/31/1995" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="63" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Mambiama CHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Shadrias Pearson" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>
                 <TableRow>
-                    <TableCell title="First name">
+                    <TableCell>
                         <TableCellText label="Obi" />
                     </TableCell>
-                    <TableCell title="Last name">
+                    <TableCell>
                         <TableCellText label="Okafor" />
                     </TableCell>
-                    <TableCell title="Incident date">
+                    <TableCell>
                         <TableCellText label="06/07/1990" />
                     </TableCell>
-                    <TableCell title="Last updated">
+                    <TableCell>
                         <TableCellText label="01/03/2006" />
                     </TableCell>
-                    <TableCell title="Age">
+                    <TableCell>
                         <TableCellText label="28" />
                     </TableCell>
-                    <TableCell title="Registering unit">
+                    <TableCell>
                         <TableCellText label="Dalakuru CHP" />
                     </TableCell>
-                    <TableCell title="Assigned user">
+                    <TableCell>
                         <TableCellText label="Anatoliy Shcherbatykh" />
                     </TableCell>
-                    <TableCell title="Status">
+                    <TableCell>
                         <TableCellText label="Incomplete" />
                     </TableCell>
                 </TableRow>

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -210,14 +210,18 @@ storiesOf('Table', module)
         <Table>
             <TableHead>
                 <TableRowHead>
-                    <TableCellHead label="Name" colSpan="2" noTitle />
+                    <TableCellHead
+                        label="Name"
+                        colSpan="2"
+                        hideResponsiveLabel
+                    />
                     <TableCellHead label="Incident date" />
                     <TableCellHead label="Last updated" />
                     <TableCellHead label="Age" />
                     <TableCellHead label="Registering unit" />
                     <TableCellHead label="Assigned user" />
                     <TableCellHead label="Status" />
-                    <TableCellHead label="Actions" noTitle />
+                    <TableCellHead label="Actions" hideResponsiveLabel />
                 </TableRowHead>
                 <TableRowHead>
                     <TableCellHead label="First name" />

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -92,7 +92,7 @@ storiesOf('Table', module)
                 <TableRowHead>
                     <TableCellHead label="First name" />
                     <TableCellHead label="Last name" />
-                    <TableCellHead label="" colSpan="6" />
+                    <TableCellHead colSpan="6" />
                 </TableRowHead>
             </TableHead>
             <TableBody>
@@ -222,7 +222,7 @@ storiesOf('Table', module)
                 <TableRowHead>
                     <TableCellHead label="First name" />
                     <TableCellHead label="Last name" />
-                    <TableCellHead label="" colSpan="7" />
+                    <TableCellHead colSpan="7" />
                 </TableRowHead>
             </TableHead>
             <TableBody>

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -1,14 +1,17 @@
 import React from 'react'
+
 import { storiesOf } from '@storybook/react'
+
 import { Button } from '../src/Button'
 import { Table } from '../src/Table'
 import { TableBody } from '../src/Table/TableBody'
-import { TableHead } from '../src/Table/TableHead'
-import { TableFoot } from '../src/Table/TableFoot'
-import { TableRow } from '../src/Table/TableRow'
-import { TableCellHead } from '../src/Table/TableCellHead'
 import { TableCell } from '../src/Table/TableCell'
+import { TableCellHead } from '../src/Table/TableCellHead'
 import { TableCellText } from '../src/Table/TableCellText'
+import { TableFoot } from '../src/Table/TableFoot'
+import { TableHead } from '../src/Table/TableHead'
+import { TableRow } from '../src/Table/TableRow'
+import { TableRowHead } from '../src/Table/TableRowHead'
 
 const TableFooterButton = () => (
     <div>
@@ -26,7 +29,7 @@ storiesOf('Table', module)
     .add('Default', () => (
         <Table>
             <TableHead>
-                <TableRow>
+                <TableRowHead>
                     <TableCellHead colSpan="2" label="Name" />
                     <TableCellHead label="Incident date" />
                     <TableCellHead label="Last updated" />
@@ -34,8 +37,8 @@ storiesOf('Table', module)
                     <TableCellHead label="Registering unit" />
                     <TableCellHead label="Assigned user" />
                     <TableCellHead label="Status" />
-                </TableRow>
-                <TableRow>
+                </TableRowHead>
+                <TableRowHead>
                     <TableCellHead label="First name" />
                     <TableCellHead label="Last name" />
                     <TableCellHead label="" />
@@ -44,7 +47,7 @@ storiesOf('Table', module)
                     <TableCellHead label="" />
                     <TableCellHead label="" />
                     <TableCellHead label="" />
-                </TableRow>
+                </TableRowHead>
             </TableHead>
             <TableBody>
                 <TableRow>
@@ -320,7 +323,7 @@ storiesOf('Table', module)
     .add('Static layout', () => (
         <Table staticLayout>
             <TableHead>
-                <TableRow>
+                <TableRowHead>
                     <TableCellHead label="First name" />
                     <TableCellHead label="Last name" />
                     <TableCellHead label="Incident date" />
@@ -329,7 +332,7 @@ storiesOf('Table', module)
                     <TableCellHead label="Registering unit" />
                     <TableCellHead label="Assigned user" />
                     <TableCellHead label="Status" />
-                </TableRow>
+                </TableRowHead>
             </TableHead>
             <TableBody>
                 <TableRow>

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -210,14 +210,14 @@ storiesOf('Table', module)
         <Table>
             <TableHead>
                 <TableRowHead>
-                    <TableCellHead label="Name" colSpan="2" />
+                    <TableCellHead label="Name" colSpan="2" noTitle />
                     <TableCellHead label="Incident date" />
                     <TableCellHead label="Last updated" />
                     <TableCellHead label="Age" />
                     <TableCellHead label="Registering unit" />
                     <TableCellHead label="Assigned user" />
                     <TableCellHead label="Status" />
-                    <TableCellHead label="Actions" />
+                    <TableCellHead label="Actions" noTitle />
                 </TableRowHead>
                 <TableRowHead>
                     <TableCellHead label="First name" />
@@ -235,7 +235,7 @@ storiesOf('Table', module)
                     <TableCell>Jawi</TableCell>
                     <TableCell>Sofie Hubert</TableCell>
                     <TableCell>Incomplete</TableCell>
-                    <TableCell noTitle>
+                    <TableCell>
                         <Actions />
                     </TableCell>
                 </TableRow>
@@ -248,7 +248,7 @@ storiesOf('Table', module)
                     <TableCell>Mokassie MCHP</TableCell>
                     <TableCell>Dashonte Clarke</TableCell>
                     <TableCell>Complete</TableCell>
-                    <TableCell noTitle>
+                    <TableCell>
                         <Actions />
                     </TableCell>
                 </TableRow>
@@ -261,7 +261,7 @@ storiesOf('Table', module)
                     <TableCell>Bathurst MCHP</TableCell>
                     <TableCell>Unassigned</TableCell>
                     <TableCell>Incomplete</TableCell>
-                    <TableCell noTitle>
+                    <TableCell>
                         <Actions />
                     </TableCell>
                 </TableRow>
@@ -274,7 +274,7 @@ storiesOf('Table', module)
                     <TableCell>Mayolla MCHP</TableCell>
                     <TableCell>Wan Gengxin</TableCell>
                     <TableCell>Incomplete</TableCell>
-                    <TableCell noTitle>
+                    <TableCell>
                         <Actions />
                     </TableCell>
                 </TableRow>
@@ -287,7 +287,7 @@ storiesOf('Table', module)
                     <TableCell>Gbangadu MCHP</TableCell>
                     <TableCell>Gvozden Boskovsky</TableCell>
                     <TableCell>Complete</TableCell>
-                    <TableCell noTitle>
+                    <TableCell>
                         <Actions />
                     </TableCell>
                 </TableRow>
@@ -300,7 +300,7 @@ storiesOf('Table', module)
                     <TableCell>Kunike Barina</TableCell>
                     <TableCell>Oscar de la Cavallería</TableCell>
                     <TableCell>Complete</TableCell>
-                    <TableCell noTitle>
+                    <TableCell>
                         <Actions />
                     </TableCell>
                 </TableRow>
@@ -313,7 +313,7 @@ storiesOf('Table', module)
                     <TableCell>Bargbo</TableCell>
                     <TableCell>Alberto Raya</TableCell>
                     <TableCell>Incomplete</TableCell>
-                    <TableCell noTitle>
+                    <TableCell>
                         <Actions />
                     </TableCell>
                 </TableRow>
@@ -326,7 +326,7 @@ storiesOf('Table', module)
                     <TableCell>Majihun MCHP</TableCell>
                     <TableCell>Unassigned</TableCell>
                     <TableCell>Complete</TableCell>
-                    <TableCell noTitle>
+                    <TableCell>
                         <Actions />
                     </TableCell>
                 </TableRow>
@@ -339,7 +339,7 @@ storiesOf('Table', module)
                     <TableCell>Mambiama CHP</TableCell>
                     <TableCell>Shadrias Pearson</TableCell>
                     <TableCell>Incomplete</TableCell>
-                    <TableCell noTitle>
+                    <TableCell>
                         <Actions />
                     </TableCell>
                 </TableRow>
@@ -352,7 +352,7 @@ storiesOf('Table', module)
                     <TableCell>Dalakuru CHP</TableCell>
                     <TableCell>Anatoliy Shcherbatykh</TableCell>
                     <TableCell>Incomplete</TableCell>
-                    <TableCell noTitle>
+                    <TableCell>
                         <Actions />
                     </TableCell>
                 </TableRow>


### PR DESCRIPTION
With these changes, the title for all table cells has to be provided to the table head cells.
They're extracted by leveraging the `React.Children` api, coupled with stricter propTypes to ensure that only the correct components are used.

I've decided against using a config object because it was way harder to read. Now the table can be constructed like a normal table, with multiple rows in the `thead`.

The `TableCell` component has a `noTitle` prop if the content is special and doesn't need a title.

I've added examples in the storybook

UPDATE:
I could use the same approach for row-header labels (the vertical headers displayed in pivot tables for example)