### PR TITLE
refactor: remove compact from button strip

### DIFF
--- a/src/ButtonStrip/index.js
+++ b/src/ButtonStrip/index.js
@@ -5,8 +5,8 @@ import { instanceOfComponent, mutuallyExclusive } from '@dhis2/prop-types'
 import { Button } from '../Button'
 import styles from './styles'
 
-const ButtonStrip = ({ className, children, compact, start, middle, end }) => (
-    <div className={cx(className, { compact, start, middle, end })}>
+const ButtonStrip = ({ className, children, start, middle, end }) => (
+    <div className={cx(className, { start, middle, end })}>
         {children}
 
         <style jsx>{styles}</style>
@@ -21,7 +21,6 @@ const alignmentPropType = mutuallyExclusive(
 ButtonStrip.propTypes = {
     className: propTypes.string,
     children: propTypes.arrayOf(instanceOfComponent(Button)),
-    compact: propTypes.bool,
     start: alignmentPropType,
     middle: alignmentPropType,
     end: alignmentPropType,

--- a/src/ButtonStrip/styles.js
+++ b/src/ButtonStrip/styles.js
@@ -15,21 +15,4 @@ export default css`
     div > :global(button) {
         margin-left: ${spacers.dp16};
     }
-    div.compact > :global(button),
-    div > :global(button:first-child) {
-        margin-left: 0;
-    }
-    div.compact > :global(button:not(:first-child):not(:last-child)) {
-        border-radius: 0;
-        border-right: 0;
-    }
-    div.compact > :global(button:first-child) {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-        border-right: 0;
-    }
-    div.compact > :global(button:last-child) {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-    }
 `

--- a/src/SplitButton/index.js
+++ b/src/SplitButton/index.js
@@ -4,7 +4,6 @@ import React, { Component } from 'react'
 import css from 'styled-jsx/css'
 
 import { Button } from '../Button'
-import { ButtonStrip } from '../ButtonStrip'
 import { buttonVariantPropType } from '../common-prop-types'
 import { DropMenu } from '../DropMenu'
 import { ArrowDown, ArrowUp } from '../icons/Arrow.js'
@@ -31,25 +30,17 @@ class SplitButton extends Component {
 
         return (
             <div ref={this.anchorRef}>
-                <ButtonStrip compact>
-                    <Button
-                        {...this.props}
-                        className={cx(this.props.className)}
-                    >
-                        {this.props.children}
-                    </Button>
+                <Button {...this.props} className={cx(this.props.className)}>
+                    {this.props.children}
+                </Button>
 
-                    <Button
-                        {...this.props}
-                        onClick={this.onToggle}
-                        className={cx(
-                            this.props.className,
-                            rightButton.className
-                        )}
-                    >
-                        {icon}
-                    </Button>
-                </ButtonStrip>
+                <Button
+                    {...this.props}
+                    onClick={this.onToggle}
+                    className={cx(this.props.className, rightButton.className)}
+                >
+                    {icon}
+                </Button>
 
                 {open && (
                     <DropMenu
@@ -67,6 +58,26 @@ class SplitButton extends Component {
                         color: inherit;
                         white-space: nowrap;
                     }
+
+                    div > :global(button:first-child) {
+                        margin-left: 0;
+                    }
+
+                    div > :global(button:not(:first-child):not(:last-child)) {
+                        border-radius: 0;
+                        border-right: 0;
+                    }
+
+                    div > :global(button:first-child) {
+                        border-top-right-radius: 0;
+                        border-bottom-right-radius: 0;
+                        border-right: 0;
+                    }
+
+                    div > :global(button:last-child) {
+                        border-top-left-radius: 0;
+                        border-bottom-left-radius: 0;
+                    }
                 `}</style>
             </div>
         )
@@ -74,6 +85,7 @@ class SplitButton extends Component {
 }
 
 SplitButton.propTypes = {
+    children: propTypes.string,
     component: propTypes.element.isRequired,
 
     onClick: propTypes.func,

--- a/stories/ButtonStrip.stories.js
+++ b/stories/ButtonStrip.stories.js
@@ -31,14 +31,6 @@ storiesOf('ButtonStrip', module)
             <Button>Save</Button>
         </ButtonStrip>
     ))
-    .add('Compact', () => (
-        <ButtonStrip compact>
-            <Button>Save</Button>
-            <Button>Save</Button>
-            <Button>Save</Button>
-            <Button>Save</Button>
-        </ButtonStrip>
-    ))
     .add('Default - aligned middle', () => (
         <ButtonStrip middle>
             <Button>Save</Button>
@@ -47,24 +39,8 @@ storiesOf('ButtonStrip', module)
             <Button>Save</Button>
         </ButtonStrip>
     ))
-    .add('Compact - aligned middle', () => (
-        <ButtonStrip middle compact>
-            <Button>Save</Button>
-            <Button>Save</Button>
-            <Button>Save</Button>
-            <Button>Save</Button>
-        </ButtonStrip>
-    ))
     .add('Default - aligned right', () => (
         <ButtonStrip end>
-            <Button>Save</Button>
-            <Button>Save</Button>
-            <Button>Save</Button>
-            <Button>Save</Button>
-        </ButtonStrip>
-    ))
-    .add('Compact - aligned right', () => (
-        <ButtonStrip end compact>
             <Button>Save</Button>
             <Button>Save</Button>
             <Button>Save</Button>


### PR DESCRIPTION
BREAKING CHANGE: Removes the `compact` prop and styles from the ButtonStrip.