### PR TITLE
refactor: adjust remaining handler props arguments style

### DIFF
--- a/cypress/integration/Backdrop/The_Backdrop_has_an_onClick_api.feature
+++ b/cypress/integration/Backdrop/The_Backdrop_has_an_onClick_api.feature
@@ -1,0 +1,7 @@
+Feature: The Backdrop has an onClick api
+
+    Scenario: The user clicks on the Backdrop
+        Given a Backdrop is rendered
+        And a custom onClick handler is provided
+        When the user clicks on the Backdrop
+        Then the onClick handler will be called

--- a/cypress/integration/Backdrop/The_Backdrop_has_an_onClick_api/The_user_clicks_on_the_Backdrop.js
+++ b/cypress/integration/Backdrop/The_Backdrop_has_an_onClick_api/The_user_clicks_on_the_Backdrop.js
@@ -1,0 +1,21 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a Backdrop is rendered', () => {
+    cy.visitStory('Backdrop', 'Default')
+})
+
+Given('a custom onClick handler is provided', () => {
+    cy.window().then(win => {
+        cy.stub(win, 'onClick')
+    })
+})
+
+When('the user clicks on the Backdrop', () => {
+    cy.get('.backdrop').click()
+})
+
+Then('the onClick handler will be called', () => {
+    cy.window().then(win => {
+        expect(win.onClick).to.be.calledWith({})
+    })
+})

--- a/cypress/integration/Button/The_button_has_an_onClick_api.feature
+++ b/cypress/integration/Button/The_button_has_an_onClick_api.feature
@@ -1,0 +1,7 @@
+Feature: The button has an onClick api
+
+    Scenario: The user clicks on the Button
+        Given a Button is rendered
+        And the Button is provided with an onClick handler
+        When the Button is clicked
+        Then the onClick handler is called

--- a/cypress/integration/Button/The_button_has_an_onClick_api/The_user_clicks_on_the_Button.js
+++ b/cypress/integration/Button/The_button_has_an_onClick_api/The_user_clicks_on_the_Button.js
@@ -1,0 +1,22 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a Button is rendered', () => {
+    cy.visitStory('Button: Basic', 'Default')
+})
+
+Given('the Button is provided with an onClick handler', () => {
+    cy.window().then(win => (win.onClick = cy.stub()))
+})
+
+When('the Button is clicked', () => {
+    cy.get('button').click()
+})
+
+Then('the onClick handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onClick).to.be.calledWith({
+            name: 'Button',
+            value: 'default',
+        })
+    })
+})

--- a/cypress/integration/Checkbox/The_Checkbox_has_an_onBlur_api.feature
+++ b/cypress/integration/Checkbox/The_Checkbox_has_an_onBlur_api.feature
@@ -1,0 +1,7 @@
+Feature: The Checkbox has an onBlur api
+
+    Scenario: The user focuses the next the Checkbox
+        Given an focused Checkbox is rendered
+        And the Checkbox is provided with an onBlur handler
+        When the next Checkbox is focused
+        Then the onBlur handler is called

--- a/cypress/integration/Checkbox/The_Checkbox_has_an_onBlur_api/The_user_blurs_the_Checkbox.js
+++ b/cypress/integration/Checkbox/The_Checkbox_has_an_onBlur_api/The_user_blurs_the_Checkbox.js
@@ -1,0 +1,31 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an focused Checkbox is rendered', () => {
+    cy.visitStory('Checkbox', 'Focused unchecked')
+    cy.focused().then($el => {
+        expect($el.parents('label')).to.have.class('initially-focused')
+    })
+})
+
+Given('the Checkbox is provided with an onBlur handler', () => {
+    cy.window().then(win => {
+        win.onBlur = cy.stub()
+    })
+})
+
+When('the next Checkbox is focused', () => {
+    cy.get('.initially-unfocused input').focus()
+    cy.focused().then($el => {
+        expect($el.parents('label')).to.have.class('initially-unfocused')
+    })
+})
+
+Then('the onBlur handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onBlur).to.be.calledWith({
+            value: 'default',
+            name: 'Ex',
+            checked: true,
+        })
+    })
+})

--- a/cypress/integration/Checkbox/The_Checkbox_has_an_onChange_api.feature
+++ b/cypress/integration/Checkbox/The_Checkbox_has_an_onChange_api.feature
@@ -1,0 +1,7 @@
+Feature: The Checkbox has an onChange api
+
+    Scenario: The user ticks the Checkbox
+        Given an unchecked Checkbox is rendered
+        And the Checkbox is provided with an onChange handler
+        When the Checkbox is ticked
+        Then the onChange handler is called

--- a/cypress/integration/Checkbox/The_Checkbox_has_an_onChange_api/The_user_ticks_the_Checkbox.js
+++ b/cypress/integration/Checkbox/The_Checkbox_has_an_onChange_api/The_user_ticks_the_Checkbox.js
@@ -1,0 +1,25 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an unchecked Checkbox is rendered', () => {
+    cy.visitStory('Checkbox', 'Default')
+})
+
+Given('the Checkbox is provided with an onChange handler', () => {
+    cy.window().then(win => {
+        win.onChange = cy.stub()
+    })
+})
+
+When('the Checkbox is ticked', () => {
+    cy.get('label').click()
+})
+
+Then('the onChange handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledWith({
+            value: 'default',
+            name: 'Ex',
+            checked: true,
+        })
+    })
+})

--- a/cypress/integration/Checkbox/The_Checkbox_has_an_onFocus_api.feature
+++ b/cypress/integration/Checkbox/The_Checkbox_has_an_onFocus_api.feature
@@ -1,0 +1,7 @@
+Feature: The Checkbox has an onFocus api
+
+    Scenario: The user focuses the Checkbox
+        Given an unfocused Checkbox is rendered
+        And the Checkbox is provided with an onFocus handler
+        When the Checkbox is focused
+        Then the onFocus handler is called

--- a/cypress/integration/Checkbox/The_Checkbox_has_an_onFocus_api/The_user_focuses_the_Checkbox.js
+++ b/cypress/integration/Checkbox/The_Checkbox_has_an_onFocus_api/The_user_focuses_the_Checkbox.js
@@ -1,0 +1,25 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an unfocused Checkbox is rendered', () => {
+    cy.visitStory('Checkbox', 'Default')
+})
+
+Given('the Checkbox is provided with an onFocus handler', () => {
+    cy.window().then(win => {
+        win.onFocus = cy.stub()
+    })
+})
+
+When('the Checkbox is focused', () => {
+    cy.get('input').focus()
+})
+
+Then('the onFocus handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onFocus).to.be.calledWith({
+            value: 'default',
+            name: 'Ex',
+            checked: true,
+        })
+    })
+})

--- a/cypress/integration/Chip/The_Chip_has_an_onClick_api.feature
+++ b/cypress/integration/Chip/The_Chip_has_an_onClick_api.feature
@@ -1,0 +1,7 @@
+Feature: The Chip has an onClick api
+
+    Scenario: The user clicks on the Chip
+        Given a Chip is rendered
+        And the Chip is provided with an onClick handler
+        When the Chip is clicked
+        Then the onClick handler is called

--- a/cypress/integration/Chip/The_Chip_has_an_onClick_api/The_user_clicks_the_Chip.js
+++ b/cypress/integration/Chip/The_Chip_has_an_onClick_api/The_user_clicks_the_Chip.js
@@ -1,0 +1,21 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a Chip is rendered', () => {
+    cy.visitStory('Chip', 'Default')
+})
+
+Given('the Chip is provided with an onClick handler', () => {
+    cy.window().then(win => {
+        win.onClick = cy.stub()
+    })
+})
+
+When('the Chip is clicked', () => {
+    cy.get('#root > span').click()
+})
+
+Then('the onClick handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onClick).to.be.calledWith({})
+    })
+})

--- a/cypress/integration/Chip/The_Chip_has_an_onRemove_api.feature
+++ b/cypress/integration/Chip/The_Chip_has_an_onRemove_api.feature
@@ -1,0 +1,7 @@
+Feature: The Chip has an onRemove api
+
+    Scenario: The user removes the Chip
+        Given a removable Chip is rendered
+        And the Chip is provided with an onRemove handler
+        When the remove icon is clicked
+        Then the onRemove handler is called

--- a/cypress/integration/Chip/The_Chip_has_an_onRemove_api/The_user_removes_the_Chip.js
+++ b/cypress/integration/Chip/The_Chip_has_an_onRemove_api/The_user_removes_the_Chip.js
@@ -1,0 +1,21 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a removable Chip is rendered', () => {
+    cy.visitStory('Chip', 'Removable')
+})
+
+Given('the Chip is provided with an onRemove handler', () => {
+    cy.window().then(win => {
+        win.onRemove = cy.stub()
+    })
+})
+
+When('the remove icon is clicked', () => {
+    cy.get('#root > span > span:nth-child(2)').click()
+})
+
+Then('the onRemove handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onRemove).to.be.calledWith({})
+    })
+})

--- a/cypress/integration/DropdownButton/The_DropdownButton_has_an_onClick_api.feature
+++ b/cypress/integration/DropdownButton/The_DropdownButton_has_an_onClick_api.feature
@@ -1,0 +1,7 @@
+Feature: The DropdownButton has an onClick api
+
+    Scenario: The user clicks on the DropdownButton
+        Given a DropdownButton with closed dropdown is rendered
+        And the DropdownButton is provided with an onClick handler
+        When the DropdownButton is clicked
+        Then the onClick handler is called

--- a/cypress/integration/DropdownButton/The_DropdownButton_has_an_onClick_api/The_user_clicks_the_DropdownButton.js
+++ b/cypress/integration/DropdownButton/The_DropdownButton_has_an_onClick_api/The_user_clicks_the_DropdownButton.js
@@ -1,0 +1,18 @@
+import '../common/index'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('the DropdownButton is provided with an onClick handler', () => {
+    cy.window().then(win => {
+        win.onClick = cy.stub()
+    })
+})
+
+Then('the onClick handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onClick).to.be.calledWith({
+            name: 'Button',
+            value: 'default',
+            open: true,
+        })
+    })
+})

--- a/cypress/integration/DropdownButton/The_DropdownButton_renders_a_dropdown.feature
+++ b/cypress/integration/DropdownButton/The_DropdownButton_renders_a_dropdown.feature
@@ -1,0 +1,11 @@
+Feature: The DropdownButton renders a dropdown
+
+    Scenario: The user opens the dropdown
+        Given a DropdownButton with closed dropdown is rendered
+        When the DropdownButton is clicked
+        Then the dropdown is rendered
+
+    Scenario: The user closes the dropdown
+        Given a DropdownButton with opened dropdown is rendered
+        When the DropdownButton is clicked
+        Then the dropdown is not rendered

--- a/cypress/integration/DropdownButton/The_DropdownButton_renders_a_dropdown/The_user_closes_the_dropdown.js
+++ b/cypress/integration/DropdownButton/The_DropdownButton_renders_a_dropdown/The_user_closes_the_dropdown.js
@@ -1,0 +1,12 @@
+import '../common/index'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a DropdownButton with opened dropdown is rendered', () => {
+    cy.visitStory('DropdownButton: Basic', 'Default')
+    cy.get('button').click()
+    cy.get('.dropdown-button-dropmenu').should('exist')
+})
+
+Then('the dropdown is not rendered', () => {
+    cy.get('.dropdown-button-dropmenu').should('not.exist')
+})

--- a/cypress/integration/DropdownButton/The_DropdownButton_renders_a_dropdown/The_user_opens_the_dropdown.js
+++ b/cypress/integration/DropdownButton/The_DropdownButton_renders_a_dropdown/The_user_opens_the_dropdown.js
@@ -1,0 +1,6 @@
+import '../common/index'
+import { Then } from 'cypress-cucumber-preprocessor/steps'
+
+Then('the dropdown is rendered', () => {
+    cy.get('.dropdown-button-dropmenu').should('exist')
+})

--- a/cypress/integration/DropdownButton/common/index.js
+++ b/cypress/integration/DropdownButton/common/index.js
@@ -1,0 +1,9 @@
+import { Given, When } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a DropdownButton with closed dropdown is rendered', () => {
+    cy.visitStory('DropdownButton: Basic', 'Default')
+})
+
+When('the DropdownButton is clicked', () => {
+    cy.get('button').click()
+})

--- a/cypress/integration/FileListItem/The_FileListItem_has_an_onCancel_api.feature
+++ b/cypress/integration/FileListItem/The_FileListItem_has_an_onCancel_api.feature
@@ -1,0 +1,7 @@
+Feature: The FileListItem has an onCancel api
+
+    Scenario: The user cancels a file
+        Given a loading FileListItem is rendered
+        And an onCancel handler is provided
+        When the user clicks on the cancel text
+        Then the onCancel handler is called

--- a/cypress/integration/FileListItem/The_FileListItem_has_an_onCancel_api/The_user_cancels_a_file.js
+++ b/cypress/integration/FileListItem/The_FileListItem_has_an_onCancel_api/The_user_cancels_a_file.js
@@ -1,0 +1,21 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a loading FileListItem is rendered', () => {
+    cy.visitStory('FileListItem', 'Loading')
+})
+
+Given('an onCancel handler is provided', () => {
+    cy.window().then(win => {
+        win.onCancel = cy.stub()
+    })
+})
+
+When('the user clicks on the cancel text', () => {
+    cy.get('.action:contains("Cancel")').click()
+})
+
+Then('the onCancel handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onCancel).to.be.calledWith({})
+    })
+})

--- a/cypress/integration/FileListItem/The_FileListItem_has_an_onRemove_api.feature
+++ b/cypress/integration/FileListItem/The_FileListItem_has_an_onRemove_api.feature
@@ -1,0 +1,7 @@
+Feature: The FileListItem has an onRemove api
+
+    Scenario: The user removes a file
+        Given a removable FileListItem is rendered
+        And an onRemove handler is provided
+        When the user clicks on the remove text
+        Then the onRemove handler is called

--- a/cypress/integration/FileListItem/The_FileListItem_has_an_onRemove_api/The_user_removes_a_file.js
+++ b/cypress/integration/FileListItem/The_FileListItem_has_an_onRemove_api/The_user_removes_a_file.js
@@ -1,0 +1,21 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a removable FileListItem is rendered', () => {
+    cy.visitStory('FileListItem', 'Default')
+})
+
+Given('an onRemove handler is provided', () => {
+    cy.window().then(win => {
+        win.onRemove = cy.stub()
+    })
+})
+
+When('the user clicks on the remove text', () => {
+    cy.get('.action:contains("Remove")').click()
+})
+
+Then('the onRemove handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onRemove).to.be.calledWith({})
+    })
+})

--- a/cypress/integration/Input/The_Input_has_an_onBlur_api.feature
+++ b/cypress/integration/Input/The_Input_has_an_onBlur_api.feature
@@ -1,0 +1,7 @@
+Feature: The Input has an onBlur api
+
+    Scenario: The user focuses the next the Input
+        Given a focused Input is rendered
+        And the Input is provided with an onBlur handler
+        When the next Input is focused
+        Then the onBlur handler is called

--- a/cypress/integration/Input/The_Input_has_an_onBlur_api/The_user_blurs_the_Input.js
+++ b/cypress/integration/Input/The_Input_has_an_onBlur_api/The_user_blurs_the_Input.js
@@ -1,0 +1,27 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a focused Input is rendered', () => {
+    cy.visitStory('Input', 'Focus')
+})
+
+Given('the Input is provided with an onBlur handler', () => {
+    cy.window().then(win => {
+        win.onBlur = cy.stub()
+    })
+})
+
+When('the next Input is focused', () => {
+    cy.get('.initially-unfocused input').focus()
+    cy.focused().then($el => {
+        expect($el.parent()).to.have.class('initially-unfocused')
+    })
+})
+
+Then('the onBlur handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onBlur).to.be.calledWith({
+            value: '',
+            name: 'Default',
+        })
+    })
+})

--- a/cypress/integration/Input/The_Input_has_an_onChange_api.feature
+++ b/cypress/integration/Input/The_Input_has_an_onChange_api.feature
@@ -1,0 +1,7 @@
+Feature: The Input has an onChange api
+
+    Scenario: The user types a character into the Input
+        Given an empty Input is rendered
+        And the Input is provided with an onChange handler
+        When the Input is filled with a character
+        Then the onChange handler is called

--- a/cypress/integration/Input/The_Input_has_an_onChange_api/The_user_ticks_the_Input.js
+++ b/cypress/integration/Input/The_Input_has_an_onChange_api/The_user_ticks_the_Input.js
@@ -1,0 +1,21 @@
+import '../common/index'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('the Input is provided with an onChange handler', () => {
+    cy.window().then(win => {
+        win.onChange = cy.stub()
+    })
+})
+
+When('the Input is filled with a character', () => {
+    cy.get('input').type('a')
+})
+
+Then('the onChange handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledWith({
+            value: 'a',
+            name: 'Default',
+        })
+    })
+})

--- a/cypress/integration/Input/The_Input_has_an_onFocus_api.feature
+++ b/cypress/integration/Input/The_Input_has_an_onFocus_api.feature
@@ -1,0 +1,7 @@
+Feature: The Input has an onFocus api
+
+    Scenario: The user focuses the Input
+        Given an empty Input is rendered
+        And the Input is provided with an onFocus handler
+        When the Input is focused
+        Then the onFocus handler is called

--- a/cypress/integration/Input/The_Input_has_an_onFocus_api/The_user_focuses_the_Input.js
+++ b/cypress/integration/Input/The_Input_has_an_onFocus_api/The_user_focuses_the_Input.js
@@ -1,0 +1,21 @@
+import '../common/index'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('the Input is provided with an onFocus handler', () => {
+    cy.window().then(win => {
+        win.onFocus = cy.stub()
+    })
+})
+
+When('the Input is focused', () => {
+    cy.get('input').focus()
+})
+
+Then('the onFocus handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onFocus).to.be.calledWith({
+            value: '',
+            name: 'Default',
+        })
+    })
+})

--- a/cypress/integration/Input/common/index.js
+++ b/cypress/integration/Input/common/index.js
@@ -1,0 +1,5 @@
+import { Given } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an empty Input is rendered', () => {
+    cy.visitStory('Input', 'Default')
+})

--- a/cypress/integration/MenuItem/The_MenuItem_has_an_onClick_api.feature
+++ b/cypress/integration/MenuItem/The_MenuItem_has_an_onClick_api.feature
@@ -1,0 +1,7 @@
+Feature: The MenuItem has an onClick api
+
+    Scenario: The user clicks on the MenuItem
+        Given a MenuItem is rendered
+        And the MenuItem is provided with an onClick handler
+        When the MenuItem is clicked
+        Then the onClick handler is called

--- a/cypress/integration/MenuItem/The_MenuItem_has_an_onClick_api/The_user_clicks_on_the_MenuItem.js
+++ b/cypress/integration/MenuItem/The_MenuItem_has_an_onClick_api/The_user_clicks_on_the_MenuItem.js
@@ -1,0 +1,21 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a MenuItem is rendered', () => {
+    cy.visitStory('MenuItem', 'Default')
+})
+
+Given('the MenuItem is provided with an onClick handler', () => {
+    cy.window().then(win => (win.onClick = cy.stub()))
+})
+
+When('the MenuItem is clicked', () => {
+    cy.get('a').click()
+})
+
+Then('the onClick handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onClick).to.be.calledWith({
+            value: 'default',
+        })
+    })
+})

--- a/cypress/integration/Modal/The_Modal_has_an_onClose_api.feature
+++ b/cypress/integration/Modal/The_Modal_has_an_onClose_api.feature
@@ -1,0 +1,7 @@
+Feature: The Modal has an onClose api
+
+    Scenario: The user clicks on the Backdrop
+        Given a Modal is rendered
+        And the Modal is provided with an onClose handler
+        When the Backdrop is clicked
+        Then the onClose handler is called

--- a/cypress/integration/Modal/The_Modal_has_an_onClose_api/The_user_clicks_on_the_Backdrop.js
+++ b/cypress/integration/Modal/The_Modal_has_an_onClose_api/The_user_clicks_on_the_Backdrop.js
@@ -1,0 +1,21 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a Modal is rendered', () => {
+    cy.visitStory('Modal', 'Small: Title, Content, Action')
+})
+
+Given('the Modal is provided with an onClose handler', () => {
+    cy.window().then(win => {
+        cy.stub(win, 'onClose', (...args) => console.log('args', args))
+    })
+})
+
+When('the Backdrop is clicked', () => {
+    cy.get('.backdrop').click('topLeft')
+})
+
+Then('the onClose handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onClose).to.be.calledWith({})
+    })
+})

--- a/cypress/integration/Node/The_Node_has_an_onClose_api.feature
+++ b/cypress/integration/Node/The_Node_has_an_onClose_api.feature
@@ -1,0 +1,7 @@
+Feature: The Node has an onClose api
+
+    Scenario: The user closes the Node
+        Given a closed Node is rendered
+        And the Node is provided with an onClose handler
+        When the arrow is clicked
+        Then the onClose handler is called

--- a/cypress/integration/Node/The_Node_has_an_onClose_api/The_user_closes_the_Node.js
+++ b/cypress/integration/Node/The_Node_has_an_onClose_api/The_user_closes_the_Node.js
@@ -1,0 +1,21 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a closed Node is rendered', () => {
+    cy.visitStory('Node', '2 Levels open')
+})
+
+Given('the Node is provided with an onClose handler', () => {
+    cy.window().then(win => {
+        win.onClose = cy.stub()
+    })
+})
+
+When('the arrow is clicked', () => {
+    cy.get('#root > .tree > .tree__arrow > span').click()
+})
+
+Then('the onClose handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onClose).to.be.calledWith({ open: false })
+    })
+})

--- a/cypress/integration/Node/The_Node_has_an_onOpen_api.feature
+++ b/cypress/integration/Node/The_Node_has_an_onOpen_api.feature
@@ -1,0 +1,7 @@
+Feature: The Node has an onOpen api
+
+    Scenario: The user opens the Node
+        Given an opened Node is rendered
+        And the Node is provided with an onOpen handler
+        When the arrow is clicked
+        Then the onOpen handler is called

--- a/cypress/integration/Node/The_Node_has_an_onOpen_api/The_user_opens_the_Node.js
+++ b/cypress/integration/Node/The_Node_has_an_onOpen_api/The_user_opens_the_Node.js
@@ -1,0 +1,21 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an opened Node is rendered', () => {
+    cy.visitStory('Node', 'Multiple roots')
+})
+
+Given('the Node is provided with an onOpen handler', () => {
+    cy.window().then(win => {
+        win.onOpen = cy.stub()
+    })
+})
+
+When('the arrow is clicked', () => {
+    cy.get('#root > div > .tree:first-child > .tree__arrow > span').click()
+})
+
+Then('the onOpen handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onOpen).to.be.calledWith({ open: true })
+    })
+})

--- a/cypress/integration/Radio/The_Radio_has_an_onBlur_api.feature
+++ b/cypress/integration/Radio/The_Radio_has_an_onBlur_api.feature
@@ -1,0 +1,7 @@
+Feature: The Radio has an onBlur api
+
+    Scenario: The user focuses the next the Radio
+        Given an focused Radio is rendered
+        And the Radio is provided with an onBlur handler
+        When the next Radio is focused
+        Then the onBlur handler is called

--- a/cypress/integration/Radio/The_Radio_has_an_onBlur_api/The_user_blurs_the_Checkbox.js
+++ b/cypress/integration/Radio/The_Radio_has_an_onBlur_api/The_user_blurs_the_Checkbox.js
@@ -1,0 +1,31 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an focused Radio is rendered', () => {
+    cy.visitStory('Radio', 'Focused unchecked')
+    cy.focused().then($el => {
+        expect($el.parents('label')).to.have.class('initially-focused')
+    })
+})
+
+Given('the Radio is provided with an onBlur handler', () => {
+    cy.window().then(win => {
+        win.onBlur = cy.stub()
+    })
+})
+
+When('the next Radio is focused', () => {
+    cy.get('.initially-unfocused input').focus()
+    cy.focused().then($el => {
+        expect($el.parents('label')).to.have.class('initially-unfocused')
+    })
+})
+
+Then('the onBlur handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onBlur).to.be.calledWith({
+            value: 'default',
+            name: 'Ex',
+            checked: true,
+        })
+    })
+})

--- a/cypress/integration/Radio/The_Radio_has_an_onChange_api.feature
+++ b/cypress/integration/Radio/The_Radio_has_an_onChange_api.feature
@@ -1,0 +1,7 @@
+Feature: The Radio has an onChange api
+
+    Scenario: The user checks the Radio
+        Given an unchecked Radio is rendered
+        And the Radio is provided with an onChange handler
+        When the Radio is checked
+        Then the onChange handler is called

--- a/cypress/integration/Radio/The_Radio_has_an_onChange_api/The_user_ticks_the_Checkbox.js
+++ b/cypress/integration/Radio/The_Radio_has_an_onChange_api/The_user_ticks_the_Checkbox.js
@@ -1,0 +1,25 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an unchecked Radio is rendered', () => {
+    cy.visitStory('Radio', 'Default')
+})
+
+Given('the Radio is provided with an onChange handler', () => {
+    cy.window().then(win => {
+        win.onChange = cy.stub()
+    })
+})
+
+When('the Radio is checked', () => {
+    cy.get('label').click()
+})
+
+Then('the onChange handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledWith({
+            value: 'default',
+            name: 'Ex',
+            checked: true,
+        })
+    })
+})

--- a/cypress/integration/Radio/The_Radio_has_an_onFocus_api.feature
+++ b/cypress/integration/Radio/The_Radio_has_an_onFocus_api.feature
@@ -1,0 +1,7 @@
+Feature: The Radio has an onFocus api
+
+    Scenario: The user focuses the Radio
+        Given an unfocused Radio is rendered
+        And the Radio is provided with an onFocus handler
+        When the Radio is focused
+        Then the onFocus handler is called

--- a/cypress/integration/Radio/The_Radio_has_an_onFocus_api/The_user_focuses_the_Checkbox.js
+++ b/cypress/integration/Radio/The_Radio_has_an_onFocus_api/The_user_focuses_the_Checkbox.js
@@ -1,0 +1,25 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an unfocused Radio is rendered', () => {
+    cy.visitStory('Radio', 'Default')
+})
+
+Given('the Radio is provided with an onFocus handler', () => {
+    cy.window().then(win => {
+        win.onFocus = cy.stub()
+    })
+})
+
+When('the Radio is focused', () => {
+    cy.get('input').focus()
+})
+
+Then('the onFocus handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onFocus).to.be.calledWith({
+            value: 'default',
+            name: 'Ex',
+            checked: true,
+        })
+    })
+})

--- a/cypress/integration/ScreenCover/The_ScreenCover_provides_an_onClick_api.feature
+++ b/cypress/integration/ScreenCover/The_ScreenCover_provides_an_onClick_api.feature
@@ -1,0 +1,7 @@
+Feature: The ScreenCover provides an onClick api
+
+    Scenario: The user clicks on the Backdrop
+        Given a ScreenCover is rendered
+        And a custom onClick handler is provided
+        When the user clicks on the Backdrop
+        Then the onClick handler will be called

--- a/cypress/integration/ScreenCover/The_ScreenCover_provides_an_onClick_api/The_user_clicks_on_the_Backdrop.js
+++ b/cypress/integration/ScreenCover/The_ScreenCover_provides_an_onClick_api/The_user_clicks_on_the_Backdrop.js
@@ -1,0 +1,21 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a ScreenCover is rendered', () => {
+    cy.visitStory('ScreenCover', 'Default')
+})
+
+Given('a custom onClick handler is provided', () => {
+    cy.window().then(win => {
+        cy.stub(win, 'onClick')
+    })
+})
+
+When('the user clicks on the Backdrop', () => {
+    cy.get('.backdrop').click()
+})
+
+Then('the onClick handler will be called', () => {
+    cy.window().then(win => {
+        expect(win.onClick).to.be.calledWith({})
+    })
+})

--- a/cypress/integration/SplitButton/The_SplitButton_has_an_onClick_api.feature
+++ b/cypress/integration/SplitButton/The_SplitButton_has_an_onClick_api.feature
@@ -1,0 +1,7 @@
+Feature: The SplitButton has an onClick api
+
+    Scenario: The user clicks on the SplitButton
+        Given a SplitButton with closed DropMenu is rendered
+        And the SplitButton is provided with an onClick handler
+        When the SplitButton is clicked
+        Then the onClick handler is called

--- a/cypress/integration/SplitButton/The_SplitButton_has_an_onClick_api/The_user_clicks_the_SplitButton.js
+++ b/cypress/integration/SplitButton/The_SplitButton_has_an_onClick_api/The_user_clicks_the_SplitButton.js
@@ -1,0 +1,18 @@
+import '../common/index'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('the SplitButton is provided with an onClick handler', () => {
+    cy.window().then(win => {
+        cy.stub(win, 'onClick', console.log.bind(null, 'args'))
+    })
+})
+
+Then('the onClick handler is called', () => {
+    cy.window()
+        .its('onClick')
+        .should('be.calledWith', {
+            name: 'Button',
+            value: 'default',
+            open: false,
+        })
+})

--- a/cypress/integration/SplitButton/The_SplitButton_renders_a_DropMenu.feature
+++ b/cypress/integration/SplitButton/The_SplitButton_renders_a_DropMenu.feature
@@ -1,0 +1,11 @@
+Feature: The SplitButton renders a DropMenu
+
+    Scenario: The user opens the DropMenu
+        Given a SplitButton with closed DropMenu is rendered
+        When the SplitButton arrow icon is clicked
+        Then the DropMenu is rendered
+
+    Scenario: The user closes the DropMenu
+        Given a SplitButton with opened DropMenu is rendered
+        When the SplitButton arrow icon is clicked
+        Then the DropMenu is not rendered

--- a/cypress/integration/SplitButton/The_SplitButton_renders_a_DropMenu/The_user_closes_the_DropMenu.js
+++ b/cypress/integration/SplitButton/The_SplitButton_renders_a_DropMenu/The_user_closes_the_DropMenu.js
@@ -1,0 +1,12 @@
+import '../common/index'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a SplitButton with opened DropMenu is rendered', () => {
+    cy.visitStory('SplitButton: Basic', 'Default')
+    cy.get('button:nth-child(2)').click()
+    cy.get('.split-button-dropmenu').should('exist')
+})
+
+Then('the DropMenu is not rendered', () => {
+    cy.get('.DropMenu-button-dropmenu').should('not.exist')
+})

--- a/cypress/integration/SplitButton/The_SplitButton_renders_a_DropMenu/The_user_opens_the_DropMenu.js
+++ b/cypress/integration/SplitButton/The_SplitButton_renders_a_DropMenu/The_user_opens_the_DropMenu.js
@@ -1,0 +1,10 @@
+import '../common/index'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a SplitButton with opened DropMenu is rendered', () => {
+    cy.visitStory('SplitButton: Basic', 'Default')
+})
+
+Then('the DropMenu is rendered', () => {
+    cy.get('.split-button-dropmenu').should('exist')
+})

--- a/cypress/integration/SplitButton/common/index.js
+++ b/cypress/integration/SplitButton/common/index.js
@@ -1,0 +1,13 @@
+import { Given, When } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a SplitButton with closed DropMenu is rendered', () => {
+    cy.visitStory('SplitButton: Basic', 'Default')
+})
+
+When('the SplitButton is clicked', () => {
+    cy.get('button:first-child').click()
+})
+
+When('the SplitButton arrow icon is clicked', () => {
+    cy.get('button:nth-child(2)').click()
+})

--- a/cypress/integration/Switch/The_Switch_has_an_onBlur_api.feature
+++ b/cypress/integration/Switch/The_Switch_has_an_onBlur_api.feature
@@ -1,0 +1,7 @@
+Feature: The Switch has an onBlur api
+
+    Scenario: The user focuses the next the Switch
+        Given an focused Switch is rendered
+        And the Switch is provided with an onBlur handler
+        When the next Switch is focused
+        Then the onBlur handler is called

--- a/cypress/integration/Switch/The_Switch_has_an_onBlur_api/The_user_blurs_the_Switch.js
+++ b/cypress/integration/Switch/The_Switch_has_an_onBlur_api/The_user_blurs_the_Switch.js
@@ -1,0 +1,31 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an focused Switch is rendered', () => {
+    cy.visitStory('Switch', 'Focused unchecked')
+    cy.focused().then($el => {
+        expect($el.parents('label')).to.have.class('initially-focused')
+    })
+})
+
+Given('the Switch is provided with an onBlur handler', () => {
+    cy.window().then(win => {
+        win.onBlur = cy.stub()
+    })
+})
+
+When('the next Switch is focused', () => {
+    cy.get('.initially-unfocused input').focus()
+    cy.focused().then($el => {
+        expect($el.parents('label')).to.have.class('initially-unfocused')
+    })
+})
+
+Then('the onBlur handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onBlur).to.be.calledWith({
+            value: 'default',
+            name: 'Ex',
+            checked: true,
+        })
+    })
+})

--- a/cypress/integration/Switch/The_Switch_has_an_onChange_api.feature
+++ b/cypress/integration/Switch/The_Switch_has_an_onChange_api.feature
@@ -1,0 +1,7 @@
+Feature: The Switch has an onChange api
+
+    Scenario: The user ticks the Switch
+        Given an unchecked Switch is rendered
+        And the Switch is provided with an onChange handler
+        When the Switch is ticked
+        Then the onChange handler is called

--- a/cypress/integration/Switch/The_Switch_has_an_onChange_api/The_user_ticks_the_Switch.js
+++ b/cypress/integration/Switch/The_Switch_has_an_onChange_api/The_user_ticks_the_Switch.js
@@ -1,0 +1,25 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an unchecked Switch is rendered', () => {
+    cy.visitStory('Switch', 'Default')
+})
+
+Given('the Switch is provided with an onChange handler', () => {
+    cy.window().then(win => {
+        win.onChange = cy.stub()
+    })
+})
+
+When('the Switch is ticked', () => {
+    cy.get('label').click()
+})
+
+Then('the onChange handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledWith({
+            value: 'default',
+            name: 'Ex',
+            checked: true,
+        })
+    })
+})

--- a/cypress/integration/Switch/The_Switch_has_an_onFocus_api.feature
+++ b/cypress/integration/Switch/The_Switch_has_an_onFocus_api.feature
@@ -1,0 +1,7 @@
+Feature: The Switch has an onFocus api
+
+    Scenario: The user focuses the Switch
+        Given an unfocused Switch is rendered
+        And the Switch is provided with an onFocus handler
+        When the Switch is focused
+        Then the onFocus handler is called

--- a/cypress/integration/Switch/The_Switch_has_an_onFocus_api/The_user_focuses_the_Switch.js
+++ b/cypress/integration/Switch/The_Switch_has_an_onFocus_api/The_user_focuses_the_Switch.js
@@ -1,0 +1,25 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an unfocused Switch is rendered', () => {
+    cy.visitStory('Switch', 'Default')
+})
+
+Given('the Switch is provided with an onFocus handler', () => {
+    cy.window().then(win => {
+        win.onFocus = cy.stub()
+    })
+})
+
+When('the Switch is focused', () => {
+    cy.get('input').focus()
+})
+
+Then('the onFocus handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onFocus).to.be.calledWith({
+            value: 'default',
+            name: 'Ex',
+            checked: true,
+        })
+    })
+})

--- a/cypress/integration/Tab/The_Tab_has_an_onClick_api.feature
+++ b/cypress/integration/Tab/The_Tab_has_an_onClick_api.feature
@@ -1,0 +1,7 @@
+Feature: The Tab has an onClick api
+
+    Scenario: The user clicks on the Tab
+        Given a Tab is rendered
+        And the Tab is provided with an onClick handler
+        When the Tab is clicked
+        Then the onClick handler is called

--- a/cypress/integration/Tab/The_Tab_has_an_onClick_api/The_user_clicks_on_the_Tab.js
+++ b/cypress/integration/Tab/The_Tab_has_an_onClick_api/The_user_clicks_on_the_Tab.js
@@ -1,0 +1,19 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a Tab is rendered', () => {
+    cy.visitStory('TabBar', 'Default (fluid)')
+})
+
+Given('the Tab is provided with an onClick handler', () => {
+    cy.window().then(win => (win.onClick = cy.stub()))
+})
+
+When('the Tab is clicked', () => {
+    cy.get('.tab:first-child').click()
+})
+
+Then('the onClick handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onClick).to.be.calledWith({})
+    })
+})

--- a/cypress/integration/TextArea/The_TextArea_has_an_onBlur_api.feature
+++ b/cypress/integration/TextArea/The_TextArea_has_an_onBlur_api.feature
@@ -1,0 +1,7 @@
+Feature: The TextArea has an onBlur api
+
+    Scenario: The user focuses the next the TextArea
+        Given a focused TextArea is rendered
+        And the TextArea is provided with an onBlur handler
+        When the next TextArea is focused
+        Then the onBlur handler is called

--- a/cypress/integration/TextArea/The_TextArea_has_an_onBlur_api/The_user_blurs_the_TextArea.js
+++ b/cypress/integration/TextArea/The_TextArea_has_an_onBlur_api/The_user_blurs_the_TextArea.js
@@ -1,0 +1,27 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a focused TextArea is rendered', () => {
+    cy.visitStory('TextArea', 'Focus')
+})
+
+Given('the TextArea is provided with an onBlur handler', () => {
+    cy.window().then(win => {
+        win.onBlur = cy.stub()
+    })
+})
+
+When('the next TextArea is focused', () => {
+    cy.get('.initially-unfocused textarea').focus()
+    cy.focused().then($el => {
+        expect($el.parent()).to.have.class('initially-unfocused')
+    })
+})
+
+Then('the onBlur handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onBlur).to.be.calledWith({
+            value: '',
+            name: 'textarea',
+        })
+    })
+})

--- a/cypress/integration/TextArea/The_TextArea_has_an_onChange_api.feature
+++ b/cypress/integration/TextArea/The_TextArea_has_an_onChange_api.feature
@@ -1,0 +1,7 @@
+Feature: The TextArea has an onChange api
+
+    Scenario: The user types a character into the TextArea
+        Given an empty TextArea is rendered
+        And the TextArea is provided with an onChange handler
+        When the TextArea is filled with a character
+        Then the onChange handler is called

--- a/cypress/integration/TextArea/The_TextArea_has_an_onChange_api/The_user_ticks_the_TextArea.js
+++ b/cypress/integration/TextArea/The_TextArea_has_an_onChange_api/The_user_ticks_the_TextArea.js
@@ -1,0 +1,21 @@
+import '../common/index'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('the TextArea is provided with an onChange handler', () => {
+    cy.window().then(win => {
+        win.onChange = cy.stub()
+    })
+})
+
+When('the TextArea is filled with a character', () => {
+    cy.get('textarea').type('a')
+})
+
+Then('the onChange handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledWith({
+            value: 'a',
+            name: 'textarea',
+        })
+    })
+})

--- a/cypress/integration/TextArea/The_TextArea_has_an_onFocus_api.feature
+++ b/cypress/integration/TextArea/The_TextArea_has_an_onFocus_api.feature
@@ -1,0 +1,7 @@
+Feature: The TextArea has an onFocus api
+
+    Scenario: The user focuses the TextArea
+        Given an empty TextArea is rendered
+        And the TextArea is provided with an onFocus handler
+        When the TextArea is focused
+        Then the onFocus handler is called

--- a/cypress/integration/TextArea/The_TextArea_has_an_onFocus_api/The_user_focuses_the_TextArea.js
+++ b/cypress/integration/TextArea/The_TextArea_has_an_onFocus_api/The_user_focuses_the_TextArea.js
@@ -1,0 +1,21 @@
+import '../common/index'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('the TextArea is provided with an onFocus handler', () => {
+    cy.window().then(win => {
+        win.onFocus = cy.stub()
+    })
+})
+
+When('the TextArea is focused', () => {
+    cy.get('textarea').focus()
+})
+
+Then('the onFocus handler is called', () => {
+    cy.window().then(win => {
+        expect(win.onFocus).to.be.calledWith({
+            value: '',
+            name: 'textarea',
+        })
+    })
+})

--- a/cypress/integration/TextArea/common/index.js
+++ b/cypress/integration/TextArea/common/index.js
@@ -1,0 +1,5 @@
+import { Given } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an empty TextArea is rendered', () => {
+    cy.visitStory('TextArea', 'Default')
+})

--- a/cypress/support/visitStory.js
+++ b/cypress/support/visitStory.js
@@ -1,6 +1,12 @@
+const urlEncodeStoryBookName = name =>
+    name
+        .replace(/\(|\)/g, '')
+        .replace(/[^a-zA-Z0-9]+/g, '-')
+        .toLowerCase()
+
 Cypress.Commands.add('visitStory', (namespace, storyName) => {
-    const formattedNamespace = namespace.toLowerCase()
-    const formattedStoryName = storyName.replace(/ /g, '-').toLowerCase()
+    const formattedNamespace = urlEncodeStoryBookName(namespace)
+    const formattedStoryName = urlEncodeStoryBookName(storyName)
     const id = `${formattedNamespace}--${formattedStoryName}`
     cy.visit(`iframe.html?id=${id}`)
 })

--- a/src/AlertBar.js
+++ b/src/AlertBar.js
@@ -20,6 +20,8 @@ import styles, { ANIMATION_TIME } from './AlertBar/styles.js'
  * @see Live demo: {@link /demo/?path=/story/alertbar--default|Storybook}
  */
 class AlertBar extends Component {
+    // visible is used to control the show/hide animation
+    // hidden is used to stop rendering entirely after hide animation
     state = {
         visible: false,
         hidden: false,
@@ -54,7 +56,7 @@ class AlertBar extends Component {
     startDisplayTimeout = () => {
         if (this.shouldAutoHide()) {
             this.displayTimeout = setTimeout(() => {
-                this.hide()
+                this.hide(null)
             }, this.timeRemaining)
         }
     }
@@ -67,13 +69,15 @@ class AlertBar extends Component {
         }
     }
 
-    hide = () => {
+    hide = event => {
         clearTimeout(this.displayTimeout)
         this.setState({ visible: false })
 
         this.onHiddenTimeout = setTimeout(() => {
-            this.setState({ hidden: true })
-            this.props.onHidden && this.props.onHidden()
+            this.setState(
+                { hidden: true },
+                () => this.props.onHidden && this.props.onHidden({}, event)
+            )
         }, ANIMATION_TIME)
     }
 

--- a/src/AlertBar/Action.js
+++ b/src/AlertBar/Action.js
@@ -3,9 +3,9 @@ import propTypes from '@dhis2/prop-types'
 import { spacers } from '../theme.js'
 
 class Action extends Component {
-    onClick = () => {
-        this.props.onClick()
-        this.props.hide()
+    onClick = event => {
+        this.props.onClick(event)
+        this.props.hide(event)
     }
 
     render() {

--- a/src/Backdrop.js
+++ b/src/Backdrop.js
@@ -15,7 +15,10 @@ const Backdrop = ({ onClick, transparent, children, zIndex, className }) => {
     return (
         <Layer zIndexBase={layers.blocking} zIndex={zIndex}>
             {zIndexComputed => (
-                <div className={cx('backdrop', className)} onClick={onClick}>
+                <div
+                    className={cx('backdrop', className)}
+                    onClick={event => onClick({}, event)}
+                >
                     <div
                         onClick={e => {
                             // stop events from bubbling up through the

--- a/src/Button.js
+++ b/src/Button.js
@@ -45,7 +45,7 @@ export class Button extends Component {
         return (
             <button
                 disabled={disabled}
-                onClick={onClick}
+                onClick={event => onClick({ name, value }, event)}
                 className={cx(className, {
                     primary,
                     secondary,

--- a/src/Chip.js
+++ b/src/Chip.js
@@ -18,7 +18,7 @@ import { Remove } from './Chip/Remove.js'
 class Chip extends Component {
     onClick = e => {
         if (!this.props.disabled && this.props.onClick) {
-            this.props.onClick(e)
+            this.props.onClick({}, e)
         }
     }
 
@@ -43,7 +43,7 @@ class Chip extends Component {
             >
                 <Icon icon={this.props.icon} />
                 <Content overflow={overflow}>{children}</Content>
-                <Remove onRemove={this.props.onRemove} />
+                <Remove onRemove={event => this.props.onRemove({}, event)} />
 
                 <style jsx>{`
                     span {

--- a/src/DropMenu.js
+++ b/src/DropMenu.js
@@ -63,7 +63,7 @@ class DropMenu extends Component {
             !this.elContainer.current.contains(evt.target) &&
             !this.props.stayOpen
         ) {
-            this.props.onClose()
+            this.props.onClose({}, evt)
         }
     }
 

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -19,10 +19,17 @@ class DropdownButton extends Component {
     }
     anchorRef = React.createRef()
 
-    onToggle = (_, event) => {
+    onToggle = ({ name, value }, event) => {
         this.setState({ open: !this.state.open }, () => {
             if (this.props.onClick) {
-                this.props.onClick({ open: this.state.open }, event)
+                this.props.onClick(
+                    {
+                        name,
+                        value,
+                        open: this.state.open,
+                    },
+                    event
+                )
             }
         })
     }
@@ -34,7 +41,7 @@ class DropdownButton extends Component {
 
         return (
             <div ref={this.anchorRef}>
-                <Button onClick={this.onToggle} {...this.props}>
+                <Button {...this.props} onClick={this.onToggle}>
                     {this.props.children}
 
                     {ArrowIcon}
@@ -42,6 +49,7 @@ class DropdownButton extends Component {
 
                 {open && (
                     <DropMenu
+                        className="dropdown-button-dropmenu"
                         component={this.props.component}
                         onClose={() => this.setState({ open: false })}
                         anchorEl={this.anchorRef.current}

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -19,7 +19,13 @@ class DropdownButton extends Component {
     }
     anchorRef = React.createRef()
 
-    onToggle = () => this.setState({ open: !this.state.open })
+    onToggle = (_, event) => {
+        this.setState({ open: !this.state.open }, () => {
+            if (this.props.onClick) {
+                this.props.onClick({ open: this.state.open }, event)
+            }
+        })
+    }
 
     render() {
         const { open } = this.state
@@ -79,6 +85,8 @@ DropdownButton.propTypes = {
     component: propTypes.element.isRequired,
     icon: propTypes.element,
     children: propTypes.string,
+
+    onClick: propTypes.func,
 
     small: sizePropType,
     large: sizePropType,

--- a/src/FileListItem.js
+++ b/src/FileListItem.js
@@ -32,13 +32,13 @@ const FileListItem = ({
             <span className="label">{label}</span>
 
             {loading && onCancel && cancelText && (
-                <span className="action" onClick={onCancel}>
+                <span className="action" onClick={event => onCancel({}, event)}>
                     {cancelText}
                 </span>
             )}
 
             {!loading && (
-                <span className="action" onClick={onRemove}>
+                <span className="action" onClick={event => onRemove({}, event)}>
                     {removeText}
                 </span>
             )}

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -44,7 +44,7 @@ const createOnClickHandler = (onClick, value) => evt => {
     if (onClick) {
         evt.preventDefault()
         evt.stopPropagation()
-        onClick(value)
+        onClick({ value }, evt)
     }
 }
 

--- a/src/Node.js
+++ b/src/Node.js
@@ -38,7 +38,9 @@ const Arrow = ({ hasLeaves, open, onOpen, onClose }) => {
                 'has-leaves': hasLeaves,
             })}
         >
-            <span onClick={onClick}>{arrowIcon}</span>
+            <span onClick={event => onClick({ open: !open }, event)}>
+                {arrowIcon}
+            </span>
 
             <style jsx>{`
                 div {

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -34,6 +34,19 @@ class SplitButton extends Component {
     }
     anchorRef = React.createRef()
 
+    onClick = (payload, event) => {
+        if (this.props.onClick) {
+            this.props.onClick(
+                {
+                    name: payload.name,
+                    value: payload.value,
+                    open: this.state.open,
+                },
+                event
+            )
+        }
+    }
+
     onToggle = () => this.setState({ open: !this.state.open })
 
     render() {
@@ -43,7 +56,11 @@ class SplitButton extends Component {
 
         return (
             <div ref={this.anchorRef}>
-                <Button {...this.props} className={cx(this.props.className)}>
+                <Button
+                    {...this.props}
+                    onClick={this.onClick}
+                    className={cx(this.props.className)}
+                >
                     {this.props.children}
                 </Button>
 
@@ -57,6 +74,7 @@ class SplitButton extends Component {
 
                 {open && (
                     <DropMenu
+                        className="split-button-dropmenu"
                         component={this.props.component}
                         onClose={() => this.setState({ open: false })}
                         anchorEl={this.anchorRef.current}

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -19,7 +19,7 @@ const Tab = ({ icon, onClick, selected, disabled, children, className }) => (
             selected,
             disabled,
         })}`}
-        onClick={disabled ? undefined : onClick}
+        onClick={disabled ? undefined : event => onClick({}, event)}
     >
         {icon}
         <span>{children}</span>

--- a/stories/AlertBar.stories.js
+++ b/stories/AlertBar.stories.js
@@ -48,10 +48,25 @@ storiesOf('AlertBar', module)
             <AlertBar className="third" critical>
                 Critial never auto-hides
             </AlertBar>
-            <AlertBar className="fourth" duration={2000}>
+            <AlertBar
+                className="fourth"
+                duration={2000}
+                onHidden={(payload, event) => {
+                    console.log('onHidden payload', payload)
+                    console.log('onHidden event', event)
+                }}
+            >
                 Custom duration, hides after 2s
             </AlertBar>
-            <AlertBar className="fifth">Default auto-hides after 8s</AlertBar>
+            <AlertBar
+                className="fifth"
+                onHidden={(payload, event) => {
+                    console.log('onHidden payload', payload)
+                    console.log('onHidden event', event)
+                }}
+            >
+                Default auto-hides after 8s
+            </AlertBar>
         </React.Fragment>
     ))
     .add('With actions', () => (

--- a/stories/Backdrop.stories.testing.js
+++ b/stories/Backdrop.stories.testing.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { Backdrop } from '../src/Backdrop'
+
+// default onClick, should be overriden with a stub by cypress
+window.onClick = (payload, event) => {
+    console.log('onClick payload', payload)
+    console.log('onClick event', event)
+}
+
+const onClick = (...args) => window.onClick(...args)
+
+storiesOf('Backdrop', module).add('Default', () => (
+    <Backdrop onClick={onClick} />
+))

--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -31,30 +31,40 @@ createStory('Button: Destructive', {
     destructive: true,
 })
 
+window.onClick = (payload, event) => {
+    console.log('onClick payload', payload)
+    console.log('onClick event', event)
+}
+const onClick = (...args) => window.onClick(...args)
+
 function createStory(name, props) {
     storiesOf(name, module)
-        .add('Default', () => <Button {...props}>Label me!</Button>)
+        .add('Default', () => (
+            <Button {...props} onClick={onClick}>
+                Label me!
+            </Button>
+        ))
 
         .add('Disabled', () => (
-            <Button {...props} disabled>
+            <Button {...props} disabled onClick={onClick}>
                 Label me!
             </Button>
         ))
 
         .add('Small', () => (
-            <Button {...props} small>
+            <Button {...props} small onClick={onClick}>
                 Label me!
             </Button>
         ))
 
         .add('Large', () => (
-            <Button {...props} large>
+            <Button {...props} large onClick={onClick}>
                 Label me!
             </Button>
         ))
 
         .add('Focus', () => (
-            <Button {...props} initialFocus>
+            <Button {...props} initialFocus onClick={onClick}>
                 Label me!
             </Button>
         ))

--- a/stories/Checkbox.stories.js
+++ b/stories/Checkbox.stories.js
@@ -3,8 +3,24 @@ import React from 'react'
 
 import { Checkbox } from '../src'
 
-const logger = ({ name, value, checked }) =>
-    console.info(`name: ${name}, value: ${value}, checked: ${checked}`)
+window.onChange = (payload, event) => {
+    console.log('onClick payload', payload)
+    console.log('onClick event', event)
+}
+
+window.onFocus = (payload, event) => {
+    console.log('onFocus payload', payload)
+    console.log('onFocus event', event)
+}
+
+window.onBlur = (payload, event) => {
+    console.log('onBlur payload', payload)
+    console.log('onBlur event', event)
+}
+
+const onChange = (...args) => window.onChange(...args)
+const onFocus = (...args) => window.onFocus(...args)
+const onBlur = (...args) => window.onBlur(...args)
 
 storiesOf('Checkbox', module)
     // Regular
@@ -13,29 +29,58 @@ storiesOf('Checkbox', module)
             name="Ex"
             label="Checkbox"
             value="default"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
     .add('Focused unchecked', () => (
-        <Checkbox
-            initialFocus
-            name="Ex"
-            label="Checkbox"
-            value="default"
-            onChange={logger}
-        />
+        <>
+            <Checkbox
+                initialFocus
+                name="Ex"
+                label="Checkbox"
+                value="default"
+                className="initially-focused"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+            <Checkbox
+                name="Ex2"
+                label="Checkbox"
+                value="default2"
+                className="initially-unfocused"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+        </>
     ))
 
     .add('Focused checked', () => (
-        <Checkbox
-            initialFocus
-            checked
-            name="Ex"
-            label="Checkbox"
-            value="default"
-            onChange={logger}
-        />
+        <>
+            <Checkbox
+                initialFocus
+                checked
+                name="Ex"
+                label="Checkbox"
+                value="default"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+            <Checkbox
+                checked
+                name="Ex2"
+                label="Checkbox"
+                value="default2"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+        </>
     ))
 
     .add('Checked', () => (
@@ -44,7 +89,9 @@ storiesOf('Checkbox', module)
             label="Checkbox"
             checked
             value="checked"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -54,7 +101,9 @@ storiesOf('Checkbox', module)
             label="Checkbox"
             indeterminate
             value="checked"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -65,7 +114,9 @@ storiesOf('Checkbox', module)
                 label="Checkbox"
                 disabled
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Checkbox
                 name="Ex"
@@ -73,7 +124,9 @@ storiesOf('Checkbox', module)
                 disabled
                 checked
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -85,7 +138,9 @@ storiesOf('Checkbox', module)
                 label="Checkbox"
                 valid
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Checkbox
                 name="Ex"
@@ -93,7 +148,9 @@ storiesOf('Checkbox', module)
                 valid
                 checked
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -105,7 +162,9 @@ storiesOf('Checkbox', module)
                 label="Checkbox"
                 warning
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Checkbox
                 name="Ex"
@@ -113,7 +172,9 @@ storiesOf('Checkbox', module)
                 warning
                 checked
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -125,7 +186,9 @@ storiesOf('Checkbox', module)
                 label="Checkbox"
                 error
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Checkbox
                 name="Ex"
@@ -133,7 +196,9 @@ storiesOf('Checkbox', module)
                 error
                 checked
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -143,7 +208,9 @@ storiesOf('Checkbox', module)
             name="Ex"
             label={<img src="https://picsum.photos/id/82/200/100" />}
             value="with-help"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -154,7 +221,9 @@ storiesOf('Checkbox', module)
             name="Ex"
             label="Checkbox"
             value="default"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -165,7 +234,9 @@ storiesOf('Checkbox', module)
             name="Ex"
             label="Checkbox"
             value="default"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -177,7 +248,9 @@ storiesOf('Checkbox', module)
             name="Ex"
             label="Checkbox"
             value="default"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -188,7 +261,9 @@ storiesOf('Checkbox', module)
             label="Checkbox"
             checked
             value="checked"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -199,7 +274,9 @@ storiesOf('Checkbox', module)
             label="Checkbox"
             indeterminate
             value="checked"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -211,7 +288,9 @@ storiesOf('Checkbox', module)
                 label="Checkbox"
                 disabled
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Checkbox
                 dense
@@ -220,7 +299,9 @@ storiesOf('Checkbox', module)
                 disabled
                 checked
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -233,7 +314,9 @@ storiesOf('Checkbox', module)
                 label="Checkbox"
                 valid
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Checkbox
                 dense
@@ -242,7 +325,9 @@ storiesOf('Checkbox', module)
                 valid
                 checked
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -255,7 +340,9 @@ storiesOf('Checkbox', module)
                 label="Checkbox"
                 warning
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Checkbox
                 dense
@@ -264,7 +351,9 @@ storiesOf('Checkbox', module)
                 warning
                 checked
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -277,7 +366,9 @@ storiesOf('Checkbox', module)
                 label="Checkbox"
                 error
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Checkbox
                 dense
@@ -286,7 +377,9 @@ storiesOf('Checkbox', module)
                 error
                 checked
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -297,6 +390,8 @@ storiesOf('Checkbox', module)
             name="Ex"
             label={<img src="https://picsum.photos/id/82/200/100" />}
             value="with-help"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))

--- a/stories/Chip.stories.js
+++ b/stories/Chip.stories.js
@@ -2,25 +2,45 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Chip } from '../src'
 
+window.onClick = (payload, event) => {
+    console.log('onClick payload', payload)
+    console.log('onClick event', event)
+}
+
+window.onRemove = (payload, event) => {
+    console.log('onRemove payload', payload)
+    console.log('onRemove event', event)
+}
+
+const onClick = (...args) => window.onClick(...args)
+const onRemove = (...args) => window.onRemove(...args)
+
 storiesOf('Chip', module)
-    .add('Default', () => <Chip>Chippy</Chip>)
+    .add('Default', () => <Chip onClick={onClick}>Chippy</Chip>)
 
-    .add('Selected', () => <Chip selected>Chipmunk</Chip>)
-
-    .add('Overflow', () => (
-        <Chip selected>A super long chip which should definitely truncate</Chip>
-    ))
-
-    .add('Removable', () => (
-        <Chip
-            onClick={e => console.log('click', e)}
-            onRemove={e => console.log('remove', e)}
-        >
+    .add('Selected', () => (
+        <Chip selected onClick={onClick}>
             Chipmunk
         </Chip>
     ))
 
-    .add('Icon', () => <Chip icon={<Globe />}>With an icon</Chip>)
+    .add('Overflow', () => (
+        <Chip selected onClick={onClick}>
+            A super long chip which should definitely truncate
+        </Chip>
+    ))
+
+    .add('Removable', () => (
+        <Chip onClick={onClick} onRemove={onRemove}>
+            Chipmunk
+        </Chip>
+    ))
+
+    .add('Icon', () => (
+        <Chip onClick={onClick} icon={<Globe />}>
+            With an icon
+        </Chip>
+    ))
 
 const Globe = () => (
     <svg role="img" viewBox="0 0 24 24" height="100px" width="100px">

--- a/stories/DropdownButton.stories.js
+++ b/stories/DropdownButton.stories.js
@@ -4,6 +4,13 @@ import { DropdownButton } from '../src'
 
 import { Menu, MenuItem, Divider, Switch } from '../src'
 
+window.onClick = (payload, event) => {
+    console.log('onClick payload', payload)
+    console.log('onClick event', event)
+}
+
+const onClick = (...args) => window.onClick(...args)
+
 const componentMenu = (
     <Menu>
         <MenuItem
@@ -73,6 +80,7 @@ createStory('DropdownButton: Basic', {
     name: 'Button',
     value: 'default',
     component: Simple,
+    onClick,
 })
 
 createStory('DropdownButton: Primary', {
@@ -80,6 +88,7 @@ createStory('DropdownButton: Primary', {
     value: 'default',
     primary: true,
     component: Simple,
+    onClick,
 })
 
 createStory('DropdownButton: Secondary', {
@@ -87,6 +96,7 @@ createStory('DropdownButton: Secondary', {
     value: 'default',
     secondary: true,
     component: Simple,
+    onClick,
 })
 
 createStory('DropdownButton: Destructive', {
@@ -94,6 +104,7 @@ createStory('DropdownButton: Destructive', {
     value: 'default',
     destructive: true,
     component: Simple,
+    onClick,
 })
 
 function createStory(name, props) {

--- a/stories/FileListItem.stories.testing.js
+++ b/stories/FileListItem.stories.testing.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { FileListItem } from '../src'
+
+window.onRemove = (payload, event) => {
+    console.log('onRemove payload', payload)
+    console.log('onRemove event', event)
+}
+
+window.onCancel = (payload, event) => {
+    console.log('onCancel payload', payload)
+    console.log('onCancel event', event)
+}
+
+const onRemove = (...args) => window.onRemove(...args)
+const onCancel = (...args) => window.onCancel(...args)
+
+storiesOf('FileListItem', module)
+    .add('Default', () => (
+        <FileListItem
+            label="File list item"
+            onRemove={onRemove}
+            removeText="Remove"
+        />
+    ))
+    .add('Loading', () => (
+        <FileListItem
+            loading
+            label="File list item"
+            onRemove={onRemove}
+            removeText="Remove"
+            onCancel={onCancel}
+            cancelText="Cancel"
+        />
+    ))

--- a/stories/Input.stories.testing.js
+++ b/stories/Input.stories.testing.js
@@ -1,0 +1,43 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import { Input } from '../src'
+
+window.onChange = (payload, event) => {
+    console.log('onChange payload', payload)
+    console.log('onChange event', event)
+}
+
+window.onFocus = (payload, event) => {
+    console.log('onFocus payload', payload)
+    console.log('onFocus event', event)
+}
+
+window.onBlur = (payload, event) => {
+    console.log('onBlur payload', payload)
+    console.log('onBlur event', event)
+}
+
+const onChange = (...args) => window.onChange(...args)
+const onFocus = (...args) => window.onFocus(...args)
+const onBlur = (...args) => window.onBlur(...args)
+
+createStory('Input', {
+    label: 'Default label',
+    name: 'Default',
+    value: '',
+    onChange,
+    onFocus,
+    onBlur,
+})
+
+function createStory(name, props) {
+    return storiesOf(name, module)
+        .add('Default', () => <Input {...props} />)
+        .add('Focus', () => (
+            <>
+                <Input className="initially-focused" {...props} initialFocus />
+                <Input className="initially-unfocused" {...props} />
+            </>
+        ))
+}

--- a/stories/MenuItem.stories.testing.js
+++ b/stories/MenuItem.stories.testing.js
@@ -1,0 +1,15 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import { MenuItem } from '../src'
+
+window.onClick = (payload, event) => {
+    console.log('onClick payload', payload)
+    console.log('onClick event', event)
+}
+
+const onClick = (...args) => window.onClick(...args)
+
+storiesOf('MenuItem', module).add('Default', () => (
+    <MenuItem label="Menu item" value="default" onClick={onClick} />
+))

--- a/stories/Modal.stories.js
+++ b/stories/Modal.stories.js
@@ -14,9 +14,16 @@ import {
 
 const say = something => () => alert(something)
 
+window.onClose = (payload, event) => {
+    console.log('onClose payload', payload)
+    console.log('onClose event', event)
+}
+
+const onClose = (...args) => window.onClose(...args)
+
 storiesOf('Modal', module)
     .add('Small: Title, Content, Action', () => (
-        <Modal open small>
+        <Modal open small onClose={onClose}>
             <ModalTitle>
                 This is a small modal with title, content and primary action
             </ModalTitle>

--- a/stories/Node.stories.js
+++ b/stories/Node.stories.js
@@ -6,13 +6,26 @@ import { Node } from '../src/Node'
 
 const say = something => () => alert(something)
 
+window.onOpen = (payload, event) => {
+    console.log('onOpen payload', payload)
+    console.log('onOpen event', event)
+}
+
+window.onClose = (payload, event) => {
+    console.log('onClose payload', payload)
+    console.log('onClose event', event)
+}
+
+const onOpen = (...args) => window.onOpen(...args)
+const onClose = (...args) => window.onClose(...args)
+
 storiesOf('Node', module)
     .add('Multiple roots', () => (
         <div>
             <Node
                 open={false}
-                onOpen={say('open tree 1.1')}
-                onClose={say('close tree 1.1')}
+                onOpen={onOpen}
+                onClose={onClose}
                 component={
                     <Checkbox
                         label="Node label 1.1"
@@ -28,8 +41,8 @@ storiesOf('Node', module)
 
             <Node
                 open={false}
-                onOpen={say('open tree 1.2')}
-                onClose={say('close tree 1.2')}
+                onOpen={onOpen}
+                onClose={onClose}
                 component={
                     <Checkbox
                         label="Node label 1.2"
@@ -48,8 +61,8 @@ storiesOf('Node', module)
     .add('2 Levels open', () => (
         <Node
             open={true}
-            onOpen={say('open tree 1.1')}
-            onClose={say('close tree 1.1')}
+            onOpen={onOpen}
+            onClose={onClose}
             component={
                 <Checkbox
                     label="Node label"
@@ -62,8 +75,8 @@ storiesOf('Node', module)
         >
             <Node
                 open={true}
-                onOpen={say('open tree 2.1')}
-                onClose={say('close tree 2.1')}
+                onOpen={onOpen}
+                onClose={onClose}
                 component={
                     <Checkbox
                         label="Node label"
@@ -110,7 +123,7 @@ storiesOf('Node', module)
             </Node>
             <Node
                 open={false}
-                onOpen={say('open tree 2.2')}
+                onOpen={onOpen}
                 onCLose={say('close tree 2.2')}
                 component={
                     <Checkbox
@@ -158,8 +171,8 @@ storiesOf('Node', module)
             </Node>
             <Node
                 open={false}
-                onOpen={say('open tree 2.3')}
-                onClose={say('close tree 2.3')}
+                onOpen={onOpen}
+                onClose={onClose}
                 component={
                     <Checkbox
                         label="Node label"
@@ -172,8 +185,8 @@ storiesOf('Node', module)
             />
             <Node
                 open={false}
-                onOpen={say('open tree 2.4')}
-                onClose={say('close tree 2.4')}
+                onOpen={onOpen}
+                onClose={onClose}
                 component={
                     <Checkbox
                         label="Node label"
@@ -186,8 +199,8 @@ storiesOf('Node', module)
             />
             <Node
                 open={false}
-                onOpen={say('open tree 2.5')}
-                onClose={say('close tree 2.5')}
+                onOpen={onOpen}
+                onClose={onClose}
                 component={
                     <Checkbox
                         label="Node label"
@@ -200,8 +213,8 @@ storiesOf('Node', module)
             />
             <Node
                 open={false}
-                onOpen={say('open tree 2.5')}
-                onClose={say('close tree 2.5')}
+                onOpen={onOpen}
+                onClose={onClose}
                 component={
                     <Checkbox
                         label="Node label"
@@ -221,8 +234,8 @@ storiesOf('Node', module)
         <div>
             <Node
                 open={true}
-                onOpen={say('open tree level 1')}
-                onClose={say('close tree level 1')}
+                onOpen={onOpen}
+                onClose={onClose}
                 arrowTopOffset="10px"
                 component={
                     <h2>
@@ -242,8 +255,8 @@ storiesOf('Node', module)
                 <div className="sub-tree sub-tree--open">
                     <Node
                         open={true}
-                        onOpen={say('open tree level 2.1')}
-                        onClose={say('close tree level 2.1')}
+                        onOpen={onOpen}
+                        onClose={onClose}
                         component={
                             <h2>
                                 Lorem ipsum dolor sit amet, consetetur
@@ -266,8 +279,8 @@ storiesOf('Node', module)
                 <div className="sub-tree">
                     <Node
                         open={false}
-                        onOpen={say('open tree level 2.2')}
-                        onClose={say('close tree level 2.2')}
+                        onOpen={onOpen}
+                        onClose={onClose}
                         component={
                             <h2>
                                 Lorem ipsum dolor sit amet, consetetur
@@ -281,8 +294,8 @@ storiesOf('Node', module)
                 <div className="sub-tree">
                     <Node
                         open={false}
-                        onOpen={say('open tree level 2.3')}
-                        onClose={say('close tree level 2.3')}
+                        onOpen={onOpen}
+                        onClose={onClose}
                         component={
                             <h2>
                                 Lorem ipsum dolor sit amet, consetetur
@@ -296,8 +309,8 @@ storiesOf('Node', module)
                 <div className="sub-tree">
                     <Node
                         open={false}
-                        onOpen={say('open tree level 2.4')}
-                        onClose={say('close tree level 2.4')}
+                        onOpen={onOpen}
+                        onClose={onClose}
                         component={
                             <h2>
                                 Lorem ipsum dolor sit amet, consetetur
@@ -311,8 +324,8 @@ storiesOf('Node', module)
                 <div className="sub-tree">
                     <Node
                         open={false}
-                        onOpen={say('open tree level 2.5')}
-                        onClose={say('close tree level 2.5')}
+                        onOpen={onOpen}
+                        onClose={onClose}
                         component={
                             <h2>
                                 Lorem ipsum dolor sit amet, consetetur

--- a/stories/Radio.stories.js
+++ b/stories/Radio.stories.js
@@ -3,34 +3,85 @@ import React from 'react'
 
 import { Radio } from '../src'
 
-const logger = ({ name, value, checked }) =>
-    console.info(`name: ${name}, value: ${value}, checked: ${checked}`)
+window.onChange = (payload, event) => {
+    console.log('onChange payload', payload)
+    console.log('onChange event', event)
+}
+
+window.onFocus = (payload, event) => {
+    console.log('onFocus payload', payload)
+    console.log('onFocus event', event)
+}
+
+window.onBlur = (payload, event) => {
+    console.log('onBlur payload', payload)
+    console.log('onBlur event', event)
+}
+
+const onChange = (...args) => window.onChange(...args)
+const onFocus = (...args) => window.onFocus(...args)
+const onBlur = (...args) => window.onBlur(...args)
 
 storiesOf('Radio', module)
     // Regular
     .add('Default', () => (
-        <Radio name="Ex" label="Radio" value="default" onChange={logger} />
+        <Radio
+            name="Ex"
+            label="Radio"
+            value="default"
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+        />
     ))
 
     .add('Focused unchecked', () => (
-        <Radio
-            initialFocus
-            name="Ex"
-            label="Radio"
-            value="default"
-            onChange={logger}
-        />
+        <>
+            <Radio
+                initialFocus
+                name="Ex"
+                label="Radio"
+                value="default"
+                className="initially-focused"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+            <Radio
+                name="Ex"
+                label="Radio"
+                value="default"
+                className="initially-unfocused"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+        </>
     ))
 
     .add('Focused checked', () => (
-        <Radio
-            initialFocus
-            checked
-            name="Ex"
-            label="Radio"
-            value="default"
-            onChange={logger}
-        />
+        <>
+            <Radio
+                initialFocus
+                checked
+                name="Ex"
+                label="Radio"
+                value="default"
+                className="initially-focused"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+            <Radio
+                name="Ex"
+                label="Radio"
+                value="default"
+                className="initially-unfocused"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+        </>
     ))
 
     .add('Checked', () => (
@@ -39,7 +90,9 @@ storiesOf('Radio', module)
             label="Radio"
             checked
             value="checked"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -50,7 +103,9 @@ storiesOf('Radio', module)
                 label="Radio"
                 disabled
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Radio
                 name="Ex"
@@ -58,7 +113,9 @@ storiesOf('Radio', module)
                 disabled
                 checked
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -70,7 +127,9 @@ storiesOf('Radio', module)
                 label="Radio"
                 valid
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Radio
                 name="Ex"
@@ -78,7 +137,9 @@ storiesOf('Radio', module)
                 valid
                 checked
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -90,7 +151,9 @@ storiesOf('Radio', module)
                 label="Radio"
                 warning
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Radio
                 name="Ex"
@@ -98,7 +161,9 @@ storiesOf('Radio', module)
                 warning
                 checked
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -110,7 +175,9 @@ storiesOf('Radio', module)
                 label="Radio"
                 error
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Radio
                 name="Ex"
@@ -118,7 +185,9 @@ storiesOf('Radio', module)
                 error
                 checked
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -128,7 +197,9 @@ storiesOf('Radio', module)
             name="Ex"
             label={<img src="https://picsum.photos/id/82/200/100" />}
             value="with-help"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -139,7 +210,9 @@ storiesOf('Radio', module)
             name="Ex"
             label="Radio"
             value="default"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -150,7 +223,9 @@ storiesOf('Radio', module)
             name="Ex"
             label="Radio"
             value="default"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -162,7 +237,9 @@ storiesOf('Radio', module)
             name="Ex"
             label="Radio"
             value="default"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -173,7 +250,9 @@ storiesOf('Radio', module)
             label="Radio"
             checked
             value="checked"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -185,7 +264,9 @@ storiesOf('Radio', module)
                 label="Radio"
                 disabled
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Radio
                 dense
@@ -194,7 +275,9 @@ storiesOf('Radio', module)
                 disabled
                 checked
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -207,7 +290,9 @@ storiesOf('Radio', module)
                 label="Radio"
                 valid
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Radio
                 dense
@@ -216,7 +301,9 @@ storiesOf('Radio', module)
                 valid
                 checked
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -229,7 +316,9 @@ storiesOf('Radio', module)
                 label="Radio"
                 warning
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Radio
                 dense
@@ -238,7 +327,9 @@ storiesOf('Radio', module)
                 warning
                 checked
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -251,7 +342,9 @@ storiesOf('Radio', module)
                 label="Radio"
                 error
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Radio
                 dense
@@ -260,7 +353,9 @@ storiesOf('Radio', module)
                 error
                 checked
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -271,6 +366,8 @@ storiesOf('Radio', module)
             name="Ex"
             label={<img src="https://picsum.photos/id/82/200/100" />}
             value="with-help"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))

--- a/stories/ScreenCover.stories.js
+++ b/stories/ScreenCover.stories.js
@@ -2,7 +2,12 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { CircularLoader, ScreenCover, Menu, MenuItem, Divider } from '../src'
 
-const onClick = () => alert('Clicked the backdrop')
+window.onClick = (payload, event) => {
+    console.log('onClick payload', payload)
+    console.log('onClick event', event)
+}
+
+const onClick = (...args) => window.onClick(...args)
 
 storiesOf('ScreenCover', module)
     .add('Default', () => <ScreenCover onClick={onClick} />)

--- a/stories/SplitButton.stories.js
+++ b/stories/SplitButton.stories.js
@@ -4,6 +4,13 @@ import { SplitButton } from '../src'
 
 import { Menu, MenuItem, Divider, Switch } from '../src'
 
+window.onClick = (payload, event) => {
+    console.log('onClick payload', payload)
+    console.log('onClick event', event)
+}
+
+const onClick = (...args) => window.onClick(...args)
+
 const componentMenu = (
     <Menu>
         <MenuItem
@@ -65,36 +72,32 @@ const Simple = <span>Simplest thing</span>
 createStory('SplitButton: Basic', {
     name: 'Button',
     value: 'default',
-    onClick: e =>
-        alert(`Clicked button ${e.target.name} with ${e.target.value}`),
     component: Simple,
+    onClick,
 })
 
 createStory('SplitButton: Primary', {
     name: 'Button',
     value: 'default',
-    onClick: e =>
-        alert(`Clicked button ${e.target.name} with ${e.target.value}`),
     primary: true,
     component: Simple,
+    onClick,
 })
 
 createStory('SplitButton: Secondary', {
     name: 'Button',
     value: 'default',
-    onClick: e =>
-        alert(`Clicked button ${e.target.name} with ${e.target.value}`),
     secondary: true,
     component: Simple,
+    onClick,
 })
 
 createStory('SplitButton: Destructive', {
     name: 'Button',
     value: 'default',
-    onClick: e =>
-        alert(`Clicked button ${e.target.name} with ${e.target.value}`),
     destructive: true,
     component: Simple,
+    onClick,
 })
 
 function createStory(name, props) {

--- a/stories/Switch.stories.js
+++ b/stories/Switch.stories.js
@@ -3,34 +3,85 @@ import React from 'react'
 
 import { Switch } from '../src'
 
-const logger = ({ name, value, checked }) =>
-    console.info(`name: ${name}, value: ${value}, checked: ${checked}`)
+window.onChange = (payload, event) => {
+    console.log('onClick payload', payload)
+    console.log('onClick event', event)
+}
+
+window.onFocus = (payload, event) => {
+    console.log('onFocus payload', payload)
+    console.log('onFocus event', event)
+}
+
+window.onBlur = (payload, event) => {
+    console.log('onBlur payload', payload)
+    console.log('onBlur event', event)
+}
+
+const onChange = (...args) => window.onChange(...args)
+const onFocus = (...args) => window.onFocus(...args)
+const onBlur = (...args) => window.onBlur(...args)
 
 storiesOf('Switch', module)
     // Regular
     .add('Default', () => (
-        <Switch name="Ex" label="Switch" value="default" onChange={logger} />
+        <Switch
+            name="Ex"
+            label="Switch"
+            value="default"
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+        />
     ))
 
     .add('Focused unchecked', () => (
-        <Switch
-            initialFocus
-            name="Ex"
-            label="Switch"
-            value="default"
-            onChange={logger}
-        />
+        <>
+            <Switch
+                initialFocus
+                name="Ex"
+                label="Switch"
+                value="default"
+                className="initially-focused"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+            <Switch
+                name="Ex2"
+                label="Switch"
+                value="default"
+                className="initially-unfocused"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+        </>
     ))
 
     .add('Focused checked', () => (
-        <Switch
-            initialFocus
-            checked
-            name="Ex"
-            label="Switch"
-            value="default"
-            onChange={logger}
-        />
+        <>
+            <Switch
+                initialFocus
+                checked
+                name="Ex"
+                label="Switch"
+                value="default"
+                className="initially-focused"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+            <Switch
+                name="Ex2"
+                label="Switch"
+                value="default"
+                className="initially-unfocused"
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+        </>
     ))
 
     .add('Checked', () => (
@@ -39,7 +90,9 @@ storiesOf('Switch', module)
             label="Switch"
             checked
             value="checked"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -50,7 +103,9 @@ storiesOf('Switch', module)
                 label="Switch"
                 disabled
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Switch
                 name="Ex"
@@ -58,7 +113,9 @@ storiesOf('Switch', module)
                 disabled
                 checked
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -70,7 +127,9 @@ storiesOf('Switch', module)
                 label="Switch"
                 valid
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Switch
                 name="Ex"
@@ -78,7 +137,9 @@ storiesOf('Switch', module)
                 valid
                 checked
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -90,7 +151,9 @@ storiesOf('Switch', module)
                 label="Switch"
                 warning
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Switch
                 name="Ex"
@@ -98,7 +161,9 @@ storiesOf('Switch', module)
                 warning
                 checked
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -110,7 +175,9 @@ storiesOf('Switch', module)
                 label="Switch"
                 error
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Switch
                 name="Ex"
@@ -118,7 +185,9 @@ storiesOf('Switch', module)
                 error
                 checked
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -128,7 +197,9 @@ storiesOf('Switch', module)
             name="Ex"
             label={<img src="https://picsum.photos/id/82/200/100" />}
             value="with-help"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -139,7 +210,9 @@ storiesOf('Switch', module)
             name="Ex"
             label="Switch"
             value="default"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -150,7 +223,9 @@ storiesOf('Switch', module)
             name="Ex"
             label="Switch"
             value="default"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -162,7 +237,9 @@ storiesOf('Switch', module)
             name="Ex"
             label="Switch"
             value="default"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -173,7 +250,9 @@ storiesOf('Switch', module)
             label="Switch"
             checked
             value="checked"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))
 
@@ -185,7 +264,9 @@ storiesOf('Switch', module)
                 label="Switch"
                 disabled
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Switch
                 dense
@@ -194,7 +275,9 @@ storiesOf('Switch', module)
                 disabled
                 checked
                 value="disabled"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -207,7 +290,9 @@ storiesOf('Switch', module)
                 label="Switch"
                 valid
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Switch
                 dense
@@ -216,7 +301,9 @@ storiesOf('Switch', module)
                 valid
                 checked
                 value="valid"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -229,7 +316,9 @@ storiesOf('Switch', module)
                 label="Switch"
                 warning
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Switch
                 dense
@@ -238,7 +327,9 @@ storiesOf('Switch', module)
                 warning
                 checked
                 value="warning"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -251,7 +342,9 @@ storiesOf('Switch', module)
                 label="Switch"
                 error
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
             <Switch
                 dense
@@ -260,7 +353,9 @@ storiesOf('Switch', module)
                 error
                 checked
                 value="error"
-                onChange={logger}
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
             />
         </>
     ))
@@ -271,6 +366,8 @@ storiesOf('Switch', module)
             name="Ex"
             label={<img src="https://picsum.photos/id/82/200/100" />}
             value="with-help"
-            onChange={logger}
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
         />
     ))

--- a/stories/Tabs.stories.js
+++ b/stories/Tabs.stories.js
@@ -14,58 +14,73 @@ const Wrapper = fn => (
     </div>
 )
 
+window.onClick = (payload, event) => {
+    console.log('onClick payload', payload)
+    console.log('onClick event', event)
+}
+
+const onClick = (...args) => window.onClick(...args)
+
 storiesOf('TabBar', module)
     .addDecorator(Wrapper)
     .add('Default (fluid)', () => (
         <TabBar>
-            <Tab>Tab A</Tab>
-            <Tab>Tab B</Tab>
-            <Tab selected>Tab C</Tab>
-            <Tab>Tab D</Tab>
-            <Tab>Tab E</Tab>
-            <Tab>Tab F</Tab>
-            <Tab>Tab G</Tab>
+            <Tab onClick={onClick}>Tab A</Tab>
+            <Tab onClick={onClick}>Tab B</Tab>
+            <Tab onClick={onClick} selected>
+                Tab C
+            </Tab>
+            <Tab onClick={onClick}>Tab D</Tab>
+            <Tab onClick={onClick}>Tab E</Tab>
+            <Tab onClick={onClick}>Tab F</Tab>
+            <Tab onClick={onClick}>Tab G</Tab>
         </TabBar>
     ))
     .add('Fixed - tabs fill content', () => (
         <TabBar fixed>
-            <Tab>Tab A</Tab>
-            <Tab>Tab B</Tab>
-            <Tab selected>Tab C</Tab>
-            <Tab>Tab D</Tab>
-            <Tab>Tab E</Tab>
-            <Tab>Tab F</Tab>
-            <Tab>Tab G</Tab>
+            <Tab onClick={onClick}>Tab A</Tab>
+            <Tab onClick={onClick}>Tab B</Tab>
+            <Tab onClick={onClick} selected>
+                Tab C
+            </Tab>
+            <Tab onClick={onClick}>Tab D</Tab>
+            <Tab onClick={onClick}>Tab E</Tab>
+            <Tab onClick={onClick}>Tab F</Tab>
+            <Tab onClick={onClick}>Tab G</Tab>
         </TabBar>
     ))
     .add('Tabs with scroller', () => (
         <TabBar scrollable>
-            <Tab>Tab A</Tab>
-            <Tab>Tab B</Tab>
-            <Tab>Tab C</Tab>
-            <Tab>Tab D</Tab>
-            <Tab>Tab E</Tab>
-            <Tab>Tab F</Tab>
-            <Tab>Tab G</Tab>
-            <Tab>Tab H</Tab>
-            <Tab>Tab I</Tab>
-            <Tab>Tab J</Tab>
-            <Tab>Tab K</Tab>
-            <Tab>Tab L</Tab>
-            <Tab selected>Tab M</Tab>
-            <Tab>Tab N</Tab>
-            <Tab>Tab O</Tab>
-            <Tab>Tab P</Tab>
-            <Tab>Tab Q</Tab>
-            <Tab>Tab R</Tab>
+            <Tab onClick={onClick}>Tab A</Tab>
+            <Tab onClick={onClick}>Tab B</Tab>
+            <Tab onClick={onClick}>Tab C</Tab>
+            <Tab onClick={onClick}>Tab D</Tab>
+            <Tab onClick={onClick}>Tab E</Tab>
+            <Tab onClick={onClick}>Tab F</Tab>
+            <Tab onClick={onClick}>Tab G</Tab>
+            <Tab onClick={onClick}>Tab H</Tab>
+            <Tab onClick={onClick}>Tab I</Tab>
+            <Tab onClick={onClick}>Tab J</Tab>
+            <Tab onClick={onClick}>Tab K</Tab>
+            <Tab onClick={onClick}>Tab L</Tab>
+            <Tab onClick={onClick} selected>
+                Tab M
+            </Tab>
+            <Tab onClick={onClick}>Tab N</Tab>
+            <Tab onClick={onClick}>Tab O</Tab>
+            <Tab onClick={onClick}>Tab P</Tab>
+            <Tab onClick={onClick}>Tab Q</Tab>
+            <Tab onClick={onClick}>Tab R</Tab>
         </TabBar>
     ))
     .add('Tab states', () => (
         <TabBar>
-            <Tab>Default</Tab>
-            <Tab selected>Selected</Tab>
+            <Tab onClick={onClick}>Default</Tab>
+            <Tab onClick={onClick} selected>
+                Selected
+            </Tab>
             <Tab disabled>Disabled</Tab>
-            <Tab>
+            <Tab onClick={onClick}>
                 Text overflow - This tab has a very long text and it exceeds the
                 maximum width of 320px
             </Tab>
@@ -73,14 +88,16 @@ storiesOf('TabBar', module)
     ))
     .add('Tab states - with icon', () => (
         <TabBar>
-            <Tab icon={<AttachFile />}>Default</Tab>
-            <Tab icon={<AttachFile />} selected>
+            <Tab onClick={onClick} icon={<AttachFile />}>
+                Default
+            </Tab>
+            <Tab onClick={onClick} icon={<AttachFile />} selected>
                 Selected
             </Tab>
             <Tab icon={<AttachFile />} disabled>
                 Disabled
             </Tab>
-            <Tab icon={<AttachFile />}>
+            <Tab onClick={onClick} icon={<AttachFile />}>
                 Text overflow - This tab has a very long text and it exceeds the
                 maximum width of 320px
             </Tab>

--- a/stories/TextArea.stories.js
+++ b/stories/TextArea.stories.js
@@ -1,0 +1,312 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { TextArea } from '../src/index.js'
+
+window.onChange = (payload, event) => {
+    console.log('onChange payload', payload)
+    console.log('onChange event', event)
+}
+
+window.onFocus = (payload, event) => {
+    console.log('onFocus payload', payload)
+    console.log('onFocus event', event)
+}
+
+window.onBlur = (payload, event) => {
+    console.log('onBlur payload', payload)
+    console.log('onBlur event', event)
+}
+
+const onChange = (...args) => window.onChange(...args)
+const onFocus = (...args) => window.onFocus(...args)
+const onBlur = (...args) => window.onBlur(...args)
+
+storiesOf('TextArea', module)
+    .add('Default', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+        />
+    ))
+
+    .add('Placeholder, no value', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            placeholder="Hold the place"
+        />
+    ))
+
+    .add('With value', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            value="This is set through the value prop, which means the component is controlled."
+        />
+    ))
+
+    .add('Focus', () => (
+        <>
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea"
+                initialFocus
+                className="initially-focused"
+            />
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea"
+                className="initially-unfocused"
+            />
+        </>
+    ))
+
+    .add('Status: Valid', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            value="This value is valid"
+            valid
+        />
+    ))
+
+    .add('Status: Warning', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            value="This value produces a warning"
+            warning
+        />
+    ))
+
+    .add('Status: Error', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            error
+            value="This value produces an error"
+            helpText="This is some help text to advice what this input actually is."
+            validationText="This describes the error, if a message is supplied."
+        />
+    ))
+
+    .add('Status: Loading', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            value="This value produces a loading state"
+            loading
+        />
+    ))
+
+    .add('Disabled', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            value="This field is disabled"
+            disabled
+        />
+    ))
+
+    .add('Read only', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            value="This field is readOnly"
+            readOnly
+        />
+    ))
+
+    .add('Dense', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            value="This field is dense"
+            dense
+        />
+    ))
+
+    .add('Textarea text overflow', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            label="I have a scrollbar"
+            value={[
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+                'A line of text',
+            ].join('\n')}
+        />
+    ))
+
+    .add('Required', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            label="I am required and have an asterisk"
+            required
+        />
+    ))
+
+    .add('Rows', () => (
+        <TextArea
+            onChange={onChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            name="textarea"
+            label="You can set the height with the rows prop, I have 8"
+            rows={8}
+        />
+    ))
+
+    .add('Input width', () => (
+        <>
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea"
+                label="My textarea has a width of 100px"
+                inputWidth="100px"
+            />
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea"
+                label="My textarea has a width of 220px"
+                inputWidth="220px"
+            />
+        </>
+    ))
+
+    .add('Resize', () => (
+        <>
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea1"
+                label="Resize: vertical (default)"
+            />
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea2"
+                label="Resize: none"
+                resize="none"
+            />
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea3"
+                label="Resize: both"
+                resize="both"
+            />
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea4"
+                label="Resize: horizontal"
+                resize="horizontal"
+            />
+        </>
+    ))
+
+    .add('Autogrow', () => (
+        <>
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea1"
+                label="Autogrow step 1"
+                autoGrow
+                rows={2}
+                value="This TextArea has a height of 2 rows"
+            />
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea2"
+                label="Autogrow step 2"
+                autoGrow
+                rows={2}
+                value={[
+                    'This TextArea has a height of two rows',
+                    'it also has autoGrow set to true so it will grow with the content',
+                ].join('\n')}
+            />
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea3"
+                label="Autogrow step 3"
+                autoGrow
+                rows={2}
+                value={[
+                    'This TextArea has a height of two rows',
+                    'it also has autoGrow set to true so it will grow with the content.',
+                    'See: rows is still 2, but I now have 3 lines.',
+                ].join('\n')}
+            />
+            <TextArea
+                onChange={onChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                name="textarea4"
+                label="Autogrow step 4"
+                value={[
+                    'This TextArea has a height of two rows',
+                    'it also has autoGrow set to true so it will grow with the content.',
+                    'See: rows is still 2...',
+                    'And now I have 4 lines and still no scroll bar in sight.',
+                ].join('\n')}
+            />
+        </>
+    ))


### PR DESCRIPTION
Updated the handler styles of some components (check commit messages for a list of which components I've worked on)

I've added cypress tests for quite a few components to check if the event handlers are called correctly:

- [x] Backdrop
- [x] Button
- [x] Checkbox
- [x] Chip
- [x] DropdownButton
- [x] Backdrop
- [x] FileListItem
- [x] Input
- [x] MenuItem
- [x] Modal
- [x] Node
- [x] Radio
- [x] ScreenCover
- [x] SplitButton
- [x] Switch
- [x] Tab
- [x] TextArea

Two components actually have state, I added tests for that as well

- [x] DropdownButton
- [x] SplitButton

<hr />

I've left a few components out:

These components will be tested by @ismay 
- [ ] Select
- [ ] SingleSelect
- [ ] MultiSelect

These components do have behavior, but the actual behavior comes from the internally used components and the handlers are just passed through, so I think it's not worth adding tests for these:
- [ ] Field
- [ ] FileInput
- [ ] FileInputField
- [ ] InputField
- [ ] RadioGroup
- [ ] RadioGroupField
- [ ] SwitchField
- [ ] SwitchGroup
- [ ] SwitchGroupField
- [ ] TextAreaField
- [ ] ToggleField
- [ ] ToggleGroup
- [ ] ToggleGroupField

All others simply have no handlers and therefore no behavior whatsoever and therefore don't need any cypress tests