### PR TITLE
feat: add dense prop to static table

### DIFF
--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -5,35 +5,28 @@ import css from 'styled-jsx/css'
 const tableCellStyles = css`
     td {
         border-bottom: 1px solid #e8edf2;
-        padding-left: 12px;
-        padding-right: 12px;
-        height: 45px;
         font-size: 14px;
         line-height: 18px;
     }
-
-    :global(tbody) td {
-        padding-top: 13px;
-        padding-bottom: 13px;
-    }
-
-    :global(tfoot) td {
-        height: 36px;
-        padding-top: 9px;
-        padding-bottom: 9px;
-    }
 `
 
-export const TableCell = ({ children, colSpan, rowSpan }) => (
+export const TableCell = ({ children, colSpan, rowSpan, dense }) => (
     <td colSpan={colSpan} rowSpan={rowSpan}>
         {children}
 
         <style jsx>{tableCellStyles}</style>
+        <style jsx>{`
+            td {
+                padding: ${dense ? '9px 12px' : '13px 12px'};
+                height: ${dense ? '36px' : '45px'};
+            }
+        `}</style>
     </td>
 )
 
 TableCell.propTypes = {
     colSpan: propTypes.string,
+    dense: propTypes.bool,
     rowSpan: propTypes.string,
     children: propTypes.node,
 }

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -5,28 +5,28 @@ import css from 'styled-jsx/css'
 const tableCellStyles = css`
     td {
         border-bottom: 1px solid #e8edf2;
-        padding: 0 12px;
-    }
-
-    div {
-        min-height: 45px;
+        padding-left: 12px;
+        padding-right: 12px;
+        height: 45px;
         font-size: 14px;
         line-height: 18px;
     }
 
-    :global(tbody) div {
-        padding: 13px 0;
+    :global(tbody) td {
+        padding-top: 13px;
+        padding-bottom: 13px;
     }
 
-    :global(tfooter) div {
-        min-height: 36px;
-        padding: 9px 0;
+    :global(tfoot) td {
+        height: 36px;
+        padding-top: 9px;
+        padding-bottom: 9px;
     }
 `
 
 export const TableCell = ({ children, colSpan, rowSpan }) => (
     <td colSpan={colSpan} rowSpan={rowSpan}>
-        <div>{children}</div>
+        {children}
 
         <style jsx>{tableCellStyles}</style>
     </td>

--- a/src/Table/TableCellHead.js
+++ b/src/Table/TableCellHead.js
@@ -5,23 +5,29 @@ import css from 'styled-jsx/css'
 const tableCellHeadStyles = css`
     th {
         border-bottom: 1px solid #e8edf2;
-        padding: 9px 12px;
         font-size: 14px;
         line-height: 18px;
-        height: 36px;
     }
 `
 
-export const TableCellHead = ({ children, colSpan, rowSpan, label }) => (
+export const TableCellHead = ({ children, colSpan, rowSpan, dense }) => (
     <th colSpan={colSpan} rowSpan={rowSpan}>
         {children}
 
         <style jsx>{tableCellHeadStyles}</style>
+        <style jsx>{`
+            th {
+                padding: ${dense ? '9px 12px' : '13px 12px'};
+                height: ${dense ? '36px' : '45px'};
+            }
+        `}</style>
     </th>
 )
 
 TableCellHead.propTypes = {
     colSpan: propTypes.string,
+    dense: propTypes.bool,
     rowSpan: propTypes.string,
     label: propTypes.string,
+    children: propTypes.node,
 }

--- a/src/Table/TableCellHead.js
+++ b/src/Table/TableCellHead.js
@@ -5,20 +5,16 @@ import css from 'styled-jsx/css'
 const tableCellHeadStyles = css`
     th {
         border-bottom: 1px solid #e8edf2;
-        padding: 0 12px;
-    }
-
-    div {
-        padding: 9px 0;
+        padding: 9px 12px;
         font-size: 14px;
         line-height: 18px;
-        min-height: 36px;
+        height: 36px;
     }
 `
 
 export const TableCellHead = ({ children, colSpan, rowSpan, label }) => (
     <th colSpan={colSpan} rowSpan={rowSpan}>
-        <div>{children}</div>
+        {children}
 
         <style jsx>{tableCellHeadStyles}</style>
     </th>

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -19,7 +19,7 @@ export const TableRow = ({ children, dense }) => (
         <style jsx>{tableRowStyles}</style>
         <style jsx>{`
             tr {
-                min-height: ${dense ? '36px' : '45px'};
+                height: ${dense ? '36px' : '45px'};
             }
         `}</style>
     </tr>

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -7,24 +7,21 @@ import { TableCell } from './TableCell.js'
 import { TableCellHead } from './TableCellHead.js'
 
 const tableRowStyles = css`
-    tr {
-        min-height: 45px;
-    }
-
     tr:nth-child(even) {
         background: #fbfcfd;
     }
-
-    :global(thead) tr,
-    :global(tbody) tr {
-        min-height: 36px;
-    }
 `
 
-export const TableRow = ({ children }) => (
+export const TableRow = ({ children, dense }) => (
     <tr>
         {children}
+
         <style jsx>{tableRowStyles}</style>
+        <style jsx>{`
+            tr {
+                min-height: ${dense ? '36px' : '45px'};
+            }
+        `}</style>
     </tr>
 )
 
@@ -34,6 +31,7 @@ const childPropType = propTypes.oneOfType([
 ])
 
 TableRow.propTypes = {
+    dense: propTypes.bool,
     children: propTypes.oneOfType([
         childPropType,
         propTypes.arrayOf(childPropType),

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -12,16 +12,11 @@ const tableRowStyles = css`
     }
 `
 
-export const TableRow = ({ children, dense }) => (
+export const TableRow = ({ children }) => (
     <tr>
         {children}
 
         <style jsx>{tableRowStyles}</style>
-        <style jsx>{`
-            tr {
-                height: ${dense ? '36px' : '45px'};
-            }
-        `}</style>
     </tr>
 )
 
@@ -31,7 +26,6 @@ const childPropType = propTypes.oneOfType([
 ])
 
 TableRow.propTypes = {
-    dense: propTypes.bool,
     children: propTypes.oneOfType([
         childPropType,
         propTypes.arrayOf(childPropType),

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -39,14 +39,14 @@ storiesOf('Table', module).add('Static layout', () => (
     <Table>
         <TableHead>
             <TableRowHead>
-                <TableCellHead dense>First name</TableCellHead>
-                <TableCellHead dense>Last name</TableCellHead>
-                <TableCellHead dense>Incident date</TableCellHead>
-                <TableCellHead dense>Last updated</TableCellHead>
-                <TableCellHead dense>Age</TableCellHead>
-                <TableCellHead dense>Registering unit</TableCellHead>
-                <TableCellHead dense>Assigned user</TableCellHead>
-                <TableCellHead dense>Status</TableCellHead>
+                <TableCellHead>First name</TableCellHead>
+                <TableCellHead>Last name</TableCellHead>
+                <TableCellHead>Incident date</TableCellHead>
+                <TableCellHead>Last updated</TableCellHead>
+                <TableCellHead>Age</TableCellHead>
+                <TableCellHead>Registering unit</TableCellHead>
+                <TableCellHead>Assigned user</TableCellHead>
+                <TableCellHead>Status</TableCellHead>
             </TableRowHead>
         </TableHead>
         <TableBody>
@@ -149,6 +149,132 @@ storiesOf('Table', module).add('Static layout', () => (
                 <TableCell>Dalakuru CHP</TableCell>
                 <TableCell>Anatoliy Shcherbatykh</TableCell>
                 <TableCell>Incomplete</TableCell>
+            </TableRow>
+        </TableBody>
+        <TableFoot>
+            <TableRow>
+                <TableCell colSpan="8">
+                    <TableFooterButton />
+                </TableCell>
+            </TableRow>
+        </TableFoot>
+    </Table>
+))
+
+storiesOf('Table', module).add('Static layout dense', () => (
+    <Table>
+        <TableHead>
+            <TableRowHead>
+                <TableCellHead dense>First name</TableCellHead>
+                <TableCellHead dense>Last name</TableCellHead>
+                <TableCellHead dense>Incident date</TableCellHead>
+                <TableCellHead dense>Last updated</TableCellHead>
+                <TableCellHead dense>Age</TableCellHead>
+                <TableCellHead dense>Registering unit</TableCellHead>
+                <TableCellHead dense>Assigned user</TableCellHead>
+                <TableCellHead dense>Status</TableCellHead>
+            </TableRowHead>
+        </TableHead>
+        <TableBody>
+            <TableRow>
+                <TableCell dense>Onyekachukwu</TableCell>
+                <TableCell dense>Kariuki</TableCell>
+                <TableCell dense>02/06/2007</TableCell>
+                <TableCell dense>05/25/1972</TableCell>
+                <TableCell dense>66</TableCell>
+                <TableCell dense>Jawi</TableCell>
+                <TableCell dense>Sofie Hubert</TableCell>
+                <TableCell dense>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell dense>Kwasi</TableCell>
+                <TableCell dense>Okafor</TableCell>
+                <TableCell dense>08/11/2010</TableCell>
+                <TableCell dense>02/26/1991</TableCell>
+                <TableCell dense>38</TableCell>
+                <TableCell dense>Mokassie MCHP</TableCell>
+                <TableCell dense>Dashonte Clarke</TableCell>
+                <TableCell dense>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell dense>Siyabonga</TableCell>
+                <TableCell dense>Abiodun</TableCell>
+                <TableCell dense>07/21/1981</TableCell>
+                <TableCell dense>02/06/2007</TableCell>
+                <TableCell dense>98</TableCell>
+                <TableCell dense>Bathurst MCHP</TableCell>
+                <TableCell dense>Unassigned</TableCell>
+                <TableCell dense>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell dense>Chiyembekezo</TableCell>
+                <TableCell dense>Okeke</TableCell>
+                <TableCell dense>01/23/1982</TableCell>
+                <TableCell dense>07/15/2003</TableCell>
+                <TableCell dense>2</TableCell>
+                <TableCell dense>Mayolla MCHP</TableCell>
+                <TableCell dense>Wan Gengxin</TableCell>
+                <TableCell dense>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell dense>Mtendere</TableCell>
+                <TableCell dense>Afolayan</TableCell>
+                <TableCell dense>08/12/1994</TableCell>
+                <TableCell dense>05/12/1972</TableCell>
+                <TableCell dense>37</TableCell>
+                <TableCell dense>Gbangadu MCHP</TableCell>
+                <TableCell dense>Gvozden Boskovsky</TableCell>
+                <TableCell dense>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell dense>Inyene</TableCell>
+                <TableCell dense>Okonkwo</TableCell>
+                <TableCell dense>04/01/1971</TableCell>
+                <TableCell dense>03/16/2000</TableCell>
+                <TableCell dense>70</TableCell>
+                <TableCell dense>Kunike Barina</TableCell>
+                <TableCell dense>Oscar de la Cavallería</TableCell>
+                <TableCell dense>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell dense>Amaka</TableCell>
+                <TableCell dense>Pretorius</TableCell>
+                <TableCell dense>01/25/1996</TableCell>
+                <TableCell dense>09/15/1986</TableCell>
+                <TableCell dense>32</TableCell>
+                <TableCell dense>Bargbo</TableCell>
+                <TableCell dense>Alberto Raya</TableCell>
+                <TableCell dense>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell dense>Meti</TableCell>
+                <TableCell dense>Abiodun</TableCell>
+                <TableCell dense>10/24/2010</TableCell>
+                <TableCell dense>07/26/1989</TableCell>
+                <TableCell dense>8</TableCell>
+                <TableCell dense>Majihun MCHP</TableCell>
+                <TableCell dense>Unassigned</TableCell>
+                <TableCell dense>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell dense>Eshe</TableCell>
+                <TableCell dense>Okeke</TableCell>
+                <TableCell dense>01/31/1995</TableCell>
+                <TableCell dense>01/31/1995</TableCell>
+                <TableCell dense>63</TableCell>
+                <TableCell dense>Mambiama CHP</TableCell>
+                <TableCell dense>Shadrias Pearson</TableCell>
+                <TableCell dense>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell dense>Obi</TableCell>
+                <TableCell dense>Okafor</TableCell>
+                <TableCell dense>06/07/1990</TableCell>
+                <TableCell dense>01/03/2006</TableCell>
+                <TableCell dense>28</TableCell>
+                <TableCell dense>Dalakuru CHP</TableCell>
+                <TableCell dense>Anatoliy Shcherbatykh</TableCell>
+                <TableCell dense>Incomplete</TableCell>
             </TableRow>
         </TableBody>
         <TableFoot>

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -39,14 +39,14 @@ storiesOf('Table', module).add('Static layout', () => (
     <Table>
         <TableHead>
             <TableRowHead>
-                <TableCellHead>First name</TableCellHead>
-                <TableCellHead>Last name</TableCellHead>
-                <TableCellHead>Incident date</TableCellHead>
-                <TableCellHead>Last updated</TableCellHead>
-                <TableCellHead>Age</TableCellHead>
-                <TableCellHead>Registering unit</TableCellHead>
-                <TableCellHead>Assigned user</TableCellHead>
-                <TableCellHead>Status</TableCellHead>
+                <TableCellHead dense>First name</TableCellHead>
+                <TableCellHead dense>Last name</TableCellHead>
+                <TableCellHead dense>Incident date</TableCellHead>
+                <TableCellHead dense>Last updated</TableCellHead>
+                <TableCellHead dense>Age</TableCellHead>
+                <TableCellHead dense>Registering unit</TableCellHead>
+                <TableCellHead dense>Assigned user</TableCellHead>
+                <TableCellHead dense>Status</TableCellHead>
             </TableRowHead>
         </TableHead>
         <TableBody>
@@ -153,7 +153,7 @@ storiesOf('Table', module).add('Static layout', () => (
         </TableBody>
         <TableFoot>
             <TableRow>
-                <TableCell colSpan="8">
+                <TableCell dense colSpan="8">
                     <TableFooterButton />
                 </TableCell>
             </TableRow>

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -27,6 +27,8 @@ const TableFooterButton = () => (
     </div>
 )
 
+const TableButton = () => <Button primary>Table button</Button>
+
 const Actions = () => (
     <div>
         <a className="icon" href="#">
@@ -161,128 +163,151 @@ storiesOf('Table', module).add('Static layout', () => (
     </Table>
 ))
 
-storiesOf('Table', module).add('Static layout dense', () => (
-    <Table>
-        <TableHead>
-            <TableRowHead>
-                <TableCellHead dense>First name</TableCellHead>
-                <TableCellHead dense>Last name</TableCellHead>
-                <TableCellHead dense>Incident date</TableCellHead>
-                <TableCellHead dense>Last updated</TableCellHead>
-                <TableCellHead dense>Age</TableCellHead>
-                <TableCellHead dense>Registering unit</TableCellHead>
-                <TableCellHead dense>Assigned user</TableCellHead>
-                <TableCellHead dense>Status</TableCellHead>
-            </TableRowHead>
-        </TableHead>
-        <TableBody>
-            <TableRow>
-                <TableCell dense>Onyekachukwu</TableCell>
-                <TableCell dense>Kariuki</TableCell>
-                <TableCell dense>02/06/2007</TableCell>
-                <TableCell dense>05/25/1972</TableCell>
-                <TableCell dense>66</TableCell>
-                <TableCell dense>Jawi</TableCell>
-                <TableCell dense>Sofie Hubert</TableCell>
-                <TableCell dense>Incomplete</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell dense>Kwasi</TableCell>
-                <TableCell dense>Okafor</TableCell>
-                <TableCell dense>08/11/2010</TableCell>
-                <TableCell dense>02/26/1991</TableCell>
-                <TableCell dense>38</TableCell>
-                <TableCell dense>Mokassie MCHP</TableCell>
-                <TableCell dense>Dashonte Clarke</TableCell>
-                <TableCell dense>Complete</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell dense>Siyabonga</TableCell>
-                <TableCell dense>Abiodun</TableCell>
-                <TableCell dense>07/21/1981</TableCell>
-                <TableCell dense>02/06/2007</TableCell>
-                <TableCell dense>98</TableCell>
-                <TableCell dense>Bathurst MCHP</TableCell>
-                <TableCell dense>Unassigned</TableCell>
-                <TableCell dense>Incomplete</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell dense>Chiyembekezo</TableCell>
-                <TableCell dense>Okeke</TableCell>
-                <TableCell dense>01/23/1982</TableCell>
-                <TableCell dense>07/15/2003</TableCell>
-                <TableCell dense>2</TableCell>
-                <TableCell dense>Mayolla MCHP</TableCell>
-                <TableCell dense>Wan Gengxin</TableCell>
-                <TableCell dense>Incomplete</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell dense>Mtendere</TableCell>
-                <TableCell dense>Afolayan</TableCell>
-                <TableCell dense>08/12/1994</TableCell>
-                <TableCell dense>05/12/1972</TableCell>
-                <TableCell dense>37</TableCell>
-                <TableCell dense>Gbangadu MCHP</TableCell>
-                <TableCell dense>Gvozden Boskovsky</TableCell>
-                <TableCell dense>Complete</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell dense>Inyene</TableCell>
-                <TableCell dense>Okonkwo</TableCell>
-                <TableCell dense>04/01/1971</TableCell>
-                <TableCell dense>03/16/2000</TableCell>
-                <TableCell dense>70</TableCell>
-                <TableCell dense>Kunike Barina</TableCell>
-                <TableCell dense>Oscar de la Cavallería</TableCell>
-                <TableCell dense>Complete</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell dense>Amaka</TableCell>
-                <TableCell dense>Pretorius</TableCell>
-                <TableCell dense>01/25/1996</TableCell>
-                <TableCell dense>09/15/1986</TableCell>
-                <TableCell dense>32</TableCell>
-                <TableCell dense>Bargbo</TableCell>
-                <TableCell dense>Alberto Raya</TableCell>
-                <TableCell dense>Incomplete</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell dense>Meti</TableCell>
-                <TableCell dense>Abiodun</TableCell>
-                <TableCell dense>10/24/2010</TableCell>
-                <TableCell dense>07/26/1989</TableCell>
-                <TableCell dense>8</TableCell>
-                <TableCell dense>Majihun MCHP</TableCell>
-                <TableCell dense>Unassigned</TableCell>
-                <TableCell dense>Complete</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell dense>Eshe</TableCell>
-                <TableCell dense>Okeke</TableCell>
-                <TableCell dense>01/31/1995</TableCell>
-                <TableCell dense>01/31/1995</TableCell>
-                <TableCell dense>63</TableCell>
-                <TableCell dense>Mambiama CHP</TableCell>
-                <TableCell dense>Shadrias Pearson</TableCell>
-                <TableCell dense>Incomplete</TableCell>
-            </TableRow>
-            <TableRow>
-                <TableCell dense>Obi</TableCell>
-                <TableCell dense>Okafor</TableCell>
-                <TableCell dense>06/07/1990</TableCell>
-                <TableCell dense>01/03/2006</TableCell>
-                <TableCell dense>28</TableCell>
-                <TableCell dense>Dalakuru CHP</TableCell>
-                <TableCell dense>Anatoliy Shcherbatykh</TableCell>
-                <TableCell dense>Incomplete</TableCell>
-            </TableRow>
-        </TableBody>
-        <TableFoot>
-            <TableRow>
-                <TableCell dense colSpan="8">
-                    <TableFooterButton />
-                </TableCell>
-            </TableRow>
-        </TableFoot>
-    </Table>
-))
+storiesOf('Table', module).add(
+    'Static layout with buttons in dense cells',
+    () => (
+        <Table>
+            <TableHead>
+                <TableRowHead>
+                    <TableCellHead>First name</TableCellHead>
+                    <TableCellHead>Last name</TableCellHead>
+                    <TableCellHead>Incident date</TableCellHead>
+                    <TableCellHead>Last updated</TableCellHead>
+                    <TableCellHead>Age</TableCellHead>
+                    <TableCellHead>Registering unit</TableCellHead>
+                    <TableCellHead>Assigned user</TableCellHead>
+                    <TableCellHead>Button</TableCellHead>
+                </TableRowHead>
+            </TableHead>
+            <TableBody>
+                <TableRow>
+                    <TableCell>Onyekachukwu</TableCell>
+                    <TableCell>Kariuki</TableCell>
+                    <TableCell>02/06/2007</TableCell>
+                    <TableCell>05/25/1972</TableCell>
+                    <TableCell>66</TableCell>
+                    <TableCell>Jawi</TableCell>
+                    <TableCell>Sofie Hubert</TableCell>
+                    <TableCell dense>
+                        <TableButton />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Kwasi</TableCell>
+                    <TableCell>Okafor</TableCell>
+                    <TableCell>08/11/2010</TableCell>
+                    <TableCell>02/26/1991</TableCell>
+                    <TableCell>38</TableCell>
+                    <TableCell>Mokassie MCHP</TableCell>
+                    <TableCell>Dashonte Clarke</TableCell>
+                    <TableCell dense>
+                        <TableButton />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Siyabonga</TableCell>
+                    <TableCell>Abiodun</TableCell>
+                    <TableCell>07/21/1981</TableCell>
+                    <TableCell>02/06/2007</TableCell>
+                    <TableCell>98</TableCell>
+                    <TableCell>Bathurst MCHP</TableCell>
+                    <TableCell>Unassigned</TableCell>
+                    <TableCell dense>
+                        <TableButton />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Chiyembekezo</TableCell>
+                    <TableCell>Okeke</TableCell>
+                    <TableCell>01/23/1982</TableCell>
+                    <TableCell>07/15/2003</TableCell>
+                    <TableCell>2</TableCell>
+                    <TableCell>Mayolla MCHP</TableCell>
+                    <TableCell>Wan Gengxin</TableCell>
+                    <TableCell dense>
+                        <TableButton />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Mtendere</TableCell>
+                    <TableCell>Afolayan</TableCell>
+                    <TableCell>08/12/1994</TableCell>
+                    <TableCell>05/12/1972</TableCell>
+                    <TableCell>37</TableCell>
+                    <TableCell>Gbangadu MCHP</TableCell>
+                    <TableCell>Gvozden Boskovsky</TableCell>
+                    <TableCell dense>
+                        <TableButton />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Inyene</TableCell>
+                    <TableCell>Okonkwo</TableCell>
+                    <TableCell>04/01/1971</TableCell>
+                    <TableCell>03/16/2000</TableCell>
+                    <TableCell>70</TableCell>
+                    <TableCell>Kunike Barina</TableCell>
+                    <TableCell>Oscar de la Cavallería</TableCell>
+                    <TableCell dense>
+                        <TableButton />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Amaka</TableCell>
+                    <TableCell>Pretorius</TableCell>
+                    <TableCell>01/25/1996</TableCell>
+                    <TableCell>09/15/1986</TableCell>
+                    <TableCell>32</TableCell>
+                    <TableCell>Bargbo</TableCell>
+                    <TableCell>Alberto Raya</TableCell>
+                    <TableCell dense>
+                        <TableButton />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Meti</TableCell>
+                    <TableCell>Abiodun</TableCell>
+                    <TableCell>10/24/2010</TableCell>
+                    <TableCell>07/26/1989</TableCell>
+                    <TableCell>8</TableCell>
+                    <TableCell>Majihun MCHP</TableCell>
+                    <TableCell>Unassigned</TableCell>
+                    <TableCell dense>
+                        <TableButton />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Eshe</TableCell>
+                    <TableCell>Okeke</TableCell>
+                    <TableCell>01/31/1995</TableCell>
+                    <TableCell>01/31/1995</TableCell>
+                    <TableCell>63</TableCell>
+                    <TableCell>Mambiama CHP</TableCell>
+                    <TableCell>Shadrias Pearson</TableCell>
+                    <TableCell dense>
+                        <TableButton />
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell>Obi</TableCell>
+                    <TableCell>Okafor</TableCell>
+                    <TableCell>06/07/1990</TableCell>
+                    <TableCell>01/03/2006</TableCell>
+                    <TableCell>28</TableCell>
+                    <TableCell>Dalakuru CHP</TableCell>
+                    <TableCell>Anatoliy Shcherbatykh</TableCell>
+                    <TableCell dense>
+                        <TableButton />
+                    </TableCell>
+                </TableRow>
+            </TableBody>
+            <TableFoot>
+                <TableRow>
+                    <TableCell colSpan="8">
+                        <TableFooterButton />
+                    </TableCell>
+                </TableRow>
+            </TableFoot>
+        </Table>
+    )
+)


### PR DESCRIPTION
Main goal with this PR is to add the `dense` prop to the cells and rows of the static table (or show what I meant with it at least).

Another small change is that instead of using a `div` to set a `min-height` on the table-cell, this sets a `height` on the table-cell. Which effectively does the same as the cell can still grow larger in height, and it doesn't require an extra element. This way we don't need the global styles.

I've also removed the `min-height` settings from the table row, as they were overriding the table cell heights (when set to `height`). We could put it back in the same manner as the cells (with a `height` instead of `min-height`, and a `dense` prop), but that does mean that setting `dense` on the row will override the cells, which might be confusing.

Btw. I marked my commits as chores since it's a pr for a pr. I'm not sure what the convention is here so let me know if I've done it wrong.