### PR TITLE
fix: use correct disabled style & fix checkbox and radio disabled style

### DIFF
--- a/src/Checkbox/Label.js
+++ b/src/Checkbox/Label.js
@@ -5,7 +5,7 @@ import cx from 'classnames'
 import { colors, theme, spacers } from '../theme.js'
 
 export const Label = ({ disabled, required, children }) => {
-    const className = cx('label', { disabled, required, disabled })
+    const className = cx('label', { disabled, required })
 
     return (
         <span className={className}>

--- a/src/Checkbox/Label.js
+++ b/src/Checkbox/Label.js
@@ -5,7 +5,7 @@ import cx from 'classnames'
 import { colors, theme, spacers } from '../theme.js'
 
 export const Label = ({ disabled, required, children }) => {
-    const className = cx('label', { disabled, required })
+    const className = cx('label', { disabled, required, disabled })
 
     return (
         <span className={className}>

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -84,7 +84,9 @@ class Checkbox extends Component {
 
                     {icon}
 
-                    <Label required={required}>{label}</Label>
+                    <Label required={required} disabled={disabled}>
+                        {label}
+                    </Label>
 
                     <style jsx>{`
                         label {

--- a/src/Radio/index.js
+++ b/src/Radio/index.js
@@ -25,6 +25,7 @@ const icons = css.resolve`
     }
 
     .disabled {
+        color: ${theme.disabled};
         fill: ${theme.disabled};
     }
 
@@ -159,7 +160,7 @@ class Radio extends Component {
 
                 {icon}
 
-                <span className={cx({ required })}>{label}</span>
+                <span className={cx({ required, disabled })}>{label}</span>
 
                 {icons.styles}
                 <style jsx>{styles}</style>

--- a/src/theme.js
+++ b/src/theme.js
@@ -109,7 +109,7 @@ export const theme = {
     error: colors.red500,
     valid: colors.blue600,
     warning: colors.yellow500,
-    disabled: colors.grey500,
+    disabled: colors.grey600,
 }
 
 export const layers = {


### PR DESCRIPTION
Fixes dhis2/design-system#6

This PR will change the theme's `disabled` color from `grey500` to `grey600`,
which will impact all components that are using `colors.disabled` of the theme.