### PR TITLE
build: fix docs build

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -6,7 +6,6 @@ import { FrameStylesWrapper } from './frame-styles-decorator'
 import 'typeface-roboto'
 
 addDecorator(jsxDecorator)
-addDecorator(withPropsTable)
 addDecorator(CssResetWrapper)
 addDecorator(FrameStylesWrapper)
 


### PR DESCRIPTION
As a follow up to yesterday's changes on 2b764abce54713b52043105a762b3d7e80d47efa, I assume it was also the intention to remove this line? This line still being there doesn't crash the build, but does crash the storybook app with `Uncaught ReferenceError: withPropsTable is not defined`