### PR TITLE
fix(text-area): only set height when value changes

### DIFF
--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -27,8 +27,8 @@ export class TextArea extends Component {
         }
     }
 
-    componentDidUpdate() {
-        if (this.shouldDoAutoGrow()) {
+    componentDidUpdate(prevProps) {
+        if (this.shouldDoAutoGrow() && this.props.value !== prevProps.value) {
             this.setHeight()
         }
     }


### PR DESCRIPTION
Without this fix the TextArea will throw an infinite recursion error when `autoGrow` is set to true