### PR TITLE
ci: add no unused props rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,4 +8,7 @@ module.exports = {
             version: '16.3',
         },
     },
+    rules: {
+        'react/no-unused-prop-types': 'error',
+    },
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - lts/*
 script:
-- npx d2-style js check --all
+- yarn run lint:js
 - yarn build
 deploy:
 - provider: script

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build:docs": "d2-utils-docsite build ./docs -o ./build/docs --jsdoc ./src --jsdoc-output-file api.md",
     "start:demo": "start-storybook --port 5000",
     "start:docs": "d2-utils-docsite serve ./docs -o ./build/docs --jsdoc ./src --jsdoc-output-file api.md",
-    "start": "yarn start:demo"
+    "start": "yarn start:demo",
+    "lint:js": "d2-style js check --all"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.0",

--- a/src/CssVariables.js
+++ b/src/CssVariables.js
@@ -61,13 +61,11 @@ CssVariables.defaultProps = {
  * @prop {boolean} [elevations]
  */
 CssVariables.propTypes = {
-    /* eslint-disable react/no-unused-prop-types */
     colors: propTypes.bool,
     theme: propTypes.bool,
     layers: propTypes.bool,
     spacers: propTypes.bool,
     elevations: propTypes.bool,
-    /* eslint-enable */
 }
 
 export { CssVariables }

--- a/src/CssVariables.js
+++ b/src/CssVariables.js
@@ -61,11 +61,13 @@ CssVariables.defaultProps = {
  * @prop {boolean} [elevations]
  */
 CssVariables.propTypes = {
+    /* eslint-disable react/no-unused-prop-types */
     colors: propTypes.bool,
     theme: propTypes.bool,
     layers: propTypes.bool,
     spacers: propTypes.bool,
     elevations: propTypes.bool,
+    /* eslint-enable */
 }
 
 export { CssVariables }

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -43,7 +43,6 @@ class FileInput extends PureComponent {
             large,
             disabled,
             tabIndex,
-            name,
         } = this.props
 
         return (

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -43,6 +43,7 @@ class FileInput extends PureComponent {
             large,
             disabled,
             tabIndex,
+            name,
         } = this.props
 
         return (
@@ -100,6 +101,7 @@ class FileInput extends PureComponent {
  * @typedef {Object} PropTypes
  * @static
  *
+ * @prop {string} name
  * @prop {function} onChange
  * @prop {string} [buttonLabel]
  * @prop {string} [className]

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -97,7 +97,6 @@ class FileInput extends PureComponent {
  * @typedef {Object} PropTypes
  * @static
  *
- * @prop {string} name
  * @prop {function} onChange
  * @prop {string} [buttonLabel]
  * @prop {string} [className]
@@ -117,10 +116,7 @@ class FileInput extends PureComponent {
  */
 FileInput.propTypes = {
     onChange: propTypes.func.isRequired,
-    name: propTypes.string.isRequired,
     buttonLabel: propTypes.string,
-    helpText: propTypes.string,
-    validationText: propTypes.string,
 
     className: propTypes.string,
     tabIndex: propTypes.string,

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -32,6 +32,7 @@ class FileInput extends PureComponent {
     render() {
         const {
             className,
+            name,
             buttonLabel,
             error,
             valid,
@@ -47,6 +48,8 @@ class FileInput extends PureComponent {
         return (
             <div className={cx('file-input', className)}>
                 <input
+                    id={name}
+                    name={name}
                     type="file"
                     ref={this.ref}
                     onChange={this.onChange}
@@ -115,6 +118,7 @@ class FileInput extends PureComponent {
  * @prop {boolean} [multiple] - the `multiple` attribute of the native file input https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#multiple
  */
 FileInput.propTypes = {
+    name: propTypes.string.isRequired,
     onChange: propTypes.func.isRequired,
     buttonLabel: propTypes.string,
 

--- a/src/Input.js
+++ b/src/Input.js
@@ -180,7 +180,6 @@ Input.propTypes = {
     placeholder: propTypes.string,
     tabIndex: propTypes.string,
 
-    focus: propTypes.bool,
     disabled: propTypes.bool,
     dense: propTypes.bool,
 

--- a/src/Label.js
+++ b/src/Label.js
@@ -24,15 +24,18 @@ const styles = css`
     }
 `
 
-const constructClassName = props =>
+const constructClassName = ({ required, disabled }) =>
     cx({
-        required: props.required,
-        disabled: props.disabled,
+        required: required,
+        disabled: disabled,
     })
 
-export const Label = props => (
-    <label htmlFor={props.htmlFor} className={constructClassName(props)}>
-        <span>{props.children}</span>
+export const Label = ({ htmlFor, children, required, disabled }) => (
+    <label
+        htmlFor={htmlFor}
+        className={constructClassName({ required, disabled })}
+    >
+        <span>{children}</span>
         <style jsx>{styles}</style>
     </label>
 )

--- a/src/SelectField.js
+++ b/src/SelectField.js
@@ -26,6 +26,7 @@ class SelectField extends React.Component {
             onChange,
             onFocus,
             onBlur,
+            initialFocus,
             dense,
             required,
             label,
@@ -65,6 +66,7 @@ class SelectField extends React.Component {
                     onFocus={onFocus}
                     onBlur={onBlur}
                     loading={loading}
+                    initialFocus={initialFocus}
                 >
                     {children}
                 </Select>
@@ -102,6 +104,7 @@ class SelectField extends React.Component {
  * @prop {boolean} [loading]
  * @prop {function} [onFocus]
  * @prop {function} [onBlur]
+ * @prop {boolean} [initialFocus]
  *
  * @prop {string} [validationText]
  * @prop {string} [helpText]

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -124,7 +124,6 @@ const Tab = ({ icon, onClick, selected, disabled, children }) => (
  * @static
  * @prop {Element} [icon]
  * @prop {function} [onClick]
- * @prop {function} [addTabRef]
  * @prop {boolean} [selected]
  * @prop {boolean} [disabled]
  * @prop {Node} [children]
@@ -132,7 +131,6 @@ const Tab = ({ icon, onClick, selected, disabled, children }) => (
 Tab.propTypes = {
     icon: PropTypes.element,
     onClick: PropTypes.func,
-    addTabRef: PropTypes.func,
     selected: PropTypes.bool,
     disabled: PropTypes.bool,
     children: PropTypes.node,


### PR DESCRIPTION
We have a couple of components with props that aren't used. I've added a linting rule to catch this in the future and fixed some of the linting errors. However, for some of the linting errors I'm not sure if the props can be safely removed, or if this is a mistake and we actually want to use these props:

<img width="640" alt="Screenshot 2019-09-23 at 11 15 30" src="https://user-images.githubusercontent.com/7355199/65414270-a36afd00-ddf3-11e9-868c-adffdd605d9d.png">

So @Mohammer5, @HendrikThePendric can the above props be safely removed? 