### PR TITLE
feat: wrap contents with a link element when href or onClick is given

### DIFF
--- a/src/MenuItem/index.js
+++ b/src/MenuItem/index.js
@@ -35,7 +35,16 @@ const SubMenu = ({ children, className }) => (
     <div className={className}>{children}</div>
 )
 
+const createOnClickHandler = onClick => evt => {
+    if (onClick) {
+        evt.preventDefault()
+        evt.stopPropagation()
+        onClick(value)
+    }
+}
+
 const MenuItem = ({
+    href,
     value,
     label,
     icon,
@@ -54,24 +63,23 @@ const MenuItem = ({
                 dense,
                 active,
             })}
-            onClick={evt => {
-                if (onClick) {
-                    evt.preventDefault()
-                    evt.stopPropagation()
-                    onClick(value)
-                }
-            }}
         >
-            {icon}
-            <div className="label">{label}</div>
+            <a
+                className="link"
+                href={href}
+                onClick={createOnClickHandler(onClick)}
+            >
+                {icon}
+                <div className="label">{label}</div>
 
-            {hasMenu && <ChevronRight className={subChevron.className} />}
-            {subChevron.styles}
+                {hasMenu && <ChevronRight className={subChevron.className} />}
+                {subChevron.styles}
 
-            {hasMenu && (
-                <SubMenu className={subMenu.className}>{children}</SubMenu>
-            )}
-            {subMenu.styles}
+                {hasMenu && (
+                    <SubMenu className={subMenu.className}>{children}</SubMenu>
+                )}
+                {subMenu.styles}
+            </a>
 
             <style jsx>{styles}</style>
         </li>
@@ -82,6 +90,7 @@ MenuItem.propTypes = {
     label: propTypes.oneOfType([propTypes.string, propTypes.object]).isRequired,
 
     value: propTypes.any,
+    href: propTypes.string,
     /** handler function called with `value` as the sole argument */
     onClick: propTypes.func,
 

--- a/src/MenuItem/index.js
+++ b/src/MenuItem/index.js
@@ -56,6 +56,15 @@ const MenuItem = ({
     className,
 }) => {
     const hasMenu = !!children
+    const isClickable = href || onClick
+    const LinkElement = isClickable ? 'a' : 'span'
+    const linkElementProps = {}
+
+    if (isClickable) {
+        linkElementProps.href = href
+        linkElementProps.onClick = createOnClickHandler(onClick)
+    }
+
     return (
         <li
             className={cx(className, subMenu.className, {
@@ -64,11 +73,7 @@ const MenuItem = ({
                 active,
             })}
         >
-            <a
-                className="link"
-                href={href}
-                onClick={createOnClickHandler(onClick)}
-            >
+            <LinkElement className="link" {...linkElementProps}>
                 {icon}
                 <div className="label">{label}</div>
 
@@ -79,7 +84,7 @@ const MenuItem = ({
                     <SubMenu className={subMenu.className}>{children}</SubMenu>
                 )}
                 {subMenu.styles}
-            </a>
+            </LinkElement>
 
             <style jsx>{styles}</style>
         </li>

--- a/src/MenuItem/styles.js
+++ b/src/MenuItem/styles.js
@@ -3,13 +3,11 @@ import { colors, spacers } from '../theme.js'
 
 export default css`
     li {
-        display: flex;
         position: relative;
-        flex-direction: row;
-        align-items: center;
         height: 48px;
-        padding: 0 ${spacers.dp24};
+        padding: 0;
         cursor: pointer;
+        list-style: none;
     }
 
     li div.label:not(:first-child) {
@@ -23,28 +21,6 @@ export default css`
     li:active,
     li.active {
         background-color: ${colors.grey400};
-    }
-
-    .label {
-        color: ${colors.grey900};
-        font-size: 15px;
-
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-
-        user-select: none;
-        padding-right: ${spacers.dp12};
-    }
-
-    .icon {
-        box-sizing: border-box;
-
-        margin-right: ${spacers.dp16};
-        color: #404040;
-        font-size: 24px;
-        pointer-events: none;
-        user-select: none;
     }
 
     .dense {
@@ -69,5 +45,37 @@ export default css`
     .disabled .icon,
     .disabled .label {
         color: rgba(0, 0, 0, 0.3);
+    }
+
+    .link {
+        display: block;
+        height: 100%;
+        padding: 0 ${spacers.dp24};
+        text-decoration: none;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .label {
+        color: ${colors.grey900};
+        font-size: 15px;
+
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        user-select: none;
+        padding-right: ${spacers.dp12};
+    }
+
+    .icon {
+        box-sizing: border-box;
+
+        margin-right: ${spacers.dp16};
+        color: #404040;
+        font-size: 24px;
+        pointer-events: none;
+        user-select: none;
     }
 `

--- a/src/Switch/styles.js
+++ b/src/Switch/styles.js
@@ -2,6 +2,12 @@ import css from 'styled-jsx/css'
 import { theme, spacers } from '../theme.js'
 
 export default css`
+    label {
+        display: flex;
+        height: 22px;
+        align-items: center;
+    }
+
     input {
         opacity: 0;
         width: 0;


### PR DESCRIPTION
With this change the navigation will be semantically correct, rendering `a` elements when there's either a `href` or an `onClick` callback.
Said element will be a `span` when neither if given (i. e. so a `Switch` can be renderen inside a `MenuItem`)

This PR will also add a height value to the `Switch` so it's not cut off anymore when inside elements with `overflow: hidden` (see current `Menu > Default` storybook demo)