### PR TITLE
refactor(statusicon): change statusicon to accept status instead of flags

### DIFF
--- a/src/AlertBar.js
+++ b/src/AlertBar.js
@@ -84,42 +84,31 @@ class AlertBar extends PureComponent {
     }
 
     shouldAutoHide() {
-        const { permanent, warning, critical } = this.props
-        return !(permanent || warning || critical)
+        const { permanent, status } = this.props
+
+        const warning = status === 'warning'
+        const error = status === 'error'
+
+        return !(permanent || warning || error)
     }
 
     render() {
-        const {
-            className,
-            children,
-            success,
-            warning,
-            critical,
-            icon,
-            actions,
-        } = this.props
+        const { className, children, status, icon, actions } = this.props
         const { visible, hidden } = this.state
 
         if (hidden) {
             return null
         }
 
-        const info = !critical && !success && !warning
-        const iconProps = { icon, critical, success, warning }
-
         return (
             <div
-                className={cx(className, {
-                    info,
-                    success,
-                    warning,
-                    critical,
+                className={cx(className, status, {
                     visible,
                 })}
                 onMouseEnter={this.stopDisplayTimeOut}
                 onMouseLeave={this.startDisplayTimeout}
             >
-                <Icon {...iconProps} />
+                <Icon icon={icon} status={status} />
                 <Message>{children}</Message>
                 <Actions actions={actions} hide={this.hide} />
                 <Dismiss onClick={this.hide} />
@@ -129,11 +118,6 @@ class AlertBar extends PureComponent {
         )
     }
 }
-
-const alertTypePropType = propTypes.mutuallyExclusive(
-    ['success', 'warning', 'critical'],
-    propTypes.bool
-)
 
 /**
  * @typedef {Object} PropTypes
@@ -156,9 +140,7 @@ const alertTypePropType = propTypes.mutuallyExclusive(
 AlertBar.propTypes = {
     children: propTypes.string.isRequired,
     className: propTypes.string,
-    success: alertTypePropType,
-    warning: alertTypePropType,
-    critical: alertTypePropType,
+    status: propTypes.oneOfType(['valid', 'warning', 'error', 'info']),
     icon: iconPropType,
     duration: propTypes.number,
     permanent: propTypes.bool,
@@ -167,6 +149,7 @@ AlertBar.propTypes = {
 }
 
 AlertBar.defaultProps = {
+    status: 'info',
     icon: true,
     duration: 8000,
 }

--- a/src/AlertBar/Icon.js
+++ b/src/AlertBar/Icon.js
@@ -1,12 +1,10 @@
 import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
-import { statusPropType } from '../common-prop-types.js'
-
 import { Error, Info, Valid, Warning } from '../icons/Status.js'
 import { spacers } from '../theme.js'
 
-const Icon = ({ icon, success, warning, critical }) => {
+const Icon = ({ icon, status }) => {
     if (icon === false) {
         return null
     }
@@ -14,11 +12,11 @@ const Icon = ({ icon, success, warning, critical }) => {
     let IconComponent
     if (React.isValidElement(icon)) {
         IconComponent = icon
-    } else if (critical) {
+    } else if (status === 'error') {
         IconComponent = <Error />
-    } else if (warning) {
+    } else if (status === 'warning') {
         IconComponent = <Warning />
-    } else if (success) {
+    } else if (status === 'valid') {
         IconComponent = <Valid />
     } else {
         IconComponent = <Info />
@@ -44,9 +42,7 @@ const iconPropType = propTypes.oneOfType([propTypes.bool, propTypes.element])
 
 Icon.propTypes = {
     icon: iconPropType,
-    success: statusPropType,
-    warning: statusPropType,
-    critical: statusPropType,
+    status: propTypes.oneOfType(['valid', 'warning', 'error', 'info']),
 }
 
 export { Icon, iconPropType }

--- a/src/AlertBar/styles.js
+++ b/src/AlertBar/styles.js
@@ -37,11 +37,11 @@ export default css`
     div.info :global(path) {
         fill: ${colors.white};
     }
-    div.success {
+    div.valid {
         background-color: ${colors.green800};
         color: ${colors.white};
     }
-    div.success :global(path) {
+    div.valid :global(path) {
         fill: ${colors.white};
     }
     div.warning {
@@ -51,11 +51,11 @@ export default css`
     div.warning :global(path) {
         fill: ${colors.yellow900};
     }
-    div.critical {
+    div.error {
         background-color: ${colors.red800};
         color: ${colors.white};
     }
-    div.critical :global(path) {
+    div.error :global(path) {
         fill: ${colors.white};
     }
 

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -2,8 +2,6 @@ import cx from 'classnames'
 import propTypes from '@dhis2/prop-types'
 import React, { Component, Fragment } from 'react'
 
-import { statusPropType } from './common-prop-types.js'
-
 import { theme } from './theme.js'
 
 import { Icon } from './Checkbox/Icon.js'
@@ -48,7 +46,6 @@ class Checkbox extends Component {
             checked = false,
             className,
             disabled,
-            error,
             icon,
             indeterminate,
             label,
@@ -56,9 +53,8 @@ class Checkbox extends Component {
             onChange,
             required,
             tabIndex,
-            valid,
             value,
-            warning,
+            status,
         } = this.props
         const { focus } = this.state
 
@@ -86,9 +82,7 @@ class Checkbox extends Component {
                         focus={focus}
                         checked={checked}
                         disabled={disabled}
-                        valid={valid}
-                        error={error}
-                        warning={warning}
+                        status={status}
                         indeterminate={indeterminate}
                     />
 
@@ -167,9 +161,7 @@ Checkbox.propTypes = {
     required: propTypes.bool,
     checked: propTypes.bool,
     disabled: propTypes.bool,
-    valid: statusPropType,
-    warning: statusPropType,
-    error: statusPropType,
+    status: propTypes.oneOfType(['valid', 'error', 'warning']),
     initialFocus: propTypes.bool,
 }
 

--- a/src/Checkbox/Icon.js
+++ b/src/Checkbox/Icon.js
@@ -3,7 +3,6 @@ import propTypes from '@dhis2/prop-types'
 import React from 'react'
 import { resolve } from 'styled-jsx/css'
 
-import { statusPropType } from '../common-prop-types.js'
 import { Checked, Indeterminate, Unchecked } from '../icons/Checkbox.js'
 import { colors, theme } from '../theme.js'
 
@@ -40,22 +39,15 @@ const icons = resolve`
     }
 `
 
-export const Icon = ({
-    focus,
-    checked,
-    disabled,
-    valid,
-    error,
-    warning,
-    indeterminate,
-}) => {
-    const classes = cx(icons.className, {
+export const Icon = ({ focus, checked, disabled, status, indeterminate }) => {
+    const valid = status === 'valid'
+    const error = status === 'error'
+    const warning = status === 'warning'
+
+    const classes = cx(icons.className, status, {
         checked: checked && !valid && !error && !warning,
         focus,
         disabled,
-        valid,
-        error,
-        warning,
     })
 
     return (
@@ -91,9 +83,7 @@ export const Icon = ({
 Icon.propTypes = {
     checked: propTypes.bool,
     disabled: propTypes.bool,
-    valid: statusPropType,
-    error: statusPropType,
-    warning: statusPropType,
+    status: propTypes.oneOfType(['valid', 'error', 'warning']),
     indeterminate: propTypes.bool,
     focus: propTypes.bool,
 }

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -2,11 +2,11 @@ import React, { createRef, PureComponent } from 'react'
 import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
-import { statusPropType, sizePropType } from './common-prop-types.js'
+import { sizePropType } from './common-prop-types.js'
 import { Button } from './Button.js'
 import { spacers } from './theme.js'
 import { Upload } from './icons/Upload.js'
-import { StatusIconNoDefault } from './icons/Status.js'
+import { StatusIcon } from './icons/Status.js'
 
 /**
  * @module
@@ -34,13 +34,11 @@ class FileInput extends PureComponent {
             className,
             name,
             buttonLabel,
-            error,
-            valid,
-            warning,
             accept,
             multiple,
             small,
             large,
+            status,
             disabled,
             tabIndex,
         } = this.props
@@ -68,11 +66,7 @@ class FileInput extends PureComponent {
                 >
                     {buttonLabel}
                 </Button>
-                <StatusIconNoDefault
-                    error={error}
-                    valid={valid}
-                    warning={warning}
-                />
+                <StatusIcon status={status} />
 
                 <style jsx>{`
                     input {
@@ -126,9 +120,7 @@ FileInput.propTypes = {
     className: propTypes.string,
     tabIndex: propTypes.string,
 
-    error: statusPropType,
-    valid: statusPropType,
-    warning: statusPropType,
+    status: propTypes.oneOf(['warning', 'error', 'valid']),
     small: sizePropType,
     large: sizePropType,
     disabled: propTypes.bool,

--- a/src/FileInputField.js
+++ b/src/FileInputField.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
-import { statusPropType, sizePropType } from './common-prop-types'
+import { sizePropType } from './common-prop-types'
 import { FileInput } from './FileInput.js'
 import { FileList, FileListItem, FileListPlaceholder } from './FileList.js'
 import { Field } from './Field.js'
@@ -29,9 +29,7 @@ const FileInputField = ({
     placeholder,
     tabIndex,
     children,
-    error,
-    valid,
-    warning,
+    status,
     small,
     large,
     required,
@@ -50,9 +48,7 @@ const FileInputField = ({
             onChange={onChange}
             className={className}
             buttonLabel={buttonLabel}
-            error={error}
-            valid={valid}
-            warning={warning}
+            status={status}
             accept={accept}
             multiple={multiple}
             small={small}
@@ -64,11 +60,7 @@ const FileInputField = ({
 
         {helpText ? <Help>{helpText}</Help> : null}
 
-        {validationText ? (
-            <Help error={error} warning={warning} valid={valid}>
-                {validationText}
-            </Help>
-        ) : null}
+        {validationText ? <Help status={status}>{validationText}</Help> : null}
 
         <FileList>
             {!children && placeholder ? (
@@ -126,9 +118,7 @@ FileInputField.propTypes = {
         propTypes.arrayOf(propTypes.instanceOfComponent(FileListItem)),
     ]),
 
-    error: statusPropType,
-    valid: statusPropType,
-    warning: statusPropType,
+    status: propTypes.oneOf(['warning', 'error', 'valid']),
     small: sizePropType,
     large: sizePropType,
     required: propTypes.bool,

--- a/src/Help.js
+++ b/src/Help.js
@@ -2,7 +2,6 @@ import cx from 'classnames'
 import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
-import { statusPropType } from './common-prop-types.js'
 import { spacers, theme } from './theme.js'
 
 /**
@@ -12,14 +11,8 @@ import { spacers, theme } from './theme.js'
  * @example import { Help } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/help--default|Storybook}
  */
-const Help = ({ children, valid, error, warning, className }) => (
-    <p
-        className={cx(className, {
-            valid,
-            error,
-            warning,
-        })}
-    >
+const Help = ({ children, status, className }) => (
+    <p className={cx(className, status)}>
         {children}
 
         <style jsx>{`
@@ -61,9 +54,7 @@ const Help = ({ children, valid, error, warning, className }) => (
 Help.propTypes = {
     className: propTypes.string,
     children: propTypes.string.isRequired,
-    error: statusPropType,
-    valid: statusPropType,
-    warning: statusPropType,
+    status: propTypes.oneOf(['warning', 'error', 'valid']),
 }
 
 export { Help }

--- a/src/Input.js
+++ b/src/Input.js
@@ -3,9 +3,8 @@ import React, { Component } from 'react'
 import css from 'styled-jsx/css'
 import cx from 'classnames'
 
-import { statusPropType } from './common-prop-types.js'
 import { theme, colors, spacers } from './theme.js'
-import { StatusIconNoDefault } from './icons/Status.js'
+import { StatusIcon } from './icons/Status.js'
 
 const styles = css`
     .input {
@@ -105,10 +104,7 @@ export class Input extends Component {
             readOnly,
             placeholder,
             name,
-            valid,
-            error,
-            warning,
-            loading,
+            status,
             value,
             tabIndex,
             width,
@@ -130,23 +126,15 @@ export class Input extends Component {
                     onFocus={onFocus}
                     onBlur={onBlur}
                     onChange={onChange}
-                    className={cx({
+                    className={cx(status, {
                         dense,
                         disabled,
-                        error,
-                        valid,
-                        warning,
                         'read-only': readOnly,
                     })}
                 />
 
                 <div className="status-icon">
-                    <StatusIconNoDefault
-                        error={error}
-                        valid={valid}
-                        loading={loading}
-                        warning={warning}
-                    />
+                    <StatusIcon status={status} />
                 </div>
 
                 <style jsx>{styles}</style>
@@ -210,10 +198,7 @@ Input.propTypes = {
     readOnly: propTypes.bool,
     dense: propTypes.bool,
 
-    valid: statusPropType,
-    warning: statusPropType,
-    error: statusPropType,
-    loading: propTypes.bool,
+    status: propTypes.oneOf(['warning', 'error', 'loading', 'valid']),
 
     initialFocus: propTypes.bool,
 }

--- a/src/InputField.js
+++ b/src/InputField.js
@@ -1,8 +1,6 @@
 import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
-import { statusPropType } from './common-prop-types.js'
-
 import { Field } from './Field.js'
 import { Label } from './Label.js'
 import { Input } from './Input.js'
@@ -34,10 +32,7 @@ class InputField extends React.Component {
             readOnly,
             placeholder,
             name,
-            valid,
-            error,
-            warning,
-            loading,
+            status,
             value,
             tabIndex,
             helpText,
@@ -66,10 +61,7 @@ class InputField extends React.Component {
                     value={value || ''}
                     placeholder={placeholder}
                     disabled={disabled}
-                    valid={valid}
-                    warning={warning}
-                    error={error}
-                    loading={loading}
+                    status={status}
                     dense={dense}
                     tabIndex={tabIndex}
                     initialFocus={initialFocus}
@@ -80,9 +72,7 @@ class InputField extends React.Component {
                 {helpText ? <Help>{helpText}</Help> : null}
 
                 {validationText ? (
-                    <Help error={error} warning={warning} valid={valid}>
-                        {validationText}
-                    </Help>
+                    <Help status={status}>{validationText}</Help>
                 ) : null}
             </Field>
         )
@@ -136,10 +126,7 @@ InputField.propTypes = {
     disabled: propTypes.bool,
     readOnly: propTypes.bool,
     dense: propTypes.bool,
-    valid: statusPropType,
-    warning: statusPropType,
-    error: statusPropType,
-    loading: propTypes.bool,
+    status: propTypes.oneOf(['warning', 'error', 'loading', 'valid']),
     initialFocus: propTypes.bool,
 
     onBlur: propTypes.func,

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -3,7 +3,6 @@ import propTypes from '@dhis2/prop-types'
 import React, { Component, createRef } from 'react'
 import css from 'styled-jsx/css'
 
-import { statusPropType } from './common-prop-types.js'
 import { Checked, Unchecked } from './icons/Radio.js'
 import { colors, theme } from './theme.js'
 
@@ -107,25 +106,23 @@ class Radio extends Component {
             checked = false,
             className,
             disabled,
-            error,
             icon,
             label,
             name,
             onChange,
             required,
             tabIndex,
-            valid,
             value,
-            warning,
+            status,
         } = this.props
         const { focus } = this.state
+        const valid = status === 'valid'
+        const error = status === 'error'
+        const warning = status === 'warning'
 
-        const classes = cx(icons.className, {
+        const classes = cx(icons.className, status, {
             checked: checked && !valid && !error && !warning,
             disabled,
-            valid,
-            error,
-            warning,
             focus,
         })
 
@@ -207,9 +204,7 @@ Radio.propTypes = {
     required: propTypes.bool,
     checked: propTypes.bool,
     disabled: propTypes.bool,
-    valid: statusPropType,
-    warning: statusPropType,
-    error: statusPropType,
+    status: propTypes.oneOfType(['valid', 'error', 'warning']),
     initialFocus: propTypes.bool,
 }
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -3,11 +3,10 @@ import React, { Component, createRef } from 'react'
 import css from 'styled-jsx/css'
 import cx from 'classnames'
 
-import { statusPropType } from './common-prop-types.js'
 import { theme, colors, spacers } from './theme.js'
 
 import { ArrowDown } from './icons/Arrow.js'
-import { StatusIconNoDefault } from './icons/Status.js'
+import { StatusIcon } from './icons/Status.js'
 
 const TailIcon = () => (
     <div>
@@ -148,10 +147,7 @@ export class Select extends Component {
             children,
             name,
             tabIndex,
-            valid,
-            warning,
-            error,
-            loading,
+            status,
             className,
         } = this.props
 
@@ -159,13 +155,10 @@ export class Select extends Component {
 
         return (
             <div
-                className={cx('select', className, {
+                className={cx('select', className, status, {
                     dense,
                     disabled,
                     focus,
-                    valid,
-                    warning,
-                    error,
                 })}
             >
                 <select
@@ -189,13 +182,7 @@ export class Select extends Component {
 
                 <div className="status-icon">
                     <TailIcon />
-
-                    <StatusIconNoDefault
-                        error={error}
-                        valid={valid}
-                        loading={loading}
-                        warning={warning}
-                    />
+                    <StatusIcon status={status} />
                 </div>
                 <style jsx>{styles}</style>
             </div>
@@ -231,8 +218,5 @@ Select.propTypes = {
     focus: propTypes.bool,
     initialFocus: propTypes.bool,
 
-    valid: statusPropType,
-    warning: statusPropType,
-    error: statusPropType,
-    loading: propTypes.bool,
+    status: propTypes.oneOf(['warning', 'error', 'loading', 'valid']),
 }

--- a/src/SelectField.js
+++ b/src/SelectField.js
@@ -1,8 +1,6 @@
 import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
-import { statusPropType } from './common-prop-types.js'
-
 import { Field } from './Field.js'
 import { Label } from './Label.js'
 import { Help } from './Help.js'
@@ -32,10 +30,7 @@ class SelectField extends React.Component {
             label,
             disabled,
             name,
-            valid,
-            error,
-            warning,
-            loading,
+            status,
             value,
             tabIndex,
             helpText,
@@ -65,7 +60,7 @@ class SelectField extends React.Component {
                     onChange={onChange}
                     onFocus={onFocus}
                     onBlur={onBlur}
-                    loading={loading}
+                    status={status}
                     initialFocus={initialFocus}
                 >
                     {children}
@@ -74,9 +69,7 @@ class SelectField extends React.Component {
                 {helpText ? <Help>{helpText}</Help> : null}
 
                 {validationText ? (
-                    <Help error={error} warning={warning} valid={valid}>
-                        {validationText}
-                    </Help>
+                    <Help status={status}>{validationText}</Help>
                 ) : null}
             </Field>
         )
@@ -136,10 +129,7 @@ SelectField.propTypes = {
     required: propTypes.bool,
     disabled: propTypes.bool,
     dense: propTypes.bool,
-    valid: statusPropType,
-    warning: statusPropType,
-    error: statusPropType,
-    loading: propTypes.bool,
+    status: propTypes.oneOf(['warning', 'error', 'loading', 'valid']),
     initialFocus: propTypes.bool,
 
     onFocus: propTypes.func,

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -2,7 +2,6 @@ import cx from 'classnames'
 import propTypes from '@dhis2/prop-types'
 import React, { Component, createRef } from 'react'
 
-import { statusPropType } from './common-prop-types.js'
 import { styles, switchIconStyles } from './Switch/styles.js'
 
 const Input = React.forwardRef((props, ref) => (
@@ -20,13 +19,10 @@ const Input = React.forwardRef((props, ref) => (
 ))
 Input.displayName = 'Input'
 
-const SwitchIcon = ({ checked, valid, warning, error, disabled, focus }) => {
-    const classes = cx({
+const SwitchIcon = ({ status, checked, disabled, focus }) => {
+    const classes = cx(status, {
         checked,
         disabled,
-        valid,
-        error,
-        warning,
         focus,
     })
 
@@ -43,9 +39,7 @@ const SwitchIcon = ({ checked, valid, warning, error, disabled, focus }) => {
 SwitchIcon.propTypes = {
     checked: propTypes.bool,
     disabled: propTypes.bool,
-    valid: propTypes.bool,
-    warning: propTypes.bool,
-    error: propTypes.bool,
+    status: propTypes.oneOfType(['valid', 'warning', 'error']),
     focus: propTypes.bool,
 }
 
@@ -96,9 +90,7 @@ class Switch extends Component {
             required,
             checked = false,
             disabled,
-            valid,
-            warning,
-            error,
+            status,
         } = this.props
         const { focus } = this.state
 
@@ -122,9 +114,7 @@ class Switch extends Component {
                 <SwitchIcon
                     checked={checked}
                     disabled={disabled}
-                    valid={valid}
-                    warning={warning}
-                    error={error}
+                    status={status}
                     focus={focus}
                 />
 
@@ -166,9 +156,7 @@ Switch.propTypes = {
     required: propTypes.bool,
     checked: propTypes.bool,
     disabled: propTypes.bool,
-    valid: statusPropType,
-    warning: statusPropType,
-    error: statusPropType,
+    status: propTypes.oneOfType(['valid', 'warning', 'error']),
     initialFocus: propTypes.bool,
 
     onFocus: propTypes.func,

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -2,8 +2,7 @@ import propTypes from '@dhis2/prop-types'
 import React, { PureComponent } from 'react'
 import cx from 'classnames'
 
-import { statusPropType } from './common-prop-types.js'
-import { StatusIconNoDefault } from './icons/Status.js'
+import { StatusIcon } from './icons/Status.js'
 
 import { styles } from './TextArea/styles.js'
 
@@ -89,10 +88,7 @@ export class TextArea extends PureComponent {
             readOnly,
             placeholder,
             name,
-            valid,
-            error,
-            warning,
-            loading,
+            status,
             value,
             tabIndex,
             rows,
@@ -117,23 +113,15 @@ export class TextArea extends PureComponent {
                     onBlur={onBlur}
                     onChange={onChange}
                     rows={rows}
-                    className={cx({
+                    className={cx(status, {
                         dense,
                         disabled,
-                        error,
-                        valid,
-                        warning,
                         'read-only': readOnly,
                     })}
                 />
 
                 <div className="status-icon">
-                    <StatusIconNoDefault
-                        error={error}
-                        valid={valid}
-                        loading={loading}
-                        warning={warning}
-                    />
+                    <StatusIcon status={status} />
                 </div>
 
                 <style jsx>{styles}</style>
@@ -202,10 +190,7 @@ TextArea.propTypes = {
     readOnly: propTypes.bool,
     dense: propTypes.bool,
 
-    valid: statusPropType,
-    warning: statusPropType,
-    error: statusPropType,
-    loading: propTypes.bool,
+    status: propTypes.oneOf(['warning', 'error', 'loading', 'valid']),
 
     initialFocus: propTypes.bool,
 

--- a/src/TextAreaField.js
+++ b/src/TextAreaField.js
@@ -1,8 +1,6 @@
 import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
-import { statusPropType } from './common-prop-types.js'
-
 import { Field } from './Field.js'
 import { Label } from './Label.js'
 import { TextArea } from './TextArea.js'
@@ -30,10 +28,7 @@ const TextAreaField = ({
     disabled,
     placeholder,
     name,
-    valid,
-    error,
-    warning,
-    loading,
+    status,
     value,
     tabIndex,
     helpText,
@@ -59,10 +54,7 @@ const TextAreaField = ({
             value={value || ''}
             placeholder={placeholder}
             disabled={disabled}
-            valid={valid}
-            warning={warning}
-            error={error}
-            loading={loading}
+            status={status}
             dense={dense}
             tabIndex={tabIndex}
             initialFocus={initialFocus}
@@ -75,11 +67,7 @@ const TextAreaField = ({
 
         {helpText ? <Help>{helpText}</Help> : null}
 
-        {validationText ? (
-            <Help error={error} warning={warning} valid={valid}>
-                {validationText}
-            </Help>
-        ) : null}
+        {validationText ? <Help status={status}>{validationText}</Help> : null}
     </Field>
 )
 
@@ -136,10 +124,7 @@ TextAreaField.propTypes = {
     readOnly: propTypes.bool,
 
     dense: propTypes.bool,
-    valid: statusPropType,
-    warning: statusPropType,
-    error: statusPropType,
-    loading: propTypes.bool,
+    status: propTypes.oneOf(['warning', 'error', 'loading', 'valid']),
     initialFocus: propTypes.bool,
 
     onBlur: propTypes.func,

--- a/src/common-prop-types.js
+++ b/src/common-prop-types.js
@@ -1,10 +1,5 @@
 import propTypes from '@dhis2/prop-types'
 
-export const statusPropType = propTypes.mutuallyExclusive(
-    ['valid', 'warning', 'error'],
-    propTypes.bool
-)
-
 export const buttonVariantPropType = propTypes.mutuallyExclusive(
     ['primary', 'secondary', 'destructive'],
     propTypes.bool

--- a/src/icons/Status.js
+++ b/src/icons/Status.js
@@ -168,27 +168,25 @@ Loading.propTypes = {
     className: propTypes.string,
 }
 
-export const StatusIconNoDefault = ({
-    error,
-    warning,
-    valid,
-    loading,
-    className,
-}) =>
-    valid ? (
-        <Valid className={className} />
-    ) : warning ? (
-        <Warning className={className} />
-    ) : error ? (
-        <Error className={className} />
-    ) : loading ? (
-        <Loading className={className} />
-    ) : null
+export const StatusIcon = ({ status, defaultTo: DefaultTo, className }) => {
+    switch (status) {
+        case 'info':
+            return <Info className={className} />
+        case 'warning':
+            return <Warning className={className} />
+        case 'loading':
+            return <Loading className={className} />
+        case 'error':
+            return <Error className={className} />
+        case 'valid':
+            return <Valid className={className} />
+        default:
+            return DefaultTo ? <DefaultTo className={className} /> : null
+    }
+}
 
-StatusIconNoDefault.propTypes = {
-    valid: propTypes.bool,
-    error: propTypes.bool,
-    warning: propTypes.bool,
-    loading: propTypes.bool,
+StatusIcon.propTypes = {
+    status: propTypes.oneOf(['info', 'warning', 'error', 'loading', 'valid']),
+    defaultTo: propTypes.elementType,
     className: propTypes.string,
 }

--- a/stories/AlertBar.stories.js
+++ b/stories/AlertBar.stories.js
@@ -23,22 +23,22 @@ storiesOf('AlertBar', module)
     .add('States', () => (
         <React.Fragment>
             <AlertBar permanent>Default (info)</AlertBar>
-            <AlertBar permanent success>
-                Success
+            <AlertBar permanent status="valid">
+                Valid
             </AlertBar>
-            <AlertBar permanent warning>
+            <AlertBar permanent status="warning">
                 Warning
             </AlertBar>
-            <AlertBar permanent critical>
-                Critical
+            <AlertBar permanent status="error">
+                Error
             </AlertBar>
         </React.Fragment>
     ))
     .add('Auto hiding', () => (
         <React.Fragment>
             <AlertBar permanent>Permanent never auto-hides</AlertBar>
-            <AlertBar warning>Warning never auto-hides</AlertBar>
-            <AlertBar critical>Critial never auto-hides</AlertBar>
+            <AlertBar status="warning">Warning never auto-hides</AlertBar>
+            <AlertBar status="error">Error never auto-hides</AlertBar>
             <AlertBar duration={10000}>
                 Custom duration, hides after 10s
             </AlertBar>

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -128,7 +128,7 @@ storiesOf('Checkbox', module)
             value="ex"
             name="Ex"
             label="Checkbox"
-            valid
+            status="valid"
             checked
             onChange={logger}
         />
@@ -139,7 +139,7 @@ storiesOf('Checkbox', module)
             value="ex"
             name="Ex"
             label="Checkbox"
-            warning
+            status="warning"
             checked
             onChange={logger}
         />
@@ -150,7 +150,7 @@ storiesOf('Checkbox', module)
             value="ex"
             name="Ex"
             label="Checkbox"
-            error
+            status="error"
             checked
             onChange={logger}
         />

--- a/stories/FileInputField.stories.js
+++ b/stories/FileInputField.stories.js
@@ -92,21 +92,21 @@ storiesOf('FileInputField', module)
                 label="upload something"
                 buttonLabel="Valid"
                 name="valid"
-                valid
+                status="valid"
             />
             <FileInputField
                 onChange={onChange}
                 label="upload something"
                 buttonLabel="Warning"
                 name="warning"
-                warning
+                status="warning"
             />
             <FileInputField
                 onChange={onChange}
                 label="upload something"
                 buttonLabel="Error"
                 name="error"
-                error
+                status="error"
                 validationText="Something went wrong"
             />
         </>

--- a/stories/Help.stories.js
+++ b/stories/Help.stories.js
@@ -6,10 +6,14 @@ storiesOf('Help', module)
     .add('Default', () => <Help>Allow me to be of assistance</Help>)
 
     .add('Status: Warning', () => (
-        <Help warning>Allow me to be of assistance</Help>
+        <Help status="warning">Allow me to be of assistance</Help>
     ))
-    .add('Status: Valid', () => <Help valid>Allow me to be of assistance</Help>)
-    .add('Status: Error', () => <Help error>Allow me to be of assistance</Help>)
+    .add('Status: Valid', () => (
+        <Help status="valid">Allow me to be of assistance</Help>
+    ))
+    .add('Status: Error', () => (
+        <Help status="error">Allow me to be of assistance</Help>
+    ))
     .add('Text overflow', () => (
         <div style={{ width: 200 }}>
             <Help>I take up more space than my container</Help>

--- a/stories/InputField.stories.js
+++ b/stories/InputField.stories.js
@@ -39,21 +39,21 @@ function createStory(name, props) {
         .add('Focus', () => <InputField {...props} initialFocus />)
 
         .add('Status: Valid', () => (
-            <InputField {...props} value="This value is valid" valid />
+            <InputField {...props} value="This value is valid" status="valid" />
         ))
 
         .add('Status: Warning', () => (
             <InputField
                 {...props}
                 value="This value produces a warning"
-                warning
+                status="warning"
             />
         ))
 
         .add('Status: Error', () => (
             <InputField
                 {...props}
-                error
+                status="error"
                 value="This value produces an error"
                 helpText="This is some help text to advice what this input actually is."
                 validationText="This describes the error, if a message is supplied."
@@ -64,7 +64,7 @@ function createStory(name, props) {
             <InputField
                 {...props}
                 value="This value produces a loading state"
-                loading
+                status="loading"
             />
         ))
 

--- a/stories/Radio.stories.js
+++ b/stories/Radio.stories.js
@@ -123,7 +123,7 @@ storiesOf('Radio', module)
         <Radio
             name="Ex"
             label="Radio"
-            valid
+            status="valid"
             checked
             value="valid"
             onChange={logger}
@@ -134,7 +134,7 @@ storiesOf('Radio', module)
         <Radio
             name="Ex"
             label="Radio"
-            warning
+            status="warning"
             checked
             value="warning"
             onChange={logger}
@@ -145,7 +145,7 @@ storiesOf('Radio', module)
         <Radio
             name="Ex"
             label="Radio"
-            error
+            status="error"
             checked
             value="error"
             onChange={logger}

--- a/stories/SelectField.stories.js
+++ b/stories/SelectField.stories.js
@@ -45,7 +45,7 @@ function createStory(name, props) {
                 helpText="A helpful text."
                 validationText="Totally valid"
                 value="1"
-                valid
+                status="valid"
             >
                 {options}
             </SelectField>
@@ -57,7 +57,7 @@ function createStory(name, props) {
                 helpText="A helpful text."
                 validationText="Hm, not quite, I warn thee!"
                 value="1"
-                warning
+                status="warning"
             >
                 {options}
             </SelectField>
@@ -69,14 +69,14 @@ function createStory(name, props) {
                 helpText="A helpful text."
                 validationText="NO! TOTALLY WRONG!"
                 value="2"
-                error
+                status="error"
             >
                 {options}
             </SelectField>
         ))
 
         .add('With loading status', () => (
-            <SelectField {...props} value="1" loading>
+            <SelectField {...props} value="1" status="loading">
                 {options}
             </SelectField>
         ))

--- a/stories/Switch.stories.js
+++ b/stories/Switch.stories.js
@@ -40,7 +40,7 @@ storiesOf('Switch', module)
         <Switch
             name="Ex"
             checked
-            valid
+            status="valid"
             initialFocus
             label="Switch"
             onChange={logger}
@@ -51,7 +51,7 @@ storiesOf('Switch', module)
         <Switch
             name="Ex"
             checked
-            warning
+            status="warning"
             initialFocus
             label="Switch"
             onChange={logger}
@@ -62,7 +62,7 @@ storiesOf('Switch', module)
         <Switch
             name="Ex"
             checked
-            error
+            status="error"
             initialFocus
             label="Switch"
             onChange={logger}
@@ -74,13 +74,31 @@ storiesOf('Switch', module)
     ))
 
     .add('Valid', () => (
-        <Switch name="Ex" label="Switch" checked valid onChange={logger} />
+        <Switch
+            name="Ex"
+            label="Switch"
+            checked
+            status="valid"
+            onChange={logger}
+        />
     ))
 
     .add('Warning', () => (
-        <Switch name="Ex" label="Switch" checked warning onChange={logger} />
+        <Switch
+            name="Ex"
+            label="Switch"
+            checked
+            status="warning"
+            onChange={logger}
+        />
     ))
 
     .add('Error', () => (
-        <Switch name="Ex" label="Switch" checked error onChange={logger} />
+        <Switch
+            name="Ex"
+            label="Switch"
+            checked
+            status="error"
+            onChange={logger}
+        />
     ))

--- a/stories/TextAreaField.stories.js
+++ b/stories/TextAreaField.stories.js
@@ -41,7 +41,7 @@ storiesOf('TextAreaField', module)
             onChange={() => {}}
             name="textarea"
             value="This value is valid"
-            valid
+            status="valid"
         />
     ))
 
@@ -50,7 +50,7 @@ storiesOf('TextAreaField', module)
             onChange={() => {}}
             name="textarea"
             value="This value produces a warning"
-            warning
+            status="warning"
         />
     ))
 
@@ -58,7 +58,7 @@ storiesOf('TextAreaField', module)
         <TextAreaField
             onChange={() => {}}
             name="textarea"
-            error
+            status="error"
             value="This value produces an error"
             helpText="This is some help text to advice what this input actually is."
             validationText="This describes the error, if a message is supplied."
@@ -70,7 +70,7 @@ storiesOf('TextAreaField', module)
             onChange={() => {}}
             name="textarea"
             value="This value produces a loading state"
-            loading
+            status="loading"
         />
     ))
 


### PR DESCRIPTION
Proposal for a slight API change for StatusIcon as discussed on slack. This affects a couple of other areas as well. The reasoning behind this is that the current API for statusicon uses flags for a concept that is more accurately expressed as an enum.

We're now catching this with a special propType rule, but I think for the end-user and us the API contract would be more clear if we'd accept a single prop that accepts a status string. That way it's immediately clear that it's mutually exclusive. 

p.s.: not all the components accept all the statuses that the StatusIcon supports. So I haven't inherited from StatusIcon's props, but defined the accepted types separately. Something to discuss.

p.p.s.: @HendrikThePendric mentioned the mutually exclusive booleans are also used in other areas. For consistency accepting this would probably mean taking a look at those as well

Still todo if we want this:

- [ ] Update jsdoc
