### PR TITLE
chore(prop-types): switched to our own @dhis2/prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,11 @@
     "typeface-roboto": "^0.0.75"
   },
   "peerDependencies": {
-    "prop-types": "^15",
     "react": "^16.3",
     "react-dom": "^16.3"
   },
   "dependencies": {
-    "@dhis2/prop-types": "^1.1.0",
+    "@dhis2/prop-types": "^1.1.1",
     "classnames": "^2.2.6",
     "styled-jsx": "^3.2.2"
   },

--- a/src/AlertBar.js
+++ b/src/AlertBar.js
@@ -1,7 +1,6 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React, { PureComponent } from 'react'
-import { mutuallyExclusive } from '@dhis2/prop-types'
 
 import { Actions, actionsPropType } from './AlertBar/Actions.js'
 import { Dismiss } from './AlertBar/Dismiss.js'
@@ -131,7 +130,7 @@ class AlertBar extends PureComponent {
     }
 }
 
-const alertTypePropType = mutuallyExclusive(
+const alertTypePropType = propTypes.mutuallyExclusive(
     ['success', 'warning', 'critical'],
     propTypes.bool
 )

--- a/src/AlertBar/Action.js
+++ b/src/AlertBar/Action.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import { spacers } from '../theme.js'
 
 class Action extends PureComponent {

--- a/src/AlertBar/Actions.js
+++ b/src/AlertBar/Actions.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
-import { arrayWithLength } from '@dhis2/prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { Action } from './Action.js'
 import { spacers } from '../theme.js'
@@ -25,7 +24,7 @@ const Actions = ({ actions, hide }) => {
     )
 }
 
-const actionsPropType = arrayWithLength(
+const actionsPropType = propTypes.arrayWithLength(
     0,
     2,
     propTypes.shape({

--- a/src/AlertBar/Dismiss.js
+++ b/src/AlertBar/Dismiss.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import { spacers } from '../theme.js'
 import { Close } from '../icons/Close.js'
 

--- a/src/AlertBar/Icon.js
+++ b/src/AlertBar/Icon.js
@@ -1,4 +1,4 @@
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
 import { statusPropType } from '../common-prop-types.js'

--- a/src/AlertBar/Message.js
+++ b/src/AlertBar/Message.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 const Message = ({ children }) => (
     <div>

--- a/src/AlertStack.js
+++ b/src/AlertStack.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import { createPortal } from 'react-dom'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
-import { instanceOfComponent } from '@dhis2/prop-types'
 
 import styles from './AlertStack/styles.js'
 import { AlertBar } from './AlertBar.js'
@@ -31,7 +30,7 @@ const AlertStack = ({ className, children }) =>
  */
 AlertStack.propTypes = {
     className: propTypes.string,
-    children: propTypes.arrayOf(instanceOfComponent(AlertBar)),
+    children: propTypes.arrayOf(propTypes.instanceOfComponent(AlertBar)),
 }
 
 export { AlertStack }

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React, { Component, createRef } from 'react'
 
 import { buttonVariantPropType, sizePropType } from './common-prop-types.js'

--- a/src/ButtonStrip.js
+++ b/src/ButtonStrip.js
@@ -1,8 +1,6 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
-
-import { instanceOfComponent, mutuallyExclusive } from '@dhis2/prop-types'
 
 import { Button } from './Button.js'
 import styles from './ButtonStrip/styles.js'
@@ -22,7 +20,10 @@ const ButtonStrip = ({ className, children, middle, end }) => (
     </div>
 )
 
-const alignmentPropType = mutuallyExclusive(['middle', 'end'], propTypes.bool)
+const alignmentPropType = propTypes.mutuallyExclusive(
+    ['middle', 'end'],
+    propTypes.bool
+)
 
 /**
  * @typedef {Object} PropTypes
@@ -36,7 +37,7 @@ const alignmentPropType = mutuallyExclusive(['middle', 'end'], propTypes.bool)
  */
 ButtonStrip.propTypes = {
     className: propTypes.string,
-    children: propTypes.arrayOf(instanceOfComponent(Button)),
+    children: propTypes.arrayOf(propTypes.instanceOfComponent(Button)),
     middle: alignmentPropType,
     end: alignmentPropType,
 }

--- a/src/Card.js
+++ b/src/Card.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { colors } from './theme.js'

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React, { Component, Fragment } from 'react'
 
 import { statusPropType } from './common-prop-types.js'

--- a/src/Checkbox/Icon.js
+++ b/src/Checkbox/Icon.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React from 'react'
 import { resolve } from 'styled-jsx/css'
 

--- a/src/Checkbox/Input.js
+++ b/src/Checkbox/Input.js
@@ -1,5 +1,5 @@
 import React, { Component, createRef } from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export class Input extends Component {
     ref = createRef()

--- a/src/Checkbox/Label.js
+++ b/src/Checkbox/Label.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { colors, theme, spacers } from '../theme.js'

--- a/src/Chip.js
+++ b/src/Chip.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { colors, theme, spacers } from './theme.js'

--- a/src/Chip/Content.js
+++ b/src/Chip/Content.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { spacers } from '../theme.js'

--- a/src/Chip/Icon.js
+++ b/src/Chip/Icon.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { spacers } from '../theme.js'
 

--- a/src/Chip/Remove.js
+++ b/src/Chip/Remove.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import { resolve } from 'styled-jsx/css'
 
 import { Cancel } from '../icons/Cancel'

--- a/src/CircularLoader.js
+++ b/src/CircularLoader.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
 import { sizePropType } from './common-prop-types.js'

--- a/src/ComponentCover.js
+++ b/src/ComponentCover.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import { layers } from './theme.js'
 
 /**

--- a/src/CssVariables.js
+++ b/src/CssVariables.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import * as theme from './theme.js'
 
 const toPrefixedThemeSection = themeSectionKey =>

--- a/src/Divider.js
+++ b/src/Divider.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { colors, spacers } from './theme.js'
 

--- a/src/DropMenu.js
+++ b/src/DropMenu.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import ReactDOM from 'react-dom'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { getPosition } from './DropMenu/getPosition'
 import { layers } from './theme.js'

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -1,4 +1,4 @@
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React, { Component } from 'react'
 
 import { Button } from './Button.js'

--- a/src/Field.js
+++ b/src/Field.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { spacers } from './theme.js'
 

--- a/src/FieldSet.js
+++ b/src/FieldSet.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 /**
  * @module

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -1,5 +1,5 @@
 import React, { createRef, PureComponent } from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { statusPropType, sizePropType } from './common-prop-types.js'

--- a/src/FileInputField.js
+++ b/src/FileInputField.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
-import { instanceOfComponent } from '@dhis2/prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { statusPropType, sizePropType } from './common-prop-types'
 import { FileInput } from './FileInput.js'
@@ -123,8 +122,8 @@ FileInputField.propTypes = {
     tabIndex: propTypes.string,
 
     children: propTypes.oneOfType([
-        instanceOfComponent(FileListItem),
-        propTypes.arrayOf(instanceOfComponent(FileListItem)),
+        propTypes.instanceOfComponent(FileListItem),
+        propTypes.arrayOf(propTypes.instanceOfComponent(FileListItem)),
     ]),
 
     error: statusPropType,

--- a/src/FileList.js
+++ b/src/FileList.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
-import { instanceOfComponent } from '@dhis2/prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { FileListItem } from './FileList/FileListItem'
 import { FileListPlaceholder } from './FileList/FileListPlaceholder'
@@ -35,9 +34,9 @@ const FileList = ({ children, className }) => (
  */
 FileList.propTypes = {
     children: propTypes.oneOfType([
-        instanceOfComponent(FileListPlaceholder),
-        instanceOfComponent(FileListItem),
-        propTypes.arrayOf(instanceOfComponent(FileListItem)),
+        propTypes.instanceOfComponent(FileListPlaceholder),
+        propTypes.instanceOfComponent(FileListItem),
+        propTypes.arrayOf(propTypes.instanceOfComponent(FileListItem)),
     ]),
     className: propTypes.string,
 }

--- a/src/FileList/FileListItem.js
+++ b/src/FileList/FileListItem.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { colors, spacers } from '../theme.js'

--- a/src/FileList/FileListPlaceholder.js
+++ b/src/FileList/FileListPlaceholder.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import { colors, spacers } from '../theme.js'
 
 /**

--- a/src/Help.js
+++ b/src/Help.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
 import { statusPropType } from './common-prop-types.js'

--- a/src/Input.js
+++ b/src/Input.js
@@ -1,4 +1,4 @@
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React, { Component } from 'react'
 import css from 'styled-jsx/css'
 import cx from 'classnames'

--- a/src/InputField.js
+++ b/src/InputField.js
@@ -1,4 +1,4 @@
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
 import { statusPropType } from './common-prop-types.js'

--- a/src/Label.js
+++ b/src/Label.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import cx from 'classnames'
 import css from 'styled-jsx/css'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { spacers } from './theme.js'
 

--- a/src/Legend.js
+++ b/src/Legend.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { theme, spacers } from './theme.js'

--- a/src/LinearLoader.js
+++ b/src/LinearLoader.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import { theme, spacers } from './theme.js'
 
 const Progress = ({ amount }) => {

--- a/src/Logo.js
+++ b/src/Logo.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { LogoSvg } from './Logo/LogoSvg'
 import { LogoIconSvg } from './Logo/LogoIconSvg'

--- a/src/Logo/LogoIconSvg.js
+++ b/src/Logo/LogoIconSvg.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function LogoIconSvg({ iconColor, className }) {
     return (

--- a/src/Logo/LogoSvg.js
+++ b/src/Logo/LogoSvg.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function LogoSvg({ iconColor, textColor, className }) {
     return (

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { Card } from './Card.js'
 import { MenuList } from './MenuList.js'

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 import css from 'styled-jsx/css'
 

--- a/src/MenuList.js
+++ b/src/MenuList.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 /**
  * @module

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React from 'react'
 import { createPortal } from 'react-dom'
 

--- a/src/Modal/Actions.js
+++ b/src/Modal/Actions.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { spacers } from '../theme.js'
 

--- a/src/Modal/Content.js
+++ b/src/Modal/Content.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { spacers } from '../theme.js'
 

--- a/src/Modal/ModalCard.js
+++ b/src/Modal/ModalCard.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React from 'react'
 import { resolve } from 'styled-jsx/css'
 

--- a/src/Modal/Title.js
+++ b/src/Modal/Title.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { spacers } from '../theme.js'

--- a/src/Node.js
+++ b/src/Node.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { ArrowDown } from './icons/Arrow.js'

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React, { Component, createRef } from 'react'
 import css from 'styled-jsx/css'
 

--- a/src/ScreenCover.js
+++ b/src/ScreenCover.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { layers } from './theme.js'
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -1,4 +1,4 @@
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React, { Component, createRef } from 'react'
 import css from 'styled-jsx/css'
 import cx from 'classnames'

--- a/src/SelectField.js
+++ b/src/SelectField.js
@@ -1,4 +1,4 @@
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
 import { statusPropType } from './common-prop-types.js'

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React, { Component } from 'react'
 import css from 'styled-jsx/css'
 

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import React, { Component, createRef } from 'react'
 
 import { statusPropType } from './common-prop-types.js'

--- a/src/Tabs/ScrollBar.js
+++ b/src/Tabs/ScrollBar.js
@@ -1,5 +1,5 @@
 import React, { PureComponent, createRef } from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 import { ChevronLeft, ChevronRight } from '../icons/Chevron'
 import { colors } from '../theme'

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+import PropTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 import { colors, theme } from '../theme.js'
 

--- a/src/Tabs/TabBar.js
+++ b/src/Tabs/TabBar.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 import { colors } from '../theme'
 import cx from 'classnames'
 

--- a/src/common-prop-types.js
+++ b/src/common-prop-types.js
@@ -1,17 +1,16 @@
-import { mutuallyExclusive } from '@dhis2/prop-types'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
-export const statusPropType = mutuallyExclusive(
+export const statusPropType = propTypes.mutuallyExclusive(
     ['valid', 'warning', 'error'],
     propTypes.bool
 )
 
-export const buttonVariantPropType = mutuallyExclusive(
+export const buttonVariantPropType = propTypes.mutuallyExclusive(
     ['primary', 'secondary', 'destructive'],
     propTypes.bool
 )
 
-export const sizePropType = mutuallyExclusive(
+export const sizePropType = propTypes.mutuallyExclusive(
     ['small', 'large'],
     propTypes.bool
 )

--- a/src/icons/Arrow.js
+++ b/src/icons/Arrow.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function ArrowDown({ className }) {
     return (

--- a/src/icons/AttachFile.js
+++ b/src/icons/AttachFile.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function AttachFile({ className }) {
     return (

--- a/src/icons/Cancel.js
+++ b/src/icons/Cancel.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function Cancel({ className }) {
     return (

--- a/src/icons/Checkbox.js
+++ b/src/icons/Checkbox.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function Unchecked({ className }) {
     return (

--- a/src/icons/Chevron.js
+++ b/src/icons/Chevron.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function ChevronRight({ className }) {
     return (

--- a/src/icons/Close.js
+++ b/src/icons/Close.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function Close({ className }) {
     return (

--- a/src/icons/FileUpload.js
+++ b/src/icons/FileUpload.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function FileUpload({ className }) {
     return (

--- a/src/icons/Radio.js
+++ b/src/icons/Radio.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function Checked({ className }) {
     return (

--- a/src/icons/Status.js
+++ b/src/icons/Status.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 import { theme, spacers } from '../theme.js'
 

--- a/src/icons/Upload.js
+++ b/src/icons/Upload.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import propTypes from 'prop-types'
+import propTypes from '@dhis2/prop-types'
 
 export function Upload({ className }) {
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,10 +1106,12 @@
     live-server "^1.2.1"
     match-all "^1.2.5"
 
-"@dhis2/prop-types@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.1.0.tgz#6144470f336fbcf0fd9142c5ea402d03dfb92c2a"
-  integrity sha512-hHbkoqEbi7vcWcJG1VdBkjKBUFZGWj7VRkwr2GvRU3g1j7AXW5WzsrGGgd/4ejK4nQMardlkZmCrzw7+mkTcRg==
+"@dhis2/prop-types@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.1.1.tgz#a70dd59e56cff13f6e49470677a4def0ac78ff6f"
+  integrity sha512-ILyRcpPjFVtfxuZhyZ2yBp5NkIiTKBF/KfTtr6cSGqXnBIeV9XqHR+IT+C9jwcB96hxhuxBKmvfiaFQFT8uU6g==
+  dependencies:
+    prop-types "^15"
 
 "@emotion/cache@^10.0.15":
   version "10.0.15"
@@ -8235,7 +8237,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
What I've done is:
1. Removed all named imports from `@dhis2/prop-types`
1. Prefixed calls to these named functions with `propTypes.`
1. Switch to importing from `@dhis2/prop-types` which includes all of our custom methods on the default exported object

What remains is:
1. What to do with the `package.json`? Currently we have `prop-types` as a peer dependency and `@dhis2/prop-types` as a dependency. I don't think this is really correct, but not sure what would be best....