### PR TITLE
fix: align focus and blur handlers with change handler

### DIFF
--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -27,41 +27,28 @@ class Checkbox extends Component {
     }
 
     handleChange = e => {
-        const { onChange } = this.props
-
-        if (onChange) {
-            onChange(
-                {
-                    value: this.props.value,
-                    name: this.props.name,
-                    checked: !this.props.checked,
-                },
-                e
-            )
+        if (this.props.onChange) {
+            this.props.onChange(this.getHandlerObject(), e)
         }
     }
 
     handleBlur = e => {
-        const { onBlur, disabled } = this.props
-
-        if (disabled) {
-            return
-        }
-
-        if (onBlur) {
-            onBlur(e)
+        if (this.props.onBlur) {
+            this.props.onBlur(this.getHandlerObject(), e)
         }
     }
 
     handleFocus = e => {
-        const { onFocus, disabled } = this.props
-
-        if (disabled) {
-            return
+        if (this.props.onFocus) {
+            this.props.onFocus(this.getHandlerObject(), e)
         }
+    }
 
-        if (onFocus) {
-            onFocus(e)
+    getHandlerObject() {
+        return {
+            value: this.props.value,
+            name: this.props.name,
+            checked: !this.props.checked,
         }
     }
 

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -28,23 +28,23 @@ class Checkbox extends Component {
 
     handleChange = e => {
         if (this.props.onChange) {
-            this.props.onChange(this.getHandlerObject(), e)
+            this.props.onChange(this.createHandlerPayload(), e)
         }
     }
 
     handleBlur = e => {
         if (this.props.onBlur) {
-            this.props.onBlur(this.getHandlerObject(), e)
+            this.props.onBlur(this.createHandlerPayload(), e)
         }
     }
 
     handleFocus = e => {
         if (this.props.onFocus) {
-            this.props.onFocus(this.getHandlerObject(), e)
+            this.props.onFocus(this.createHandlerPayload(), e)
         }
     }
 
-    getHandlerObject() {
+    createHandlerPayload() {
         return {
             value: this.props.value,
             name: this.props.name,

--- a/src/Input.js
+++ b/src/Input.js
@@ -94,32 +94,27 @@ export class Input extends Component {
     }
 
     handleChange = e => {
-        const { onChange } = this.props
-
-        if (onChange) {
-            onChange(
-                {
-                    value: e.target.value,
-                    name: this.props.name,
-                },
-                e
-            )
+        if (this.props.onChange) {
+            this.props.onChange(this.createHandlerPayload(e), e)
         }
     }
 
     handleBlur = e => {
-        const { onBlur } = this.props
-
-        if (onBlur) {
-            onBlur(e)
+        if (this.props.onBlur) {
+            this.props.onBlur(this.createHandlerPayload(e), e)
         }
     }
 
     handleFocus = e => {
-        const { onFocus } = this.props
+        if (this.props.onFocus) {
+            this.props.onFocus(this.createHandlerPayload(e), e)
+        }
+    }
 
-        if (onFocus) {
-            onFocus(e)
+    createHandlerPayload(e) {
+        return {
+            value: e.target.value,
+            name: this.props.name,
         }
     }
 

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -27,33 +27,28 @@ class Radio extends Component {
     }
 
     handleChange = e => {
-        const { onChange } = this.props
-
-        if (onChange) {
-            onChange(
-                {
-                    value: this.props.value,
-                    name: this.props.name,
-                    checked: !this.props.checked,
-                },
-                e
-            )
+        if (this.props.onChange) {
+            this.props.onChange(this.createHandlerPayload(), e)
         }
     }
 
     handleBlur = e => {
-        const { onBlur } = this.props
-
-        if (onBlur) {
-            onBlur(e)
+        if (this.props.onBlur) {
+            this.props.onBlur(this.createHandlerPayload(), e)
         }
     }
 
     handleFocus = e => {
-        const { onFocus } = this.props
+        if (this.props.onFocus) {
+            this.props.onFocus(this.createHandlerPayload(), e)
+        }
+    }
 
-        if (onFocus) {
-            onFocus(e)
+    createHandlerPayload() {
+        return {
+            value: this.props.value,
+            name: this.props.name,
+            checked: !this.props.checked,
         }
     }
 

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -27,33 +27,28 @@ class Switch extends Component {
     }
 
     handleChange = e => {
-        const { onChange } = this.props
-
-        if (onChange) {
-            onChange(
-                {
-                    value: this.props.value,
-                    name: this.props.name,
-                    checked: !this.props.checked,
-                },
-                e
-            )
+        if (this.props.onChange) {
+            this.props.onChange(this.createHandlerPayload(), e)
         }
     }
 
     handleBlur = e => {
-        const { onBlur } = this.props
-
-        if (onBlur) {
-            onBlur(e)
+        if (this.props.onBlur) {
+            this.props.onBlur(this.createHandlerPayload(), e)
         }
     }
 
     handleFocus = e => {
-        const { onFocus } = this.props
+        if (this.props.onFocus) {
+            this.props.onFocus(this.createHandlerPayload(), e)
+        }
+    }
 
-        if (onFocus) {
-            onFocus(e)
+    createHandlerPayload() {
+        return {
+            value: this.props.value,
+            name: this.props.name,
+            checked: !this.props.checked,
         }
     }
 

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -79,32 +79,27 @@ export class TextArea extends Component {
     }
 
     handleChange = e => {
-        const { onChange } = this.props
-
-        if (onChange) {
-            onChange(
-                {
-                    value: e.target.value,
-                    name: this.props.name,
-                },
-                e
-            )
+        if (this.props.onChange) {
+            this.props.onChange(this.createHandlerPayload(e), e)
         }
     }
 
     handleBlur = e => {
-        const { onBlur } = this.props
-
-        if (onBlur) {
-            onBlur(e)
+        if (this.props.onBlur) {
+            this.props.onBlur(this.createHandlerPayload(e), e)
         }
     }
 
     handleFocus = e => {
-        const { onFocus } = this.props
+        if (this.props.onFocus) {
+            this.props.onFocus(this.createHandlerPayload(e), e)
+        }
+    }
 
-        if (onFocus) {
-            onFocus(e)
+    createHandlerPayload(e) {
+        return {
+            value: e.target.value,
+            name: this.props.name,
         }
     }
 


### PR DESCRIPTION
### Scope
This touches the following components:
- `Checkbox`
- `Input`
- `Radio`
- `Switch`
- `TextArea`

I have not worked on the `Select` because I know that @ismay is working on that.

### Things that have been discussed already:
Because I was going to do very similar things to a number of components, I asked @Mohammer5 to give some feedback on my initial commit. I'll try to summarise what was discussed, so we don't end up discussing the same things again:
- We tried various different implementations but decided to stick with the mechanism introduced in https://github.com/dhis2/ui-core/commit/86d3a4103a6c2145944b795fec7d85af9a8e2bd0, because that correctly extracts the shared functionality. An example of the "runner-up" approach  would be something like this:
    ```javascript
    handleChange = e => this.handleEvent(props.onChange, e)
    handleFocus = e => this.handleEvent(props.onFocus, e)
    handleBlur = e => this.handleEvent(props.onBlur, e)

    handleEvent = (handler, e) => {
        if (handler) {
            hander({
                value: this.props.value,
                name: this.props.name,
                checked: !this.props.checked,
            }, e)
        }
    }
    ```
    The downside of this approach is that this assumes that all events are always going to be handled identically.
- We discussed various method names and settled on `createHandlerPayload`, this was originally `getHandlerObject ` in https://github.com/dhis2/ui-core/commit/86d3a4103a6c2145944b795fec7d85af9a8e2bd0