### PR TITLE
fix(select): fix overlap on specifying input width for flex children

### DIFF
--- a/src/MultiSelect.js
+++ b/src/MultiSelect.js
@@ -99,7 +99,8 @@ const MultiSelect = ({
 
                 .root-input {
                     margin-right: ${spacers.dp4};
-                    flex: ${inputWidth ? `0 0 ${inputWidth}` : '1'};
+                    flex: 1;
+                    max-width: ${inputWidth ? inputWidth : 'unset'};
                 }
             `}</style>
         </div>

--- a/src/SingleSelect.js
+++ b/src/SingleSelect.js
@@ -99,7 +99,8 @@ const SingleSelect = ({
 
                 .root-input {
                     margin-right: ${spacers.dp4};
-                    flex: ${inputWidth ? `0 0 ${inputWidth}` : '1'};
+                    flex: 1;
+                    max-width: ${inputWidth ? inputWidth : 'unset'};
                 }
             `}</style>
         </div>


### PR DESCRIPTION
Closes #591

Max-width can be used to limit flex-basis, which seems like what we want here (see: https://gedd.ski/post/the-difference-between-width-and-flex-basis). Fixes the issue demonstrated in #591.