### PR TITLE
fix: adjust menu position after option selection

### DIFF
--- a/src/Select/MenuWrapper.js
+++ b/src/Select/MenuWrapper.js
@@ -1,83 +1,43 @@
-import React, { Component } from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom'
 import propTypes from '@dhis2/prop-types'
 import { resolve } from 'styled-jsx/css'
 import { Card } from '../Card.js'
 import { layers } from '../theme.js'
 
-class MenuWrapper extends Component {
-    state = {
-        top: 'auto',
-        left: 'auto',
-        width: 'auto',
-    }
+const MenuWrapper = ({
+    children,
+    maxHeight,
+    className,
+    menuRef,
+    menuTop,
+    menuLeft,
+    menuWidth,
+}) => {
+    const { styles, className: cardClassName } = resolve`
+        height: auto;
+        max-height: ${maxHeight};
+        overflow: auto;
+    `
 
-    requestId = null
+    return ReactDOM.createPortal(
+        <div className={className} ref={menuRef}>
+            <Card className={cardClassName}>{children}</Card>
 
-    componentDidMount() {
-        window.addEventListener('resize', this.updatePosition)
-        this.updatePosition()
-    }
+            {styles}
 
-    componentWillUnmount() {
-        window.removeEventListener('resize', this.updatePosition)
-
-        if (this.requestId) {
-            window.cancelAnimationFrame(this.requestId)
-        }
-    }
-
-    updatePosition = () => {
-        const selectEl = this.props.selectRef.current
-
-        if (this.requestId) {
-            window.cancelAnimationFrame(this.requestId)
-        }
-
-        this.requestId = window.requestAnimationFrame(() => {
-            const rect = selectEl.getBoundingClientRect()
-            const top = rect.bottom + window.scrollY
-            const left = rect.left + window.scrollX
-            const width = rect.width
-
-            const sizing = {
-                top: `${top}px`,
-                left: `${left}px`,
-                width: `${width}px`,
-            }
-
-            this.setState(sizing)
-        })
-    }
-
-    render() {
-        const { children, maxHeight, className, menuRef } = this.props
-        const { top, left, width } = this.state
-        const { styles, className: cardClassName } = resolve`
-            height: auto;
-            max-height: ${maxHeight};
-            overflow: auto;
-        `
-
-        return ReactDOM.createPortal(
-            <div className={className} ref={menuRef}>
-                <Card className={cardClassName}>{children}</Card>
-
-                {styles}
-
-                <style jsx>{`
-                    div {
-                        position: absolute;
-                        z-index: ${layers.applicationTop};
-                        top: ${top};
-                        left: ${left};
-                        width: ${width};
-                    }
-                `}</style>
-            </div>,
-            document.body
-        )
-    }
+            <style jsx>{`
+                div {
+                    position: absolute;
+                    z-index: ${layers.applicationTop};
+                    top: ${menuTop};
+                    left: ${menuLeft};
+                    width: ${menuWidth};
+                }
+            `}</style>
+        </div>,
+        document.body
+    )
 }
 
 MenuWrapper.defaultProps = {
@@ -90,6 +50,9 @@ MenuWrapper.propTypes = {
     maxHeight: propTypes.string,
     selectRef: propTypes.object.isRequired,
     menuRef: propTypes.object.isRequired,
+    menuTop: propTypes.string.isRequired,
+    menuLeft: propTypes.string.isRequired,
+    menuWidth: propTypes.string.isRequired,
 }
 
 export { MenuWrapper }


### PR DESCRIPTION
Since the select's input area can change size after a selection, we have to check the position of the menu after a selection. FF was not measuring properly when scheduling the measurement on menu open, so I'm now measuring on mount as well. That has the advantage of already having the correct position before menu open.