### PR TITLE
chore(dev-deps): bump babel dependencies to 7.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     }
   },
   "devDependencies": {
-    "@babel/cli": "^7.4.4",
+    "@babel/cli": "^7.5.0",
     "@babel/core": "^7.4.5",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,11 +297,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
 
-<<<<<<< HEAD
-"@babel/plugin-proposal-object-rest-spread@^7.3.2", "@babel/plugin-proposal-object-rest-spread@^7.4.3", "@babel/plugin-proposal-object-rest-spread@^7.4.4", "@babel/plugin-proposal-object-rest-spread@^7.5.0":
-=======
-"@babel/plugin-proposal-object-rest-spread@^7.2.0", "@babel/plugin-proposal-object-rest-spread@^7.3.2", "@babel/plugin-proposal-object-rest-spread@^7.4.3", "@babel/plugin-proposal-object-rest-spread@^7.5.0":
->>>>>>> origin/dependabot/npm_and_yarn/babel/preset-env-7.5.0
+"@babel/plugin-proposal-object-rest-spread@^7.3.2", "@babel/plugin-proposal-object-rest-spread@^7.4.3", "@babel/plugin-proposal-object-rest-spread@^7.5.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.0.tgz#4838ce3cbc9a84dd00bce7a17e9e9c36119f83a0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@babel/cli@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.4.4.tgz#5454bb7112f29026a4069d8e6f0e1794e651966c"
+"@babel/cli@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.5.0.tgz#f403c930692e28ecfa3bf02a9e7562b474f38271"
   dependencies:
     commander "^2.8.1"
     convert-source-map "^1.1.0"


### PR DESCRIPTION
Tested all of them together (works) and resolved merge conflicts for safer merge into master

chore(deps-dev): bump @babel/plugin-transform-react-constant-elements
chore(deps-dev): bump @babel/plugin-proposal-object-rest-spread
chore(deps-dev): bump @babel/cli from 7.4.4 to 7.5.0
chore(deps-dev): bump @babel/plugin-proposal-class-properties
chore(deps-dev): bump @babel/preset-env from 7.4.5 to 7.5.0
chore(deps-dev): bump @babel/core from 7.4.5 to 7.5.0