### PR TITLE
fix: checkbox value should be optional

### DIFF
--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -119,7 +119,7 @@ class Checkbox extends Component {
 Checkbox.propTypes = {
     onChange: propTypes.func.isRequired,
 
-    value: propTypes.string.isRequired,
+    value: propTypes.string,
     name: propTypes.string.isRequired,
     label: propTypes.string.isRequired,
     tabIndex: propTypes.string,

--- a/src/Checkbox/Input.js
+++ b/src/Checkbox/Input.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment, createRef } from 'react'
+import React, { Component, createRef } from 'react'
 import propTypes from 'prop-types'
 
 export class Input extends Component {
@@ -52,6 +52,7 @@ export class Input extends Component {
 Input.propTypes = {
     onChange: propTypes.func.isRequired,
     name: propTypes.string.isRequired,
+    value: propTypes.string,
 
     tabIndex: propTypes.string,
 

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -43,35 +43,20 @@ const icons = css.resolve`
     }
 `
 
-const Input = React.forwardRef(
-    (
-        { name, value, checked, disabled, tabIndex, onChange, onFocus, onBlur },
-        ref
-    ) => (
-        <div>
-            <input
-                type="radio"
-                ref={ref}
-                name={name}
-                value={value}
-                checked={checked}
-                disabled={disabled}
-                tabIndex={tabIndex}
-                onChange={onChange}
-                onFocus={onFocus}
-                onBlur={onBlur}
-            />
+const Input = React.forwardRef((props, ref) => (
+    <div>
+        <input type="radio" ref={ref} {...props} />
 
-            <style jsx>{`
-                div {
-                    height: 0;
-                    width: 0;
-                    overflow: hidden;
-                }
-            `}</style>
-        </div>
-    )
-)
+        <style jsx>{`
+            div {
+                height: 0;
+                width: 0;
+                overflow: hidden;
+            }
+        `}</style>
+    </div>
+))
+Input.displayName = 'Input'
 
 class Radio extends Component {
     ref = createRef()
@@ -174,7 +159,7 @@ Radio.propTypes = {
     onChange: propTypes.func.isRequired,
 
     name: propTypes.string.isRequired,
-    value: propTypes.string.isRequired,
+    value: propTypes.string,
     className: propTypes.string,
     label: propTypes.string,
     tabIndex: propTypes.string,


### PR DESCRIPTION
I believe that the `value` attribute on a checkbox element is not mandatory, so the corresponding prop on our component shouldn't be either.

Source:
> If the value attribute was omitted, the default value for the checkbox is on , so the submitted data in that case would be subscribe=on.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Value