### PR TITLE
fix(select): align select with callback style changes

### DIFF
--- a/src/MultiSelect/Input.js
+++ b/src/MultiSelect/Input.js
@@ -21,8 +21,10 @@ const Input = ({
 }) => {
     const hasSelection = selected.length > 0
     const onClear = e => {
+        const data = { selected: [] }
+
         e.stopPropagation()
-        onChange([], e)
+        onChange(data, e)
     }
 
     return (

--- a/src/MultiSelect/Input.js
+++ b/src/MultiSelect/Input.js
@@ -22,7 +22,7 @@ const Input = ({
     const hasSelection = selected.length > 0
     const onClear = e => {
         e.stopPropagation()
-        onChange([])
+        onChange([], e)
     }
 
     return (

--- a/src/MultiSelect/Menu.js
+++ b/src/MultiSelect/Menu.js
@@ -11,19 +11,17 @@ const onDisabledClick = e => {
 
 const createHandler = ({ isActive, onChange, selected, value, label }) => e => {
     const clickedOption = { value, label }
-
     e.stopPropagation()
     e.preventDefault()
 
     // If the option is currently selected remove it from the array of selected options
     if (isActive) {
         const filtered = removeOption(clickedOption, selected)
-
-        return onChange(filtered)
+        return onChange(filtered, e)
     }
 
     // Otherwise, add it to selected
-    return onChange(selected.concat([clickedOption]))
+    return onChange(selected.concat([clickedOption]), e)
 }
 
 const Menu = ({ options, onChange, selected, empty }) => {

--- a/src/MultiSelect/Menu.js
+++ b/src/MultiSelect/Menu.js
@@ -17,11 +17,16 @@ const createHandler = ({ isActive, onChange, selected, value, label }) => e => {
     // If the option is currently selected remove it from the array of selected options
     if (isActive) {
         const filtered = removeOption(clickedOption, selected)
-        return onChange(filtered, e)
+        const data = { selected: filtered }
+
+        return onChange(data, e)
     }
 
     // Otherwise, add it to selected
-    return onChange(selected.concat([clickedOption]), e)
+    const data = {
+        selected: selected.concat([clickedOption]),
+    }
+    return onChange(data, e)
 }
 
 const Menu = ({ options, onChange, selected, empty }) => {

--- a/src/MultiSelect/Menu.js
+++ b/src/MultiSelect/Menu.js
@@ -9,7 +9,10 @@ const onDisabledClick = e => {
     e.preventDefault()
 }
 
-const createHandler = ({ isActive, onChange, selected, value, label }) => e => {
+const createHandler = ({ isActive, onChange, selected, value, label }) => (
+    unusedData,
+    e
+) => {
     const clickedOption = { value, label }
     e.stopPropagation()
     e.preventDefault()

--- a/src/MultiSelect/SelectionList.js
+++ b/src/MultiSelect/SelectionList.js
@@ -4,7 +4,10 @@ import { multiSelectedPropType } from '../common-prop-types.js'
 import { Chip } from '../Chip.js'
 import { removeOption, findOptionChild } from '../Select/option-helpers.js'
 
-const createRemoveHandler = ({ selected, onChange, value, label }) => e => {
+const createRemoveHandler = ({ selected, onChange, value, label }) => (
+    unusedData,
+    e
+) => {
     const clickedOption = { value, label }
     const filtered = removeOption(clickedOption, selected)
     const data = { selected: filtered }

--- a/src/MultiSelect/SelectionList.js
+++ b/src/MultiSelect/SelectionList.js
@@ -4,11 +4,11 @@ import { multiSelectedPropType } from '../common-prop-types.js'
 import { Chip } from '../Chip.js'
 import { removeOption, findOptionChild } from '../Select/option-helpers.js'
 
-const createRemoveHandler = ({ selected, onChange, value, label }) => () => {
+const createRemoveHandler = ({ selected, onChange, value, label }) => e => {
     const clickedOption = { value, label }
     const filtered = removeOption(clickedOption, selected)
 
-    onChange(filtered)
+    onChange(filtered, e)
 }
 
 const SelectionList = ({ selected, onChange, disabled, options }) => (

--- a/src/MultiSelect/SelectionList.js
+++ b/src/MultiSelect/SelectionList.js
@@ -7,8 +7,9 @@ import { removeOption, findOptionChild } from '../Select/option-helpers.js'
 const createRemoveHandler = ({ selected, onChange, value, label }) => e => {
     const clickedOption = { value, label }
     const filtered = removeOption(clickedOption, selected)
+    const data = { selected: filtered }
 
-    onChange(filtered, e)
+    onChange(data, e)
 }
 
 const SelectionList = ({ selected, onChange, disabled, options }) => (

--- a/src/MultiSelectOption.js
+++ b/src/MultiSelectOption.js
@@ -27,7 +27,10 @@ const MultiSelectOption = ({ label, active, disabled, onClick, className }) => (
             className={checkboxClassname}
             checked={active}
             label={label}
-            onChange={onClick}
+            onChange={(value, e) => {
+                // Discarding value here because onClick just expects the event
+                onClick(e)
+            }}
             disabled={disabled}
             dense
         />

--- a/src/MultiSelectOption.js
+++ b/src/MultiSelectOption.js
@@ -27,8 +27,8 @@ const MultiSelectOption = ({ label, active, disabled, onClick, className }) => (
             className={checkboxClassname}
             checked={active}
             label={label}
-            onChange={(value, e) => {
-                // Discarding value here because onClick just expects the event
+            onChange={(data, e) => {
+                // Discarding data here because onClick just expects the event
                 onClick(e)
             }}
             disabled={disabled}

--- a/src/MultiSelectOption.js
+++ b/src/MultiSelectOption.js
@@ -27,10 +27,7 @@ const MultiSelectOption = ({ label, active, disabled, onClick, className }) => (
             className={checkboxClassname}
             checked={active}
             label={label}
-            onChange={(data, e) => {
-                // Discarding data here because onClick just expects the event
-                onClick(e)
-            }}
+            onChange={onClick}
             disabled={disabled}
             dense
         />

--- a/src/Select/FilterableMenu.js
+++ b/src/Select/FilterableMenu.js
@@ -12,9 +12,8 @@ export class FilterableMenu extends Component {
         filter: '',
     }
 
-    onFilterChange = e => {
-        const filter = e.target.value
-        this.setState({ filter })
+    onFilterChange = ({ value }) => {
+        this.setState({ filter: value })
     }
 
     render() {

--- a/src/SingleSelect/Input.js
+++ b/src/SingleSelect/Input.js
@@ -22,7 +22,7 @@ const Input = ({
     const hasSelection = 'label' in selected && 'value' in selected
     const onClear = e => {
         e.stopPropagation()
-        onChange({})
+        onChange({}, e)
     }
 
     return (

--- a/src/SingleSelect/Input.js
+++ b/src/SingleSelect/Input.js
@@ -21,8 +21,10 @@ const Input = ({
 }) => {
     const hasSelection = 'label' in selected && 'value' in selected
     const onClear = e => {
+        const data = { selected: {} }
+
         e.stopPropagation()
-        onChange({}, e)
+        onChange(data, e)
     }
 
     return (

--- a/src/SingleSelect/Menu.js
+++ b/src/SingleSelect/Menu.js
@@ -42,7 +42,7 @@ const Menu = ({
         const onClick = e => {
             e.stopPropagation()
 
-            onChange({ value, label })
+            onChange({ value, label }, e)
             handleClose()
             handleFocusInput()
         }

--- a/src/SingleSelect/Menu.js
+++ b/src/SingleSelect/Menu.js
@@ -40,9 +40,10 @@ const Menu = ({
         // Active means the option is currently selected
         const isActive = value === selected.value && label === selected.label
         const onClick = e => {
+            const data = { selected: { value, label } }
             e.stopPropagation()
 
-            onChange({ value, label }, e)
+            onChange(data, e)
             handleClose()
             handleFocusInput()
         }

--- a/src/SingleSelect/Menu.js
+++ b/src/SingleSelect/Menu.js
@@ -39,7 +39,7 @@ const Menu = ({
 
         // Active means the option is currently selected
         const isActive = value === selected.value && label === selected.label
-        const onClick = e => {
+        const onClick = (unusedData, e) => {
             const data = { selected: { value, label } }
             e.stopPropagation()
 

--- a/src/SingleSelectOption.js
+++ b/src/SingleSelectOption.js
@@ -25,7 +25,7 @@ const SingleSelectOption = ({
             disabled,
             active,
         })}
-        onClick={onClick}
+        onClick={e => onClick({}, e)}
     >
         {label}
 

--- a/stories/MultiSelect.stories.js
+++ b/stories/MultiSelect.stories.js
@@ -11,7 +11,7 @@ const CheckIcon = () => (
 )
 
 const CustomOption = ({ label, description, icon, active, onClick }) => (
-    <a className={cx('option', { active })} onClick={onClick}>
+    <a className={cx('option', { active })} onClick={e => onClick({}, e)}>
         {icon && <div className="option-icon">{icon}</div>}
         <div className="text">
             <h3 className="label">{label}</h3>

--- a/stories/MultiSelect.stories.js
+++ b/stories/MultiSelect.stories.js
@@ -80,8 +80,9 @@ const longLabel =
 
 const defaultProps = {
     selected: [{ value: '1', label: 'one' }],
-    onChange: selected =>
-        alert(`Selected changed to: ${JSON.stringify(selected, null, 2)}`),
+    onChange: selected => {
+        alert(`Selected changed to: ${JSON.stringify(selected, null, 2)}`)
+    },
     tabIndex: '0',
 }
 

--- a/stories/MultiSelect.stories.js
+++ b/stories/MultiSelect.stories.js
@@ -80,7 +80,7 @@ const longLabel =
 
 const defaultProps = {
     selected: [{ value: '1', label: 'one' }],
-    onChange: selected => {
+    onChange: ({ selected }) => {
         alert(`Selected changed to: ${JSON.stringify(selected, null, 2)}`)
     },
     tabIndex: '0',

--- a/stories/SingleSelect.stories.js
+++ b/stories/SingleSelect.stories.js
@@ -87,7 +87,7 @@ const longLabel =
 
 const defaultProps = {
     selected: { value: '1', label: 'one' },
-    onChange: selected => {
+    onChange: ({ selected }) => {
         alert(`Selected changed to: ${JSON.stringify(selected, null, 2)}`)
     },
     tabIndex: '0',

--- a/stories/SingleSelect.stories.js
+++ b/stories/SingleSelect.stories.js
@@ -18,7 +18,7 @@ const CheckIcon = () => (
 )
 
 const CustomOption = ({ label, description, icon, active, onClick }) => (
-    <a className={cx('option', { active })} onClick={onClick}>
+    <a className={cx('option', { active })} onClick={e => onClick({}, e)}>
         {icon && <div className="option-icon">{icon}</div>}
         <div className="text">
             <h3 className="label">{label}</h3>

--- a/stories/SingleSelect.stories.js
+++ b/stories/SingleSelect.stories.js
@@ -87,8 +87,9 @@ const longLabel =
 
 const defaultProps = {
     selected: { value: '1', label: 'one' },
-    onChange: selected =>
-        alert(`Selected changed to: ${JSON.stringify(selected, null, 2)}`),
+    onChange: selected => {
+        alert(`Selected changed to: ${JSON.stringify(selected, null, 2)}`)
+    },
     tabIndex: '0',
 }
 


### PR DESCRIPTION
This aligns the Select components with the changes in callback style. Things that aren't done yet:

#### ~~1. Property name for cb object~~ ✅ resolved (`selected`)

Currently onChange will be called with the new value for `selected`, and the event. But I understand that the intention is to use an object as the first argument. I wasn't sure what name we'd want to use there. Maybe just `selected`? Suggestions are welcome.

#### ~~2. Select option cb style~~ ✅ resolved (our style of cb)

We have to choose what to support by default for the callback style we supply to the options. We supply a callback that expects just an event, so it could be passed to an element like so: `onClick={onClick}`. I've gone with keeping that style, and am handling the exception in our MultiSelect [here](https://github.com/dhis2/ui-core/pull/566/files#diff-30592b1d577759c4462fd708b2a517cbR30). The MultiSelect option is an exception because it uses our checkbox, and thus uses the `obj, event` style.

That seems simplest to me for the user, as they can now still attach it to say, a link, and it'll work. We could also change this though, and choose to support the other style by default. Which does mean that it'd break if attached to a native element without any wrapping. What would everyone prefer here?

(Or we could change style altogether, and supply the user with our onChange cb. But that would really burden the user with logic that I think we should be handling in the lib.)