### PR TITLE
docs(drop-menu): mark jsDoc comments as private to keep out of docs

### DIFF
--- a/src/DropMenu.js
+++ b/src/DropMenu.js
@@ -6,6 +6,7 @@ import { layers } from './theme.js'
 
 /**
  * @module
+ * @private
  * @param {DropMenu.PropTypes} props
  * @returns {React.Component}
  * @example import { DropMenu } from @dhis2/ui-core


### PR DESCRIPTION
I've inserted `@private` into both jsDocv blocks. Not sure if that is required... Feel free to remove one.