### PR TITLE
fix(layer-context): add support for preserving layer hierarchy in context

### DIFF
--- a/src/LayerContext.js
+++ b/src/LayerContext.js
@@ -1,19 +1,34 @@
 import React, { useContext } from 'react'
 import propTypes from '@dhis2/prop-types'
+import { layers } from './theme.js'
 
 const LayerContext = React.createContext(0)
+
+const getStackedLayer = (defaultLayer, context) => {
+    // Keep alert layer constant
+    if (defaultLayer === layers.alert) {
+        return layers.alert
+    }
+
+    // Differentiate between a stacked blocking and applicationTop layer
+    const layerIncrement = defaultLayer === layers.blocking ? 2 : 1
+    const layer = context + layerIncrement
+
+    // stay within stack layer boundaries defined by the design system
+    // https://github.com/dhis2/design-system/blob/master/principles/spacing-alignment.md#stacking
+    if (layer >= layers.alert) {
+        return layers.alert - 1
+    }
+
+    return layer
+}
 
 const useLayer = (defaultLayer, customLayer) => {
     const context = useContext(LayerContext)
 
     if (customLayer) return customLayer
 
-    // stay within stack layer boundaries defined by the design system
-    // https://github.com/dhis2/design-system/blob/master/principles/spacing-alignment.md#stacking
-    const capReached = context && context % 1000 === 999
-    if (capReached) return context
-
-    if (context) return context + 1
+    if (context) return getStackedLayer(defaultLayer, context)
 
     return defaultLayer
 }


### PR DESCRIPTION
I realise that this fix only addresses a hypothetical issue given our current component set, but since we are all quite deeply into this now, it might still be a good time to tackle this....

In the current implementation, the following could hypothetically go wrong:
1. User opens modal => context z-index = 3000
2. User opens hypothetical component with `layers.blocking` from the modal => this would get z-index 3001
3. Whilst the component in (2) is open, the user opens another hypothetical component with `layers.applicationTop` from the modal => this would get z-index 3001 too

And because the components from point 2 & 3 have an equal z-index, but 3 is appended to the body later, comp3 will now be on top of comp2. And this is incorrect because comp2 has a higher layer.

After this fix comp2 would get 3002 and comp3 would get 3001 and 2 would be on top of 3 🎉 

As I see it, with this fix applied this layer context is done for the foreseeable future. We'd only have to make changes if we define more layers.