### PR TITLE
feat(screencover): add transparent prop

### DIFF
--- a/src/ScreenCover.js
+++ b/src/ScreenCover.js
@@ -3,20 +3,26 @@ import propTypes from '@dhis2/prop-types'
 
 import { layers } from './theme.js'
 
-const Backdrop = ({ onClick }) => (
+const Backdrop = ({ onClick, transparent }) => (
     <div className="backdrop" onClick={onClick}>
         <style jsx>{`
             div {
                 height: 100%;
                 width: 100%;
-
-                background: rgba(33, 43, 54, 0.4);
+            }
+        `}</style>
+        <style jsx>{`
+            div {
+                background: ${transparent
+                    ? 'transparent'
+                    : 'rgba(33, 43, 54, 0.4)'};
             }
         `}</style>
     </div>
 )
 Backdrop.propTypes = {
     onClick: propTypes.func,
+    transparent: propTypes.bool,
 }
 
 const Content = ({ children }) => (
@@ -49,9 +55,9 @@ Content.propTypes = {
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/principles/spacing-alignment.md#stacking|Design system}
  * @see Live demo: {@link /demo/?path=/story/screencover--default|Storybook}
  */
-const ScreenCover = ({ children, onClick, className }) => (
+const ScreenCover = ({ children, onClick, className, transparent }) => (
     <div className={className}>
-        <Backdrop onClick={onClick} />
+        <Backdrop onClick={onClick} transparent={transparent} />
         <Content>{children}</Content>
 
         <style jsx>{`
@@ -74,12 +80,14 @@ const ScreenCover = ({ children, onClick, className }) => (
  * @static
  * @prop {function} [onClick]
  * @prop {string} [className]
+ * @prop {boolean} [transparent]
  * @prop {Node} [children]
  */
 ScreenCover.propTypes = {
     onClick: propTypes.func,
     className: propTypes.string,
     children: propTypes.node,
+    transparent: propTypes.bool,
 }
 
 export { ScreenCover }

--- a/stories/ScreenCover.stories.js
+++ b/stories/ScreenCover.stories.js
@@ -54,3 +54,9 @@ storiesOf('ScreenCover', module)
             </Menu>
         </ScreenCover>
     ))
+
+    .add('Transparent', () => (
+        <ScreenCover onClick={onClick} transparent>
+            With a transparent background
+        </ScreenCover>
+    ))


### PR DESCRIPTION
Add a transparent prop, so the screencover can be used to catch clicks, instead of using a click listener on the document.