### PR TITLE
fix(tab): increase line-height & decrease padding to preserve height

### DIFF
--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -24,7 +24,7 @@ const Tab = ({ icon, onClick, selected, disabled, children }) => (
                 vertical-align: bottom;
 
                 height: 100%;
-                padding: 19px 16px 14px 16px;
+                padding: 16px 16px 11px;
 
                 background-color: transparent;
                 outline: none;
@@ -33,7 +33,7 @@ const Tab = ({ icon, onClick, selected, disabled, children }) => (
 
                 color: ${colors.grey600};
                 font-size: 14px;
-                line-height: 14px;
+                line-height: 20px;
 
                 transition: all 150ms ease-in-out;
                 transition-property: color, background-color;

--- a/src/Tabs/TabBar.js
+++ b/src/Tabs/TabBar.js
@@ -16,6 +16,7 @@ const TabBar = ({ fixed, children }) => (
                 box-shadow: inset 0 -1px 0 0 ${colors.grey400};
                 flex-wrap: nowrap;
                 flex-grow: 1;
+                background: ${colors.white};
             }
         `}</style>
     </div>


### PR DESCRIPTION
Previous to this fix, the `line-height` of the `<Tab />`s was equal to the `font-size`.
This caused letters like `g` to be cut-off due to `overflow: hidden`