### PR TITLE
chore(tabs): remove interactive storybook dev example

### DIFF
--- a/stories/Tabs.stories.js
+++ b/stories/Tabs.stories.js
@@ -5,96 +5,6 @@ import { Indeterminate } from '../src/icons/Checkbox'
 
 import markdown from './info/molecules/tabs.md'
 
-class TabsContainer extends React.Component {
-    state = {
-        tabIndex: 5,
-    }
-    setTabIndex = index => {
-        this.setState({ tabIndex: index })
-    }
-    render() {
-        return (
-            <ScrollBar>
-                <TabBar>
-                    <Tab
-                        selected={this.state.tabIndex === 0}
-                        onClick={() => this.setTabIndex(0)}
-                    >
-                        Test A
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 1}
-                        onClick={() => this.setTabIndex(1)}
-                    >
-                        Test B
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 2}
-                        disabled
-                        onClick={() => this.setTabIndex(2)}
-                    >
-                        Test C
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 3}
-                        onClick={() => this.setTabIndex(3)}
-                    >
-                        Test D
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 4}
-                        onClick={() => this.setTabIndex(4)}
-                    >
-                        Test E
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 5}
-                        onClick={() => this.setTabIndex(5)}
-                    >
-                        Test F
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 6}
-                        onClick={() => this.setTabIndex(6)}
-                    >
-                        Test G
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 7}
-                        onClick={() => this.setTabIndex(7)}
-                    >
-                        Test H
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 8}
-                        onClick={() => this.setTabIndex(8)}
-                    >
-                        Test I
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 9}
-                        onClick={() => this.setTabIndex(9)}
-                    >
-                        Test J
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 10}
-                        onClick={() => this.setTabIndex(10)}
-                    >
-                        Test K
-                    </Tab>
-                    <Tab
-                        selected={this.state.tabIndex === 11}
-                        onClick={() => this.setTabIndex(11)}
-                    >
-                        Test L
-                    </Tab>
-                </TabBar>
-            </ScrollBar>
-        )
-    }
-}
-
 const Wrapper = fn => (
     <div
         style={{
@@ -185,4 +95,3 @@ storiesOf('Tabs', module)
             </Tab>
         </TabBar>
     ))
-    .add('Interactive demo with scrolling', () => <TabsContainer />)


### PR DESCRIPTION
Removed the interactive example because this was mainly used during development, and doesn't gives a very good JSX illustration of how to use this component.