### PR TITLE
fix(help): spacing

### DIFF
--- a/src/Help/index.js
+++ b/src/Help/index.js
@@ -5,12 +5,13 @@ import React from 'react'
 import { statusPropType } from '../common-prop-types'
 import { spacers, theme } from '../theme.js'
 
-const Help = ({ children, valid, error, warning, className }) => (
+const Help = ({ children, valid, error, warning, className, indent }) => (
     <p
         className={cx(className, {
             valid,
             error,
             warning,
+            indent,
         })}
     >
         {children}
@@ -18,13 +19,15 @@ const Help = ({ children, valid, error, warning, className }) => (
         <style jsx>{`
             p {
                 height: 12px;
-                padding-top: ${spacers.dp8};
-                padding-left: ${spacers.dp16};
                 font-size: 12px;
-                margin: 0;
+                margin: ${spacers.dp8} 0 0 0;
                 line-height: 12px;
                 cursor: help;
                 color: ${theme.default};
+            }
+
+            .indent {
+                margin-left: ${spacers.dp16};
             }
 
             .valid {
@@ -42,14 +45,17 @@ const Help = ({ children, valid, error, warning, className }) => (
     </p>
 )
 
-Help.defaultProps = {}
-
 Help.propTypes = {
     className: propTypes.string,
     children: propTypes.string.isRequired,
     error: statusPropType,
     valid: statusPropType,
     warning: statusPropType,
+    indent: propTypes.bool,
+}
+
+Help.defaultProps = {
+    indent: true,
 }
 
 export { Help }

--- a/src/Help/index.js
+++ b/src/Help/index.js
@@ -18,16 +18,19 @@ const Help = ({ children, valid, error, warning, className, indent }) => (
 
         <style jsx>{`
             p {
-                height: 12px;
                 font-size: 12px;
-                margin: ${spacers.dp8} 0 0 0;
                 line-height: 12px;
-                cursor: help;
+                margin: 0;
                 color: ${theme.default};
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                cursor: help;
+                padding-top: ${spacers.dp8};
             }
 
             .indent {
-                margin-left: ${spacers.dp16};
+                padding-left: ${spacers.dp16};
             }
 
             .valid {

--- a/stories/Help.stories.js
+++ b/stories/Help.stories.js
@@ -18,3 +18,8 @@ storiesOf('Help', module)
             <Help indent={false}>My identation has been set to false</Help>
         </>
     ))
+    .add('Text overflow', () => (
+        <div style={{ width: 200 }}>
+            <Help>I take up more space than my container</Help>
+        </div>
+    ))

--- a/stories/Help.stories.js
+++ b/stories/Help.stories.js
@@ -10,3 +10,11 @@ storiesOf('Help', module)
     ))
     .add('Status: Valid', () => <Help valid>Allow me to be of assistance</Help>)
     .add('Status: Error', () => <Help error>Allow me to be of assistance</Help>)
+    .add('Indentation', () => (
+        <>
+            <Help>
+                I have an indentation (indent set to true by defaultProps)
+            </Help>
+            <Help indent={false}>My identation has been set to false</Help>
+        </>
+    ))


### PR DESCRIPTION
- use margin instead of padding so the correct space is reserved by a parent with `box-sizing: border-box`
- add `indent` property to toggle `margin-left` from `0` (false) to `dp16` (true | default)