### PR TITLE
test(select): add select integration tests

### DIFF
--- a/cypress/integration/SingleSelect/opening_and_closing.feature
+++ b/cypress/integration/SingleSelect/opening_and_closing.feature
@@ -1,0 +1,35 @@
+Feature: Opening and closing the SingleSelect
+
+    Scenario: The user clicks the SingleSelect input to display the options
+        Given a closed SingleSelect with options is rendered
+        When the SingleSelect input is clicked
+        Then the options are displayed
+
+    Scenario: The user presses the down arrowkey to display the options
+        Given a closed SingleSelect with options is rendered
+        And the SingleSelect is focused
+        When the down arrowkey is pressed on the focused element
+        Then the options are displayed
+
+    Scenario: The user presses the up arrowkey to display the options
+        Given a closed SingleSelect with options is rendered
+        And the SingleSelect is focused
+        When the up arrowkey is pressed on the focused element
+        Then the options are displayed
+
+    Scenario: The user presses the spacebar to display the options
+        Given a closed SingleSelect with options is rendered
+        And the SingleSelect is focused
+        When the spacebar is pressed on the focused element
+        Then the options are displayed
+
+    Scenario: The user clicks the backdrop to hide the options
+        Given an open SingleSelect with options is rendered
+        When the user clicks the backdrop
+        Then the options are not displayed
+
+    Scenario: The user presses the escape key to hide the options
+        Given an open SingleSelect with options is rendered
+        And the SingleSelect is focused
+        When the escape key is pressed on the focused element
+        Then the options are not displayed

--- a/cypress/integration/SingleSelect/opening_and_closing/opening_and_closing.js
+++ b/cypress/integration/SingleSelect/opening_and_closing/opening_and_closing.js
@@ -1,0 +1,54 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a closed SingleSelect with options is rendered', () => {
+    cy.visitStory('SingleSelect', 'With options')
+})
+
+Given('an open SingleSelect with options is rendered', () => {
+    cy.visitStory('SingleSelect', 'With options')
+    cy.get('.select [tabIndex="0"]').click()
+
+    cy.contains('option one')
+    cy.contains('option two')
+    cy.contains('option three')
+})
+
+Given('the SingleSelect is focused', () => {
+    cy.get('.select [tabIndex="0"]').focus()
+})
+
+When('the SingleSelect input is clicked', () => {
+    cy.get('.select [tabIndex="0"]').click()
+})
+
+When('the user clicks the backdrop', () => {
+    cy.get('.backdrop').click()
+})
+
+When('the down arrowkey is pressed on the focused element', () => {
+    cy.focused().type('{downarrow}')
+})
+
+When('the spacebar is pressed on the focused element', () => {
+    cy.focused().type(' ')
+})
+
+When('the up arrowkey is pressed on the focused element', () => {
+    cy.focused().type('{uparrow}')
+})
+
+When('the escape key is pressed on the focused element', () => {
+    cy.focused().type('{esc}')
+})
+
+Then('the options are displayed', () => {
+    cy.contains('option one')
+    cy.contains('option two')
+    cy.contains('option three')
+})
+
+Then('the options are not displayed', () => {
+    cy.contains('option one').should('not.exist')
+    cy.contains('option two').should('not.exist')
+    cy.contains('option three').should('not.exist')
+})

--- a/stories/SingleSelect.stories.testing.js
+++ b/stories/SingleSelect.stories.testing.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { SingleSelect, SingleSelectOption } from '../src'
+
+storiesOf('SingleSelect', module).add('With options', () => (
+    <SingleSelect className="select">
+        <SingleSelectOption value="1" label="option one" />
+        <SingleSelectOption value="2" label="option two" />
+        <SingleSelectOption value="3" label="option three" />
+    </SingleSelect>
+))


### PR DESCRIPTION
_note: this is based on next, but not necessarily to be merged in next. We can also merge it afterwards._

I was looking at implementing cypress integration tests for the Select and I found the existing naming strategy rather verbose. Personally I'd prefer a simpler, more terse naming strategy. And preferably with dashes instead of underscores (as dashes are more conventional in js codebases in my experience).

So more like this (this still uses underscores btw.):

<img width="1064" alt="Screenshot 2019-11-21 at 10 08 35" src="https://user-images.githubusercontent.com/7355199/69323434-0091fc00-0c47-11ea-90f6-e61f5b22a57a.png">

Instead of the current:

<img width="1033" alt="Screenshot 2019-11-21 at 10 08 53" src="https://user-images.githubusercontent.com/7355199/69323419-fa038480-0c46-11ea-9f99-4d7687ce54fe.png">

With the proposed changes, when running it'll look like this:

<img width="598" alt="Screenshot 2019-11-21 at 10 14 53" src="https://user-images.githubusercontent.com/7355199/69323925-ddb41780-0c47-11ea-84b1-c9b747b106d5.png">

and

<img width="561" alt="Screenshot 2019-11-21 at 10 15 12" src="https://user-images.githubusercontent.com/7355199/69323942-e3116200-0c47-11ea-9f3b-6477943d88b3.png">


That would be an improvement in my perspective. What does everyone else think?