### PR TITLE
 docs(specs): components that requires positioning

### DIFF
--- a/cypress/integration/Menu/position.feature
+++ b/cypress/integration/Menu/position.feature
@@ -1,0 +1,51 @@
+Feature: Position of a menu component
+
+    # default max width: 380px; default max height: 380px
+    Background:
+        Given the menu component has a height and width of its default maximum
+
+    Scenario: Default rendering
+        Given there is enough space between the anchor's bottom and the body's bottom to fit the default maximum
+        When the menu is opened
+        Then the menu is below the anchor
+        And the left of the menu is aligned with the left of the anchor
+
+    Scenario: Flipped vertically
+        Given there is not enough space between the anchor's bottom and the body's bottom to fit the default maximum
+        And there is not enough space between the anchor's top and the body's top to fit the default maximum
+        When the menu is opened
+        Then the menu is above the anchor
+        And the left of the menu is aligned with the left of the anchor
+
+    Scenario: Less than 368px and more than 50px available space below and above anchor
+        Given there is not enough space between the anchor's bottom and the body's bottom to fit the default maximum
+        And there is not enough space between the anchor's top and the body's top to fit the default maximum
+        But there is more than 50px of available space between the anchor's bottom and the body's bottom
+        When the menu is opened
+        Then the menu is below the anchor
+        And the height of the menu is reduced to fit
+
+    # ¯\_(ツ)_/¯
+    # This will cause the menu always to be off screen, but that's the apps fault
+    Scenario: Less than 50px available space below and above anchor
+        Given there is not enough space between the anchor's top and the body's top to fit the default maximum
+        And there is not enough space between the anchor's bottom and the body's bottom to fit the default maximum
+        When the menu is opened
+        Then the menu is below the anchor
+        And the heght of the menu is not reduced below 50px
+
+    Scenario: Flipped horizontally
+        Given the space between the anchor's right and the body's right is less than the horizontal minimum space
+        And the space between the anchor's left and the body's left is at least the horizontal minimum space
+        When the menu is opened
+        Then the right of the menu is aligned with the right of the anchor
+        And the menu is below the anchor
+
+    # ¯\_(ツ)_/¯
+    # This will cause the menu always to be off screen, but that's the apps fault
+    Scenario: Forced body overflow
+        Given the space between the anchor's right and the body's right is less than the horizontal minimum space
+        And the space between the anchor's left and the body's left is less than the horizontal minimum space
+        When the menu is opened
+        Then the left of the menu is aligned with the left of the anchor
+        And the menu is rendered below the anchor

--- a/cypress/integration/Popover/position.feature
+++ b/cypress/integration/Popover/position.feature
@@ -1,0 +1,31 @@
+Feature: Popover positioning
+
+    Background:
+        Given the popover has a width of 360px and height of 200px
+
+    Scenario: Spacing between anchor and popover
+        When the anchor is clicked
+        Then there is some space between the anchor and the popover
+
+    Scenario: Default positioning
+        Given there is enough space between the anchor's top and the body's top to fit the Popover
+        When the anchor is clicked
+        Then the popover is rendered above the the anchor
+        And the horizontal center of the popover is aligned with the horizontal center of the anchor
+
+    Scenario: Flipped vertical
+        Given there is not enough space between the anchor's top and the body's top to fit the Popover
+        And there is enough space between the anchor's bottom and the body's bottom to fit the Popover
+        When the anchor is clicked
+        Then the popover is rendered below the anchor
+        And the horizontal center of the popover is aligned with the horizontal center of the anchor
+
+    Scenario: Adjusted width
+        Given there is not enough space between the anchor's top and the body's top to fit the Popover
+        And there is not enough space between the anchor's bottom and the body's bottom to fit the Popover
+        When the anchor is clicked
+        Then the popover is rendered above the anchor
+        And the horizontal center of the popover is aligned with the horizontal center of the anchor
+        And the popover width is reduced to fit in the available space
+
+        #!!Note: this is a exact copy of tooltip positioning

--- a/cypress/integration/Select/position.feature
+++ b/cypress/integration/Select/position.feature
@@ -1,0 +1,25 @@
+Feature: Position of select menu dropdown
+
+    Background:
+        Given the select menu dropdown has a height of 368px
+        And the select menu dropdown has a width of 280px
+
+    Scenario: Default rendering
+        Given there is enough space between the anchor's bottom and the body's bottom to fit the Select's menu
+        When the menu is opened
+        Then it is rendered below the select
+        And the left of the select is aligned with the left of the anchor
+
+    Scenario: Flipped rendering when insufficient space below
+        Given there is not enough space between the anchor's bottom and the body's bottom to fit the Select's menu
+        And there is enough space between the anchor's top and the body's top to fit the Select's menu
+        When the menu is opened
+        Then it is rendered above the select
+        And the left of the select is aligned with the left of the anchor
+
+    Scenario: A select with less than 368px available space below and above
+        Given there is not enough space between the anchor's bottom and the body's bottom to fit the Select's menu
+        And there is not enough space between the anchor's top and the body's top to fit the Select's menu
+        When the menu is opened
+        Then it is rendered below the select
+        And the height of the select dropdown menu is reduced to fit within the <body> element

--- a/cypress/integration/Tooltip/position.feature
+++ b/cypress/integration/Tooltip/position.feature
@@ -1,0 +1,38 @@
+Feature: Tooltip positioning
+
+    Background:
+        Given the tooltip has a width of 300px and height of 28px
+
+    Scenario: Spacing between anchor and tooltip
+        When the anchor is clicked
+        Then there is some space between the anchor and the tooltip
+
+    Scenario: Default positioning
+        Given there is enough space between the anchor's top and the body's top to fit the Tooltip
+        When the anchor is clicked
+        Then the tooltip is rendered above the the anchor
+        And the horizontal center of the tooltip is aligned with the horizontal center of the anchor
+
+    Scenario: Flipped vertical
+        Given there is not enough space between the anchor's top and the body's top to fit the Tooltip
+        And there is enough space between the anchor's bottom and the body's bottom to fit the Tooltip
+        When the anchor is clicked
+        Then the tooltip is rendered below the anchor
+        And the horizontal center of the tooltip is aligned with the horizontal center of the anchor
+
+    Scenario: Adjusted horiztonal position
+        Given there is enough space between the anchor's top and the body's top to fit the Tooltip
+        And there is enough space between the body's left and the body's right to fit the Tooltip
+        And the Tooltip doesn't use more than 50% of the space between the body's sides and the anchor's sides
+        When the anchor is clicked
+        Then the tooltip is rendered above the anchor
+        And the horizontal center of the tooltip is aligned with the horizontal center of the anchor
+
+    Scenario: Adjusted width
+        Given there is enough space between the anchor's top and the body's top to fit the Tooltip
+        And there is enough space between the body's left and the body's right to fit the Tooltip
+        And the Tooltip does use more than 50% of the space between the body's sides and the anchor's sides
+        When the anchor is clicked
+        Then the tooltip is rendered above the anchor
+        And the horizontal center of the tooltip is aligned with the horizontal center of the anchor
+        But the tooltip's width is reducesd to only take 50% of the space available next to the anchor

--- a/cypress/integration/position-utility/positions.feature
+++ b/cypress/integration/position-utility/positions.feature
@@ -1,0 +1,47 @@
+Feature: Generic position options
+
+    # *** Trying to be specific with positioning of the elements here, because just 'above' or 'below' etc. seems ambiguous
+
+    Background:
+        Given an anchor element
+        And a positioned element that is rendered when the user clicks on the anchor
+
+    Scenario: Top-middle position
+        When the positioned element is rendered
+        Then it is rendered above the the anchor element, the bottom of the positioned element immediately above the top of the anchor element
+        And it is horizontally center aligned with the anchor element
+
+    Scenario: Top-left position
+        When the positioned element is rendered
+        Then it is rendered above the the anchor element, the bottom of the positioned element immediately above the top of the anchor element
+        And it is horizontally left aligned with the anchor element
+
+    Scenario: Top-right position
+        When the positioned element is rendered
+        Then it is rendered above the the anchor element, the bottom of the positioned element immediately above the top of the anchor element
+        And it is horizontally right aligned with the anchor element
+
+    Scenario: Bottom-middle position
+        When the positioned element is rendered
+        Then it is rendered below the the anchor element, the top of the positioned element immediately below the bottom of the anchor element
+        And it is horizontally center aligned with the anchor element
+
+    Scenario: Bottom-left position
+        When the positioned element is rendered
+        Then it is rendered below the the anchor element, the top of the positioned element immediately below the bottom of the anchor element
+        And it is horizontally left aligned with the anchor element
+
+    Scenario: Bottom-right position
+        When the positioned element is rendered
+        Then it is rendered below the the anchor element, the top of the positioned element immediately below the bottom of the anchor element
+        And it is horizontally right aligned with the anchor element
+
+    Scenario: Left position
+        When the positioned element is rendered
+        Then it is rendered to the left the the anchor element, the right of the positioned element immediately to the left of the left boundary of the anchor element
+        And it is vertically top aligned with the anchor element
+
+    Scenario: Right position
+        When the positioned element is rendered
+        Then it is rendered to the right the the anchor element, the left of the positioned element immediately to the right of the right boundary of the anchor element
+        And it is vertically top aligned with the anchor element


### PR DESCRIPTION
First pass at specs for each component that requires positioning. A generic `position-options.feature` specs the available options/locations for positioning. This follows the [position utility discussion](https://github.com/dhis2/notes/blob/master/decisions/2019/10/15-popover-position.md).

@dhis2/team-apps, please add to and correct where necessary! I tried to keep the specs generic enough to apply to all situations, but with enough detail that they can actually be tested.

---

### Notes

I have covered the components that definitely need the position utility. There are also some 'maybe' components. These can 'reuse' the positioning in the specs, so do not have spec files.

- DropdownButton: use `menu` 
- SplitButton: use `menu`
- HeaderBar App menu: use `menu`
- HeaderBar Profile menu: use `menu`