### PR TITLE
ci: lint source on ci as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
 - lts/*
 script:
+- npx d2-style js check --all
 - yarn build
 deploy:
 - provider: script

--- a/src/Button.js
+++ b/src/Button.js
@@ -97,7 +97,7 @@ Button.defaultProps = {
  * state
  */
 Button.propTypes = {
-    children: propTypes.string,
+    children: propTypes.node,
     onClick: propTypes.func,
 
     className: propTypes.string,

--- a/src/Button.js
+++ b/src/Button.js
@@ -76,8 +76,7 @@ Button.defaultProps = {
  * @typedef {Object} PropTypes
  * @static
  *
- * @prop {string} [children] The string to show as the label text for a
- * button
+ * @prop {Node} [children] The children to render in the button
  * @prop {function} [onClick] The click handler
  *
  * @prop {boolean} [small] - `small` and `large` are mutually exclusive

--- a/src/Checkbox/Label.js
+++ b/src/Checkbox/Label.js
@@ -33,7 +33,7 @@ export const Label = ({ disabled, required, children }) => {
 }
 
 Label.propTypes = {
-    children: propTypes.string,
+    children: propTypes.oneOfType([propTypes.string, propTypes.number]),
     disabled: propTypes.bool,
     required: propTypes.bool,
 }

--- a/src/Checkbox/Label.js
+++ b/src/Checkbox/Label.js
@@ -33,6 +33,7 @@ export const Label = ({ disabled, required, children }) => {
 }
 
 Label.propTypes = {
+    children: propTypes.string,
     disabled: propTypes.bool,
     required: propTypes.bool,
 }

--- a/src/Chip/Content.js
+++ b/src/Chip/Content.js
@@ -25,5 +25,6 @@ export const Content = ({ children, overflow }) => (
 )
 
 Content.propTypes = {
+    children: propTypes.oneOfType([propTypes.string, propTypes.number]),
     overflow: propTypes.bool,
 }

--- a/src/InputField.js
+++ b/src/InputField.js
@@ -23,6 +23,8 @@ class InputField extends React.Component {
         const {
             className,
             onChange,
+            onFocus,
+            onBlur,
             type,
             dense,
             required,
@@ -54,8 +56,8 @@ class InputField extends React.Component {
 
                 <Input
                     focus={focus}
-                    onFocus={this.onFocus}
-                    onBlur={this.onBlur}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
                     onChange={onChange}
                     name={name}
                     type={type}

--- a/src/MenuList.js
+++ b/src/MenuList.js
@@ -33,7 +33,7 @@ const MenuList = ({ children, className }) => (
  * @typedef {Object} PropTypes
  * @static
  *
- * @prop {Element} children
+ * @prop {Node} children
  * @prop {string} [className]
  */
 MenuList.propTypes = {

--- a/src/MenuList.js
+++ b/src/MenuList.js
@@ -38,7 +38,7 @@ const MenuList = ({ children, className }) => (
  */
 MenuList.propTypes = {
     className: propTypes.string,
-    children: propTypes.element.isRequired,
+    children: propTypes.node.isRequired,
 }
 
 export { MenuList }

--- a/src/Node.js
+++ b/src/Node.js
@@ -81,12 +81,25 @@ const Arrow = ({ hasLeaves, open, onOpen, onClose }) => {
     )
 }
 
+Arrow.propTypes = {
+    hasLeaves: propTypes.bool,
+    open: propTypes.bool,
+    onOpen: propTypes.func,
+    onClose: propTypes.func,
+}
+
 const Content = ({ open, children, label }) => (
     <div>
         {label}
         <Contents open={open}>{children}</Contents>
     </div>
 )
+
+Content.propTypes = {
+    open: propTypes.bool,
+    children: propTypes.node,
+    label: propTypes.node,
+}
 
 /**
  * @module
@@ -125,6 +138,14 @@ export const Node = ({ open, component, children, onOpen, onClose }) => {
             `}</style>
         </div>
     )
+}
+
+Node.propTypes = {
+    open: propTypes.bool,
+    component: propTypes.element,
+    children: propTypes.node,
+    onOpen: propTypes.func,
+    onClose: propTypes.func,
 }
 
 /**

--- a/src/Node.js
+++ b/src/Node.js
@@ -140,23 +140,17 @@ export const Node = ({ open, component, children, onOpen, onClose }) => {
     )
 }
 
-Node.propTypes = {
-    open: propTypes.bool,
-    component: propTypes.element,
-    children: propTypes.node,
-    onOpen: propTypes.func,
-    onClose: propTypes.func,
-}
-
 /**
  * @typedef {Object} PropTypes
  * @static
+ * @prop {Node} [children]
  * @prop {Element} component
  * @prop {boolean} [open]
  * @prop {function} [onOpen]
  * @prop {funtion} [onClose]
  */
 Node.propTypes = {
+    children: propTypes.node,
     component: propTypes.element.isRequired,
     open: propTypes.bool,
     onOpen: propTypes.func,

--- a/src/icons/Upload.js
+++ b/src/icons/Upload.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import propTypes from 'prop-types'
 
 export function Upload({ className }) {
     return (
@@ -16,4 +17,8 @@ export function Upload({ className }) {
             `}</style>
         </svg>
     )
+}
+
+Upload.propTypes = {
+    className: propTypes.string,
 }

--- a/stories/CssReset.stories.js
+++ b/stories/CssReset.stories.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { CssReset } from '../src'
 
+// eslint-disable-next-line react/prop-types
 const App = ({ children }) => <div>{children}</div>
 
 storiesOf('CssReset', module).add('Default', () => (

--- a/stories/CssVariables.stories.js
+++ b/stories/CssVariables.stories.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import propTypes from 'prop-types'
 import { storiesOf } from '@storybook/react'
 import { CssVariables } from '../src'
 
+// eslint-disable-next-line react/prop-types
 const App = ({ children }) => <div>{children}</div>
 
 storiesOf('CssVariables', module).add('Default', () => (
@@ -30,7 +30,3 @@ storiesOf('CssVariables', module).add('All', () => (
         </p>
     </App>
 ))
-
-App.propTypes = {
-    children: propTypes.any.isRequired,
-}

--- a/stories/Logo.stories.js
+++ b/stories/Logo.stories.js
@@ -4,6 +4,7 @@ import { Logo, LogoWhite, LogoIcon, LogoIconWhite } from '../src'
 
 const Wrapper = fn => <div style={{ width: '358px' }}>{fn()}</div>
 
+// eslint-disable-next-line react/prop-types
 const Background = ({ children }) => (
     <div style={{ backgroundColor: '#276696' }}>{children}</div>
 )

--- a/stories/Node.stories.js
+++ b/stories/Node.stories.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Chevron } from '../src/icons/Chevron'
 import { Checkbox } from '../src/Checkbox'
 import { Node } from '../src/Node'
 

--- a/stories/Switch.stories.js
+++ b/stories/Switch.stories.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Switch, Help } from '../src'
 


### PR DESCRIPTION
One thing I noticed whilst going through the propType warnings that I didn't address yet:

It seems Input and Select have a `focus` prop, but the components are reporting receiving a function instead of a bool. In the Field story I'm not seeing a function being passed in for `focus` to the rendered Input component explicitly, so I'm not sure what's going on here exactly.

I looked at this with Hendrik, but we didn't have enough time to really figure out what was going wrong. It does seem like there's some funky stuff going on here. Input has an initialFocus prop as well for example (and uses it), and InputField defines one, but doesn't use it anywhere.

Wwe should enable react/no-unused-prop-types, to catch these kinds of things:

<img width="640" alt="Screenshot 2019-09-19 at 17 40 46" src="https://user-images.githubusercontent.com/7355199/65259267-b4babd80-db04-11e9-99d3-8cae5be92f5c.png">

Some false positives, but might be useful