### PR TITLE
chore(help): remove `indent` props and examples from stories

### DIFF
--- a/stories/FieldSet.stories.js
+++ b/stories/FieldSet.stories.js
@@ -43,8 +43,6 @@ storiesOf('FieldSet', module)
                     error
                 />
             </Field>
-            <Help error indent={false}>
-                You really have to choose something!
-            </Help>
+            <Help error>You really have to choose something!</Help>
         </FieldSet>
     ))

--- a/stories/Help.stories.js
+++ b/stories/Help.stories.js
@@ -10,14 +10,6 @@ storiesOf('Help', module)
     ))
     .add('Status: Valid', () => <Help valid>Allow me to be of assistance</Help>)
     .add('Status: Error', () => <Help error>Allow me to be of assistance</Help>)
-    .add('Indentation', () => (
-        <>
-            <Help>
-                I have an indentation (indent set to true by defaultProps)
-            </Help>
-            <Help indent={false}>My identation has been set to false</Help>
-        </>
-    ))
     .add('Text overflow', () => (
         <div style={{ width: 200 }}>
             <Help>I take up more space than my container</Help>


### PR DESCRIPTION
Just a small PR to clean up some relics from the past