### PR TITLE
refactor(select): display single select option in full in menu

### DIFF
--- a/src/SingleSelectOption.js
+++ b/src/SingleSelectOption.js
@@ -36,9 +36,6 @@ const SingleSelectOption = ({
                 text-decoration: none;
                 color: ${colors.grey900};
                 padding: ${spacers.dp8} ${spacers.dp12};
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
             }
 
             div:hover {


### PR DESCRIPTION
The single select option was truncated, but to align it with how the multiselect option is displayed, we're displaying it in full. Eventually it would be good to display a tooltip for truncated multi select chips in the input:

<img width="1038" alt="Screenshot 2019-11-18 at 11 19 25" src="https://user-images.githubusercontent.com/7355199/69044488-4c4d6700-09f5-11ea-941e-dd3dac6b4544.png">
