### PR TITLE
fix(css-variables): improve robustness and developer warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,9 +3,16 @@ const { config } = require('@dhis2/cli-style')
 module.exports = {
     parser: 'babel-eslint',
     extends: ['eslint:recommended', 'plugin:react/recommended', config.eslint],
+    env: {
+        es6: true,
+    },
     settings: {
         react: {
             version: '16.3',
         },
+        propWrapperFunctions: [
+            'forbidUnknowProps',
+            { property: 'forbidUnknowProps', object: 'propTypes' },
+        ],
     },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,9 +7,5 @@ module.exports = {
         react: {
             version: '16.3',
         },
-        propWrapperFunctions: [
-            'whitelistProps',
-            { property: 'whitelistProps', object: 'propTypes' },
-        ],
     },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,8 +8,8 @@ module.exports = {
             version: '16.3',
         },
         propWrapperFunctions: [
-            'forbidUnknowProps',
-            { property: 'forbidUnknownProps', object: 'propTypes' },
+            'whitelistProps',
+            { property: 'whitelistProps', object: 'propTypes' },
         ],
     },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
         },
         propWrapperFunctions: [
             'forbidUnknowProps',
-            { property: 'forbidUnknowProps', object: 'propTypes' },
+            { property: 'forbidUnknownProps', object: 'propTypes' },
         ],
     },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,9 +3,6 @@ const { config } = require('@dhis2/cli-style')
 module.exports = {
     parser: 'babel-eslint',
     extends: ['eslint:recommended', 'plugin:react/recommended', config.eslint],
-    env: {
-        es6: true,
-    },
     settings: {
         react: {
             version: '16.3',

--- a/src/CssVariables.js
+++ b/src/CssVariables.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import * as theme from './theme.js'
 
 const toPrefixedThemeSection = themeSectionKey =>
@@ -22,10 +22,11 @@ const toCustomPropertyString = themeSection =>
  * @example import { CssVariables } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/cssvariables--default|Storybook}
  */
-const CssVariables = props => {
-    const variables = Object.keys(props)
+const CssVariables = ({ colors, theme, layers, spacers, elevations }) => {
+    const allowedProps = { colors, theme, layers, spacers, elevations }
+    const variables = Object.keys(allowedProps)
         // Filter all props that are false
-        .filter(prop => props[prop])
+        .filter(prop => allowedProps[prop])
         // Map props to corresponding theme section and prefixes keys with section name
         .map(toPrefixedThemeSection)
         // Map each section to a single string of css custom property declarations
@@ -59,12 +60,12 @@ CssVariables.defaultProps = {
  * @prop {boolean} [spacers]
  * @prop {boolean} [elevations]
  */
-CssVariables.propTypes = {
+CssVariables.propTypes = propTypes.forbidUnknowProps({
     colors: propTypes.bool,
     theme: propTypes.bool,
     layers: propTypes.bool,
     spacers: propTypes.bool,
     elevations: propTypes.bool,
-}
+})
 
 export { CssVariables }

--- a/src/CssVariables.js
+++ b/src/CssVariables.js
@@ -60,12 +60,12 @@ CssVariables.defaultProps = {
  * @prop {boolean} [spacers]
  * @prop {boolean} [elevations]
  */
-CssVariables.propTypes = propTypes.whitelistProps({
+CssVariables.propTypes = {
     colors: propTypes.bool,
     theme: propTypes.bool,
     layers: propTypes.bool,
     spacers: propTypes.bool,
     elevations: propTypes.bool,
-})
+}
 
 export { CssVariables }

--- a/src/CssVariables.js
+++ b/src/CssVariables.js
@@ -60,7 +60,7 @@ CssVariables.defaultProps = {
  * @prop {boolean} [spacers]
  * @prop {boolean} [elevations]
  */
-CssVariables.propTypes = propTypes.forbidUnknowProps({
+CssVariables.propTypes = propTypes.forbidUnknownProps({
     colors: propTypes.bool,
     theme: propTypes.bool,
     layers: propTypes.bool,

--- a/src/CssVariables.js
+++ b/src/CssVariables.js
@@ -60,7 +60,7 @@ CssVariables.defaultProps = {
  * @prop {boolean} [spacers]
  * @prop {boolean} [elevations]
  */
-CssVariables.propTypes = propTypes.forbidUnknownProps({
+CssVariables.propTypes = propTypes.whitelistProps({
     colors: propTypes.bool,
     theme: propTypes.bool,
     layers: propTypes.bool,


### PR DESCRIPTION
The thinking behind this is:
1. Because we now loop through the object keys of `allowedKeys` we prevent nasty errors
1. Since the previous change cause things to fail silently (i.e. developer adds prop `shape` which isn't in the `allowedKeys` so it's simply ignored), I added some props-validation that would let the developer know he has added a not-allowed prop.

Currently this PR has draft status because it is dependent on https://github.com/dhis2/prop-types/pull/46. Once that's been merged, we still need to update the version of `@dhis2/prop-types` here....