### PR TITLE
refactor: alert bar and status icon

### DIFF
--- a/src/AlertBar.js
+++ b/src/AlertBar.js
@@ -105,7 +105,7 @@ class AlertBar extends PureComponent {
         }
 
         const info = !critical && !success && !warning
-        const iconProps = { icon, critical, success, warning }
+        const iconProps = { icon, critical, success, warning, info }
 
         return (
             <div

--- a/src/AlertBar/Icon.js
+++ b/src/AlertBar/Icon.js
@@ -1,32 +1,26 @@
 import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
-import { statusPropType } from '../common-prop-types.js'
-
-import { Error, Info, Valid, Warning } from '../icons/Status.js'
+import { StatusIcon } from '../icons/Status.js'
 import { spacers } from '../theme.js'
 
-const Icon = ({ icon, success, warning, critical }) => {
+const Icon = ({ icon, success, warning, critical, info }) => {
     if (icon === false) {
         return null
     }
 
-    let IconComponent
-    if (React.isValidElement(icon)) {
-        IconComponent = icon
-    } else if (critical) {
-        IconComponent = <Error />
-    } else if (warning) {
-        IconComponent = <Warning />
-    } else if (success) {
-        IconComponent = <Valid />
-    } else {
-        IconComponent = <Info />
-    }
-
     return (
         <div>
-            {IconComponent}
+            {React.isValidElement(icon) ? (
+                icon
+            ) : (
+                <StatusIcon
+                    valid={success}
+                    error={critical}
+                    warning={warning}
+                    info={info}
+                />
+            )}
             <style jsx>{`
                 div {
                     margin-right: ${spacers.dp16};
@@ -41,12 +35,17 @@ const Icon = ({ icon, success, warning, critical }) => {
 }
 
 const iconPropType = propTypes.oneOfType([propTypes.bool, propTypes.element])
+const alertStatePropType = propTypes.mutuallyExclusive(
+    ['success', 'warning', 'critical', 'info'],
+    propTypes.bool
+)
 
 Icon.propTypes = {
     icon: iconPropType,
-    success: statusPropType,
-    warning: statusPropType,
-    critical: statusPropType,
+    success: alertStatePropType,
+    warning: alertStatePropType,
+    info: alertStatePropType,
+    critical: alertStatePropType,
 }
 
 export { Icon, iconPropType }

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -6,7 +6,7 @@ import { statusPropType, sizePropType } from './common-prop-types.js'
 import { Button } from './Button.js'
 import { spacers } from './theme.js'
 import { Upload } from './icons/Upload.js'
-import { StatusIconNoDefault } from './icons/Status.js'
+import { StatusIcon } from './icons/Status.js'
 
 /**
  * @module
@@ -68,11 +68,7 @@ class FileInput extends PureComponent {
                 >
                     {buttonLabel}
                 </Button>
-                <StatusIconNoDefault
-                    error={error}
-                    valid={valid}
-                    warning={warning}
-                />
+                <StatusIcon error={error} valid={valid} warning={warning} />
 
                 <style jsx>{`
                     input {

--- a/src/Input.js
+++ b/src/Input.js
@@ -5,7 +5,7 @@ import cx from 'classnames'
 
 import { statusPropType } from './common-prop-types.js'
 import { theme, colors, spacers } from './theme.js'
-import { StatusIconNoDefault } from './icons/Status.js'
+import { StatusIcon } from './icons/Status.js'
 
 const styles = css`
     .input {
@@ -141,7 +141,7 @@ export class Input extends Component {
                 />
 
                 <div className="status-icon">
-                    <StatusIconNoDefault
+                    <StatusIcon
                         error={error}
                         valid={valid}
                         loading={loading}

--- a/src/Select.js
+++ b/src/Select.js
@@ -7,7 +7,7 @@ import { statusPropType } from './common-prop-types.js'
 import { theme, colors, spacers } from './theme.js'
 
 import { ArrowDown } from './icons/Arrow.js'
-import { StatusIconNoDefault } from './icons/Status.js'
+import { StatusIcon } from './icons/Status.js'
 
 const TailIcon = () => (
     <div>
@@ -190,7 +190,7 @@ export class Select extends Component {
                 <div className="status-icon">
                     <TailIcon />
 
-                    <StatusIconNoDefault
+                    <StatusIcon
                         error={error}
                         valid={valid}
                         loading={loading}

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react'
 import cx from 'classnames'
 
 import { statusPropType } from './common-prop-types.js'
-import { StatusIconNoDefault } from './icons/Status.js'
+import { StatusIcon } from './icons/Status.js'
 
 import { styles } from './TextArea/styles.js'
 
@@ -128,7 +128,7 @@ export class TextArea extends PureComponent {
                 />
 
                 <div className="status-icon">
-                    <StatusIconNoDefault
+                    <StatusIcon
                         error={error}
                         valid={valid}
                         loading={loading}

--- a/src/icons/Status.js
+++ b/src/icons/Status.js
@@ -179,17 +179,21 @@ export const StatusIcon = ({
 }) => {
     if (error) {
         return <Error className={className} />
-    } else if (warning) {
-        return <Warning className={className} />
-    } else if (valid) {
-        return <Valid className={className} />
-    } else if (loading) {
-        return <Loading className={className} />
-    } else if (info) {
-        return <Info className={className} />
-    } else {
-        return defaultTo
     }
+    if (warning) {
+        return <Warning className={className} />
+    }
+    if (valid) {
+        return <Valid className={className} />
+    }
+    if (loading) {
+        return <Loading className={className} />
+    }
+    if (info) {
+        return <Info className={className} />
+    }
+
+    return defaultTo
 }
 
 StatusIcon.defaultProps = {

--- a/src/icons/Status.js
+++ b/src/icons/Status.js
@@ -173,7 +173,9 @@ export const StatusIconNoDefault = ({
     warning,
     valid,
     loading,
+    info,
     className,
+    defaultTo,
 }) =>
     valid ? (
         <Valid className={className} />
@@ -183,12 +185,22 @@ export const StatusIconNoDefault = ({
         <Error className={className} />
     ) : loading ? (
         <Loading className={className} />
-    ) : null
+    ) : info ? (
+        <Info className={className} />
+    ) : (
+        defaultTo
+    )
+
+StatusIconNoDefault.defaultProps = {
+    defaultTo: null,
+}
 
 StatusIconNoDefault.propTypes = {
     valid: propTypes.bool,
     error: propTypes.bool,
     warning: propTypes.bool,
     loading: propTypes.bool,
+    info: propTypes.bool,
     className: propTypes.string,
+    defaultTo: propTypes.element,
 }

--- a/src/icons/Status.js
+++ b/src/icons/Status.js
@@ -176,20 +176,21 @@ export const StatusIcon = ({
     info,
     className,
     defaultTo,
-}) =>
-    valid ? (
-        <Valid className={className} />
-    ) : warning ? (
-        <Warning className={className} />
-    ) : error ? (
-        <Error className={className} />
-    ) : loading ? (
-        <Loading className={className} />
-    ) : info ? (
-        <Info className={className} />
-    ) : (
-        defaultTo
-    )
+}) => {
+    if (error) {
+        return <Error className={className} />
+    } else if (warning) {
+        return <Warning className={className} />
+    } else if (valid) {
+        return <Valid className={className} />
+    } else if (loading) {
+        return <Loading className={className} />
+    } else if (info) {
+        return <Info className={className} />
+    } else {
+        return defaultTo
+    }
+}
 
 StatusIcon.defaultProps = {
     defaultTo: null,

--- a/src/icons/Status.js
+++ b/src/icons/Status.js
@@ -168,7 +168,7 @@ Loading.propTypes = {
     className: propTypes.string,
 }
 
-export const StatusIconNoDefault = ({
+export const StatusIcon = ({
     error,
     warning,
     valid,
@@ -191,11 +191,11 @@ export const StatusIconNoDefault = ({
         defaultTo
     )
 
-StatusIconNoDefault.defaultProps = {
+StatusIcon.defaultProps = {
     defaultTo: null,
 }
 
-StatusIconNoDefault.propTypes = {
+StatusIcon.propTypes = {
     valid: propTypes.bool,
     error: propTypes.bool,
     warning: propTypes.bool,


### PR DESCRIPTION
- Added `info` and `defaultTo` props to status-icon
- Rename `StatusIconNoDefault` to `StatusIcon`
- Let AlertBar/Icon use `StatusIcon` to simplify component code