### PR TITLE
test: fix button integration test

### DIFF
--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -40,7 +40,7 @@ const onClick = (...args) => window.onClick(...args)
 function createStory(name, props) {
     storiesOf(name, module)
         .add('Default', () => (
-            <Button {...props} onClick={undefined}>
+            <Button {...props} onClick={onClick}>
                 Label me!
             </Button>
         ))


### PR DESCRIPTION
The integration test was failing because of a missing onClick handler. This wasn't caught because we're not running on CI (which we should have soon if all goes well), but I also think that our using the stories for both documentation and testing is to blame. It's easy to want to update the docs and break a test.

We already have the option to separate out stories that are for testing, and stories that are for documentation by using a `.testing` prefix. I propose we move all stories that are used for testing to `<ComponentName>.testing.stories.js`, like we're already doing for a couple of components:

<img width="315" alt="Screenshot 2019-11-26 at 13 30 49" src="https://user-images.githubusercontent.com/7355199/69633750-1d686e00-1051-11ea-872b-dd581b46aa85.png">

The .testing stories won't show up in the docs, and it signals clearly that those stories are for testing.