### PR TITLE
fix: don't use dynamic re-exports

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -1,8 +1,0 @@
-export { TableBody } from './Table/TableBody.js'
-export { TableCell } from './Table/TableCell.js'
-export { TableCellHead } from './Table/TableCellHead.js'
-export { Table } from './Table/Table.js'
-export { TableFoot } from './Table/TableFoot.js'
-export { TableHead } from './Table/TableHead.js'
-export { TableRow } from './Table/TableRow.js'
-export { TableRowHead } from './Table/TableRowHead.js'

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,16 @@ export { RadioGroup } from './RadioGroup'
 export { ScreenCover } from './ScreenCover'
 export { SelectField } from './SelectField'
 export { Switch } from './Switch'
-export * from './Table'
+
+/* table */
+export { TableBody } from './Table/TableBody.js'
+export { TableCell } from './Table/TableCell.js'
+export { TableCellHead } from './Table/TableCellHead.js'
+export { Table } from './Table/Table.js'
+export { TableFoot } from './Table/TableFoot.js'
+export { TableHead } from './Table/TableHead.js'
+export { TableRow } from './Table/TableRow.js'
+export { TableRowHead } from './Table/TableRowHead.js'
 
 /* molecules */
 export { ButtonStrip } from './ButtonStrip'


### PR DESCRIPTION
Using dynamic re-exports prevents static bundlers (like rollup) from supporting CJS named imports - if we include the named exports explicitly instead, static named imports work in CJS modules.  

See [this app-platform issue](https://github.com/dhis2/app-platform/issues/69), [the app-platform rollup config](https://github.com/dhis2/app-platform/blob/master/cli/config/rollup.config.js#L77), and [the underlying rollup explanation](https://github.com/rollup/rollup-plugin-commonjs/issues/211#issuecomment-337897124) (which explains why this affects rollup but not webpack).

We should figure out how to support ES imports in rollup (maybe stop using rollup at all?) but for now this will make it a little less confusing when trying to do CJS named imports from `ui-core`