### PR TITLE
feat(select): add input max height prop

### DIFF
--- a/src/MultiSelect.js
+++ b/src/MultiSelect.js
@@ -24,6 +24,7 @@ const MultiSelect = ({
     selected,
     tabIndex,
     maxHeight,
+    inputMaxHeight,
     onChange,
     onFocus,
     onBlur,
@@ -68,6 +69,7 @@ const MultiSelect = ({
                             clearText={clearText}
                             placeholder={placeholder}
                             prefix={prefix}
+                            inputMaxHeight={inputMaxHeight}
                         />
                     }
                     menu={menu}
@@ -132,6 +134,7 @@ MultiSelect.defaultProps = {
  * @prop {boolean} [filterable]
  * @prop {string} [loadingText]
  * @prop {string} [maxHeight]
+ * @prop {string} [inputMaxHeight]
  * @prop {string} [noMatchText] - Only required if filterable is true
  * @prop {string} [placeholder]
  * @prop {string} [prefix]
@@ -158,6 +161,7 @@ MultiSelect.propTypes = {
     filterable: propTypes.bool,
     loadingText: propTypes.string,
     maxHeight: propTypes.string,
+    inputMaxHeight: propTypes.string,
     noMatchText: propTypes.requiredIf(
         props => props.filterable,
         propTypes.string

--- a/src/MultiSelect/Input.js
+++ b/src/MultiSelect/Input.js
@@ -18,6 +18,7 @@ const Input = ({
     options,
     className,
     disabled,
+    inputMaxHeight,
 }) => {
     const hasSelection = selected.length > 0
     const onClear = e => {
@@ -34,7 +35,7 @@ const Input = ({
                 <InputPlaceholder placeholder={placeholder} />
             )}
             {hasSelection && (
-                <div>
+                <div className="root-input">
                     {/* the wrapper div above is necessary to enforce wrapping on overflow */}
                     <SelectionList
                         selected={selected}
@@ -59,13 +60,28 @@ const Input = ({
                     line-height: 16px;
                 }
 
+                .root-input {
+                    overflow-y: auto;
+                    flex: 1;
+                }
+
                 .root-right {
                     margin-left: auto;
                     margin-right: 10px;
                 }
             `}</style>
+
+            <style jsx>{`
+                .root-input {
+                    max-height: ${inputMaxHeight};
+                }
+            `}</style>
         </div>
     )
+}
+
+Input.defaultProps = {
+    inputMaxHeight: '100px',
 }
 
 Input.propTypes = {
@@ -78,6 +94,7 @@ Input.propTypes = {
     prefix: propTypes.string,
     placeholder: propTypes.string,
     disabled: propTypes.bool,
+    inputMaxHeight: propTypes.string,
 }
 
 export { Input }

--- a/src/MultiSelectField.js
+++ b/src/MultiSelectField.js
@@ -38,6 +38,7 @@ class MultiSelectField extends React.Component {
             helpText,
             validationText,
             maxHeight,
+            inputMaxHeight,
             children,
             clearable,
             clearText,
@@ -64,6 +65,7 @@ class MultiSelectField extends React.Component {
                     selected={selected}
                     tabIndex={tabIndex}
                     maxHeight={maxHeight}
+                    inputMaxHeight={inputMaxHeight}
                     onChange={onChange}
                     onFocus={onFocus}
                     onBlur={onBlur}
@@ -132,6 +134,7 @@ MultiSelectField.defaultProps = {
  * @prop {boolean} [filterable]
  * @prop {string} [loadingText]
  * @prop {string} [maxHeight]
+ * @prop {string} [inputMaxHeight]
  * @prop {string} [noMatchText] - Only required if filterable is true
  * @prop {string} [placeholder]
  * @prop {string} [prefix]
@@ -162,6 +165,7 @@ MultiSelectField.propTypes = {
     filterable: propTypes.bool,
     loadingText: propTypes.string,
     maxHeight: propTypes.string,
+    inputMaxHeight: propTypes.string,
     noMatchText: propTypes.requiredIf(
         props => props.filterable,
         propTypes.string

--- a/src/SingleSelect.js
+++ b/src/SingleSelect.js
@@ -24,6 +24,7 @@ const SingleSelect = ({
     selected,
     tabIndex,
     maxHeight,
+    inputMaxHeight,
     onChange,
     onFocus,
     onBlur,
@@ -68,6 +69,7 @@ const SingleSelect = ({
                             clearText={clearText}
                             placeholder={placeholder}
                             prefix={prefix}
+                            inputMaxHeight={inputMaxHeight}
                         />
                     }
                     menu={menu}
@@ -132,6 +134,7 @@ SingleSelect.defaultProps = {
  * @prop {boolean} [filterable]
  * @prop {string} [loadingText]
  * @prop {string} [maxHeight]
+ * @prop {string} [inputMaxHeight]
  * @prop {string} [noMatchText] - Only required if filterable is true
  * @prop {string} [placeholder]
  * @prop {string} [prefix]
@@ -158,6 +161,7 @@ SingleSelect.propTypes = {
     filterable: propTypes.bool,
     loadingText: propTypes.string,
     maxHeight: propTypes.string,
+    inputMaxHeight: propTypes.string,
     noMatchText: propTypes.requiredIf(
         props => props.filterable,
         propTypes.string

--- a/src/SingleSelect/Input.js
+++ b/src/SingleSelect/Input.js
@@ -18,6 +18,7 @@ const Input = ({
     options,
     className,
     disabled,
+    inputMaxHeight,
 }) => {
     const hasSelection = 'label' in selected && 'value' in selected
     const onClear = e => {
@@ -34,7 +35,7 @@ const Input = ({
                 <InputPlaceholder placeholder={placeholder} />
             )}
             {hasSelection && (
-                <div>
+                <div className="root-input">
                     {/* the wrapper div above is necessary to enforce wrapping on overflow */}
                     <Selection selected={selected} options={options} />
                 </div>
@@ -54,13 +55,28 @@ const Input = ({
                     line-height: 16px;
                 }
 
+                .root-input {
+                    overflow-y: auto;
+                    flex: 1;
+                }
+
                 .root-right {
                     margin-left: auto;
                     margin-right: 10px;
                 }
             `}</style>
+
+            <style jsx>{`
+                .root-input {
+                    max-height: ${inputMaxHeight};
+                }
+            `}</style>
         </div>
     )
+}
+
+Input.defaultProps = {
+    inputMaxHeight: '100px',
 }
 
 Input.propTypes = {
@@ -73,6 +89,7 @@ Input.propTypes = {
     prefix: propTypes.string,
     placeholder: propTypes.string,
     disabled: propTypes.bool,
+    inputMaxHeight: propTypes.string,
 }
 
 export { Input }

--- a/src/SingleSelectField.js
+++ b/src/SingleSelectField.js
@@ -38,6 +38,7 @@ class SingleSelectField extends React.Component {
             helpText,
             validationText,
             maxHeight,
+            inputMaxHeight,
             children,
             clearable,
             clearText,
@@ -64,6 +65,7 @@ class SingleSelectField extends React.Component {
                     selected={selected}
                     tabIndex={tabIndex}
                     maxHeight={maxHeight}
+                    inputMaxHeight={inputMaxHeight}
                     onChange={onChange}
                     onFocus={onFocus}
                     onBlur={onBlur}
@@ -132,6 +134,7 @@ SingleSelectField.defaultProps = {
  * @prop {boolean} [filterable]
  * @prop {string} [loadingText]
  * @prop {string} [maxHeight]
+ * @prop {string} [inputMaxHeight]
  * @prop {string} [noMatchText] - Only required if filterable is true
  * @prop {string} [placeholder]
  * @prop {string} [prefix]
@@ -162,6 +165,7 @@ SingleSelectField.propTypes = {
     filterable: propTypes.bool,
     loadingText: propTypes.string,
     maxHeight: propTypes.string,
+    inputMaxHeight: propTypes.string,
     noMatchText: propTypes.requiredIf(
         props => props.filterable,
         propTypes.string

--- a/stories/MultiSelect.stories.js
+++ b/stories/MultiSelect.stories.js
@@ -264,3 +264,8 @@ storiesOf('MultiSelect', module)
             {options}
         </MultiSelect>
     ))
+    .add('Input max height', () => (
+        <MultiSelect {...defaultProps} inputMaxHeight="25px">
+            {options}
+        </MultiSelect>
+    ))

--- a/stories/SingleSelect.stories.js
+++ b/stories/SingleSelect.stories.js
@@ -240,3 +240,13 @@ storiesOf('SingleSelect', module)
             {options}
         </SingleSelect>
     ))
+    .add('Input max height', () => (
+        <SingleSelect
+            {...defaultProps}
+            selected={{ value: '1', label: longLabel }}
+            inputMaxHeight="50px"
+        >
+            <SingleSelectOption key="1" value="1" label={longLabel} />
+            <SingleSelectOption key="2" value="2" label="two" />
+        </SingleSelect>
+    ))


### PR DESCRIPTION
Sets a default max-height on the input, to keep it from getting too big when there are a lot of selected options, or when a single select option contains a lot of text.

Can be overridden with `inputMaxHeight` prop.