### PR TITLE
refactor(checkbox): change outline to be in document flow

### DIFF
--- a/src/Checkbox/Icon.js
+++ b/src/Checkbox/Icon.js
@@ -71,17 +71,13 @@ export const Icon = ({
             {icons.styles}
             <style jsx>{`
                 div {
-                    position: relative;
+                    border: 2px solid transparent;
+                    border-radius: 4px;
                     margin: 0 6px 0 0;
                 }
 
-                .focus:before {
-                    content: '';
-                    position: absolute;
-                    border: 2px solid ${colors.blue600};
-                    border-radius: 4px;
-                    width: 100%;
-                    height: 100%;
+                div.focus {
+                    border-color: ${colors.blue600};
                 }
             `}</style>
         </div>

--- a/src/Checkbox/Icon.js
+++ b/src/Checkbox/Icon.js
@@ -71,13 +71,12 @@ export const Icon = ({
             {icons.styles}
             <style jsx>{`
                 div {
-                    border: 2px solid transparent;
                     border-radius: 4px;
                     margin: 0 6px 0 0;
                 }
 
                 div.focus {
-                    border-color: ${colors.blue600};
+                    box-shadow: inset 0 0 0 2px ${colors.blue600};
                 }
             `}</style>
         </div>


### PR DESCRIPTION
I ran into something where the checkbox icon was rendered over the filter input in the `Select` because of the relative positioning on the checkbox icon wrapper:

<img width="345" alt="Screenshot 2019-10-16 at 17 07 38" src="https://user-images.githubusercontent.com/7355199/66932171-7ba83700-f037-11e9-80fd-1eb675635a31.png">

I could fix this from the Select, by setting a higher z-index, but this would fix it as well _and_ mean other components also won't have to deal with this problem.

Appearance of the checkbox before the fix:

<img width="188" alt="Screenshot 2019-10-16 at 18 32 16" src="https://user-images.githubusercontent.com/7355199/66939541-8668c900-f043-11e9-8171-666bf9734480.png">

Appearance of the checkbox after the fix:

<img width="188" alt="Screenshot 2019-10-16 at 18 32 07" src="https://user-images.githubusercontent.com/7355199/66939556-8d8fd700-f043-11e9-8635-8575df603479.png">

You can see that after the fix, there is more space between the border and the checkbox. That's because the svg it's wrapping contains some whitespace around it:

<img width="425" alt="Screenshot 2019-10-16 at 18 38 14" src="https://user-images.githubusercontent.com/7355199/66939957-5a017c80-f044-11e9-94f0-1ce336828228.png">

And that's what the border is wrapping around. To fix that, we should crop the svg to just the checkbox. That way there would be no need for relative/absolute positioning, and everything would still look the same.