### PR TITLE
chore: upgrade react to support hooks

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,10 +6,10 @@ update_configs:
     update_schedule: "live"
     version_requirement_updates: "increase_versions"
     ignored_updates:
-      # ui-core supports 16.3 of react, so ignore all updates
+      # ui-core supports 16.8 of react, so ignore all updates
       - match:
           dependency_name: "react"
-          version_requirement: ">=16.4.x"
+          version_requirement: ">=16.9.x"
       - match:
           dependency_name: "react-dom"
-          version_requirement: ">=16.4.x"
+          version_requirement: ">=16.9.x"

--- a/package.json
+++ b/package.json
@@ -49,18 +49,18 @@
     "cypress": "^3.6.0",
     "cypress-cucumber-preprocessor": "^1.16.2",
     "eslint-plugin-react": "^7.16.0",
-    "react": "16.3",
+    "react": "16.8",
     "react-dev-utils": "^9.1.0",
     "react-docgen": "^4.1.1",
-    "react-dom": "16.3",
+    "react-dom": "16.8",
     "storybook-addon-jsx": "^7.1.13",
     "storybook-addon-react-docgen": "^1.2.28",
     "typeface-roboto": "^0.0.75",
     "wait-on": "^3.3.0"
   },
   "peerDependencies": {
-    "react": "^16.3",
-    "react-dom": "^16.3"
+    "react": "^16.8",
+    "react-dom": "^16.8"
   },
   "dependencies": {
     "@dhis2/prop-types": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5600,7 +5600,7 @@ faye-websocket@0.11.x, faye-websocket@~0.11.1:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.0, fbjs@^0.8.16, fbjs@^0.8.4:
+fbjs@^0.8.0, fbjs@^0.8.4:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -9608,15 +9608,15 @@ react-docgen@^4.1.0, react-docgen@^4.1.1:
     node-dir "^0.1.10"
     recast "^0.17.3"
 
-react-dom@16.3:
-  version "16.3.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.3.tgz#af4c2aef9f6a66251a46da50253c860a67ae66d9"
-  integrity sha512-ALCp7ZbSGkqRDtQoZozKVNgwXMxbxf/IGOUMC2A0yF6JHeZrS8e2cOotPT87Vf4b7PKCuUVKU4/RDEXxToA/yA==
+react-dom@16.8:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
 react-dom@^16.8.3:
   version "16.9.0"
@@ -9741,15 +9741,15 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react@16.3:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
-  integrity sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==
+react@16.8:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
 react@^16.8.3:
   version "16.9.0"
@@ -10316,6 +10316,14 @@ sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@^0.15.0:
   version "0.15.0"


### PR DESCRIPTION
Related: #572 

This would make it easier to implement the z-index context provider in #572.

UI core overview seems to indicate that everywhere we use ui-core (atm) has hooks enabled: https://dhis2.vardevs.se/layoftheland.html

As such, this seems like a reasonable change for the `next` branch.

BREAKING CHANGE: Now requires React >= 16.8.