### PR TITLE
fix(split-button): remove unused styles

### DIFF
--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -73,15 +73,6 @@ class SplitButton extends Component {
                     }
 
                     div > :global(button:first-child) {
-                        margin-left: 0;
-                    }
-
-                    div > :global(button:not(:first-child):not(:last-child)) {
-                        border-radius: 0;
-                        border-right: 0;
-                    }
-
-                    div > :global(button:first-child) {
                         border-top-right-radius: 0;
                         border-bottom-right-radius: 0;
                         border-right: 0;


### PR DESCRIPTION
I noticed a few redundant styles whilst working on the the closed PR https://github.com/dhis2/ui-core/pull/501. This PR removes them.