### PR TITLE
test(select): add select integration tests

### DIFF
--- a/cypress/integration/MultiSelect/clearing.feature
+++ b/cypress/integration/MultiSelect/clearing.feature
@@ -1,0 +1,7 @@
+Feature: Clearing the MultiSelect
+
+    Scenario: The user clicks the clear button to clear the MultiSelect
+        Given a clearable MultiSelect with a selection is rendered
+        And an onChange handler is attached
+        When the clear button is clicked
+        Then the MultiSelect is cleared

--- a/cypress/integration/MultiSelect/clearing/index.js
+++ b/cypress/integration/MultiSelect/clearing/index.js
@@ -1,0 +1,17 @@
+import '../common'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a clearable MultiSelect with a selection is rendered', () => {
+    cy.visitStory('MultiSelect', 'With clear button and selection')
+})
+
+When('the clear button is clicked', () => {
+    cy.contains('Clear').click()
+})
+
+Then('the MultiSelect is cleared', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledOnce
+        expect(win.onChange).to.be.calledWith({ selected: [] })
+    })
+})

--- a/cypress/integration/MultiSelect/common/index.js
+++ b/cypress/integration/MultiSelect/common/index.js
@@ -1,0 +1,27 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a MultiSelect with options is rendered', () => {
+    cy.visitStory('MultiSelect', 'With options')
+})
+
+Given('a MultiSelect with options and a selection is rendered', () => {
+    cy.visitStory('MultiSelect', 'With options and a selection')
+})
+
+Given('an onChange handler is attached', () => {
+    cy.window().then(win => (win.onChange = cy.stub()))
+})
+
+Given('the MultiSelect is open', () => {
+    cy.get('.select [tabIndex="0"]').click()
+
+    cy.contains('option one').should('exist')
+    cy.contains('option two').should('exist')
+    cy.contains('option three').should('exist')
+})
+
+Then('the options are not displayed', () => {
+    cy.contains('option one').should('not.exist')
+    cy.contains('option two').should('not.exist')
+    cy.contains('option three').should('not.exist')
+})

--- a/cypress/integration/MultiSelect/filtering.feature
+++ b/cypress/integration/MultiSelect/filtering.feature
@@ -1,0 +1,14 @@
+Feature: Filtering the MultiSelect options
+
+    Scenario: The user enters a filter string to filter the options
+        Given a filterable MultiSelect with options is rendered
+        And the MultiSelect is open
+        When the user enters a filter string
+        Then the matching options are displayed
+
+    Scenario: The user enters a filter string that doesn't match any options
+        Given a filterable MultiSelect with options is rendered
+        And the MultiSelect is open
+        When the user enters a filter string that doesn't match any options
+        Then the no match text is displayed
+        And the options are not displayed

--- a/cypress/integration/MultiSelect/filtering/index.js
+++ b/cypress/integration/MultiSelect/filtering/index.js
@@ -1,0 +1,24 @@
+import '../common'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a filterable MultiSelect with options is rendered', () => {
+    cy.visitStory('MultiSelect', 'With filter field')
+})
+
+When('the user enters a filter string', () => {
+    cy.focused().type('one')
+})
+
+When("the user enters a filter string that doesn't match any options", () => {
+    cy.focused().type('does not exist')
+})
+
+Then('the matching options are displayed', () => {
+    cy.contains('option one').should('exist')
+    cy.contains('option two').should('not.exist')
+    cy.contains('option three').should('not.exist')
+})
+
+Then('the no match text is displayed', () => {
+    cy.contains('No match found').should('exist')
+})

--- a/cypress/integration/MultiSelect/opening_and_closing.feature
+++ b/cypress/integration/MultiSelect/opening_and_closing.feature
@@ -1,0 +1,41 @@
+Feature: Opening and closing the MultiSelect
+
+    Scenario: The user clicks the MultiSelect input to display the options
+        Given a MultiSelect with options is rendered
+        And the MultiSelect is closed
+        When the MultiSelect input is clicked
+        Then the options are displayed
+
+    Scenario: The user presses the down arrowkey to display the options
+        Given a MultiSelect with options is rendered
+        And the MultiSelect is closed
+        And the MultiSelect is focused
+        When the down arrowkey is pressed on the focused element
+        Then the options are displayed
+
+    Scenario: The user presses the up arrowkey to display the options
+        Given a MultiSelect with options is rendered
+        And the MultiSelect is closed
+        And the MultiSelect is focused
+        When the up arrowkey is pressed on the focused element
+        Then the options are displayed
+
+    Scenario: The user presses the spacebar to display the options
+        Given a MultiSelect with options is rendered
+        And the MultiSelect is closed
+        And the MultiSelect is focused
+        When the spacebar is pressed on the focused element
+        Then the options are displayed
+
+    Scenario: The user clicks the backdrop to hide the options
+        Given a MultiSelect with options is rendered
+        And the MultiSelect is open
+        When the user clicks the backdrop
+        Then the options are not displayed
+
+    Scenario: The user presses the escape key to hide the options
+        Given a MultiSelect with options is rendered
+        And the MultiSelect is open
+        And the MultiSelect is focused
+        When the escape key is pressed on the focused element
+        Then the options are not displayed

--- a/cypress/integration/MultiSelect/opening_and_closing/index.js
+++ b/cypress/integration/MultiSelect/opening_and_closing/index.js
@@ -1,0 +1,42 @@
+import '../common'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('the MultiSelect is closed', () => {
+    cy.contains('option one').should('not.exist')
+    cy.contains('option two').should('not.exist')
+    cy.contains('option three').should('not.exist')
+})
+
+Given('the MultiSelect is focused', () => {
+    cy.get('.select [tabIndex="0"]').focus()
+})
+
+When('the MultiSelect input is clicked', () => {
+    cy.get('.select [tabIndex="0"]').click()
+})
+
+When('the user clicks the backdrop', () => {
+    cy.get('.backdrop').click()
+})
+
+When('the down arrowkey is pressed on the focused element', () => {
+    cy.focused().type('{downarrow}')
+})
+
+When('the spacebar is pressed on the focused element', () => {
+    cy.focused().type(' ')
+})
+
+When('the up arrowkey is pressed on the focused element', () => {
+    cy.focused().type('{uparrow}')
+})
+
+When('the escape key is pressed on the focused element', () => {
+    cy.focused().type('{esc}')
+})
+
+Then('the options are displayed', () => {
+    cy.contains('option one').should('exist')
+    cy.contains('option two').should('exist')
+    cy.contains('option three').should('exist')
+})

--- a/cypress/integration/MultiSelect/selecting.feature
+++ b/cypress/integration/MultiSelect/selecting.feature
@@ -1,0 +1,28 @@
+Feature: Selecting options
+
+    Scenario: The user clicks an option to select it
+        Given a MultiSelect with options is rendered
+        And an onChange handler is attached
+        And the MultiSelect is open
+        When an option is clicked
+        Then the clicked option is selected
+
+    Scenario: The user clicks another option to select it
+        Given a MultiSelect with options and a selection is rendered
+        And an onChange handler is attached
+        And the MultiSelect is open
+        When another option is clicked
+        Then the clicked option is selected as well
+
+    Scenario: The user clicks an option to deselect it
+        Given a MultiSelect with options and a selection is rendered
+        And an onChange handler is attached
+        And the MultiSelect is open
+        When the selected option is clicked
+        Then the selected option is deselected
+
+    Scenario: The user clicks a chip's X to deselect it
+        Given a MultiSelect with options and a selection is rendered
+        And an onChange handler is attached
+        When the chip's X is clicked
+        Then the selected option is deselected

--- a/cypress/integration/MultiSelect/selecting/index.js
+++ b/cypress/integration/MultiSelect/selecting/index.js
@@ -1,0 +1,50 @@
+import '../common'
+import { When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+When('an option is clicked', () => {
+    cy.contains('option one').click()
+})
+
+When('the selected option is clicked', () => {
+    cy.get('.backdrop')
+        .contains('option one')
+        .click()
+})
+
+When('another option is clicked', () => {
+    cy.contains('option two').click()
+})
+
+When("the chip's X is clicked", () => {
+    cy.contains('option one')
+        .siblings('span')
+        .click()
+})
+
+Then('the clicked option is selected', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledOnce
+        expect(win.onChange).to.be.calledWith({
+            selected: [{ label: 'option one', value: '1' }],
+        })
+    })
+})
+
+Then('the clicked option is selected as well', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledOnce
+        expect(win.onChange).to.be.calledWith({
+            selected: [
+                { label: 'option one', value: '1' },
+                { label: 'option two', value: '2' },
+            ],
+        })
+    })
+})
+
+Then('the selected option is deselected', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledOnce
+        expect(win.onChange).to.be.calledWith({ selected: [] })
+    })
+})

--- a/cypress/integration/MultiSelect/show-selections.feature
+++ b/cypress/integration/MultiSelect/show-selections.feature
@@ -1,0 +1,9 @@
+Feature: Show current selections
+
+    Scenario: The multiselect has a single selection
+        Given a MultiSelect with options and a selection is rendered
+        Then the selection is displayed
+
+    Scenario: The multiselect has multiple selections
+        Given a MultiSelect with options and multiple selections is rendered
+        Then the selections are displayed

--- a/cypress/integration/MultiSelect/show-selections/index.js
+++ b/cypress/integration/MultiSelect/show-selections/index.js
@@ -1,0 +1,15 @@
+import '../common'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a MultiSelect with options and multiple selections is rendered', () => {
+    cy.visitStory('MultiSelect', 'With options and multiple selections')
+})
+
+Then('the selection is displayed', () => {
+    cy.contains('option one').should('exist')
+})
+
+Then('the selections are displayed', () => {
+    cy.contains('option one').should('exist')
+    cy.contains('option two').should('exist')
+})

--- a/cypress/integration/SingleSelect/clearing.feature
+++ b/cypress/integration/SingleSelect/clearing.feature
@@ -1,0 +1,7 @@
+Feature: Clearing the SingleSelect
+
+    Scenario: The user clicks the clear button to clear the SingleSelect
+        Given a clearable SingleSelect with a selection is rendered
+        And an onChange handler is attached
+        When the clear button is clicked
+        Then the SingleSelect is cleared

--- a/cypress/integration/SingleSelect/clearing/index.js
+++ b/cypress/integration/SingleSelect/clearing/index.js
@@ -1,0 +1,17 @@
+import '../common'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a clearable SingleSelect with a selection is rendered', () => {
+    cy.visitStory('SingleSelect', 'With clear button and selection')
+})
+
+When('the clear button is clicked', () => {
+    cy.contains('Clear').click()
+})
+
+Then('the SingleSelect is cleared', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledOnce
+        expect(win.onChange).to.be.calledWith({ selected: {} })
+    })
+})

--- a/cypress/integration/SingleSelect/common/index.js
+++ b/cypress/integration/SingleSelect/common/index.js
@@ -1,0 +1,27 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a SingleSelect with options is rendered', () => {
+    cy.visitStory('SingleSelect', 'With options')
+})
+
+Given('a SingleSelect with options and a selection is rendered', () => {
+    cy.visitStory('SingleSelect', 'With options and a selection')
+})
+
+Given('an onChange handler is attached', () => {
+    cy.window().then(win => (win.onChange = cy.stub()))
+})
+
+Given('the SingleSelect is open', () => {
+    cy.get('.select [tabIndex="0"]').click()
+
+    cy.contains('option one').should('exist')
+    cy.contains('option two').should('exist')
+    cy.contains('option three').should('exist')
+})
+
+Then('the options are not displayed', () => {
+    cy.contains('option one').should('not.exist')
+    cy.contains('option two').should('not.exist')
+    cy.contains('option three').should('not.exist')
+})

--- a/cypress/integration/SingleSelect/filtering.feature
+++ b/cypress/integration/SingleSelect/filtering.feature
@@ -1,0 +1,14 @@
+Feature: Filtering the SingleSelect options
+
+    Scenario: The user enters a filter string to filter the options
+        Given a filterable SingleSelect with options is rendered
+        And the SingleSelect is open
+        When the user enters a filter string
+        Then the matching options are displayed
+
+    Scenario: The user enters a filter string that doesn't match any options
+        Given a filterable SingleSelect with options is rendered
+        And the SingleSelect is open
+        When the user enters a filter string that doesn't match any options
+        Then the no match text is displayed
+        And the options are not displayed

--- a/cypress/integration/SingleSelect/filtering/index.js
+++ b/cypress/integration/SingleSelect/filtering/index.js
@@ -1,0 +1,24 @@
+import '../common'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a filterable SingleSelect with options is rendered', () => {
+    cy.visitStory('SingleSelect', 'With filter field')
+})
+
+When('the user enters a filter string', () => {
+    cy.focused().type('one')
+})
+
+When("the user enters a filter string that doesn't match any options", () => {
+    cy.focused().type('does not exist')
+})
+
+Then('the matching options are displayed', () => {
+    cy.contains('option one').should('exist')
+    cy.contains('option two').should('not.exist')
+    cy.contains('option three').should('not.exist')
+})
+
+Then('the no match text is displayed', () => {
+    cy.contains('No match found').should('exist')
+})

--- a/cypress/integration/SingleSelect/opening_and_closing.feature
+++ b/cypress/integration/SingleSelect/opening_and_closing.feature
@@ -1,35 +1,41 @@
 Feature: Opening and closing the SingleSelect
 
     Scenario: The user clicks the SingleSelect input to display the options
-        Given a closed SingleSelect with options is rendered
+        Given a SingleSelect with options is rendered
+        And the SingleSelect is closed
         When the SingleSelect input is clicked
         Then the options are displayed
 
     Scenario: The user presses the down arrowkey to display the options
-        Given a closed SingleSelect with options is rendered
+        Given a SingleSelect with options is rendered
+        And the SingleSelect is closed
         And the SingleSelect is focused
         When the down arrowkey is pressed on the focused element
         Then the options are displayed
 
     Scenario: The user presses the up arrowkey to display the options
-        Given a closed SingleSelect with options is rendered
+        Given a SingleSelect with options is rendered
+        And the SingleSelect is closed
         And the SingleSelect is focused
         When the up arrowkey is pressed on the focused element
         Then the options are displayed
 
     Scenario: The user presses the spacebar to display the options
-        Given a closed SingleSelect with options is rendered
+        Given a SingleSelect with options is rendered
+        And the SingleSelect is closed
         And the SingleSelect is focused
         When the spacebar is pressed on the focused element
         Then the options are displayed
 
     Scenario: The user clicks the backdrop to hide the options
-        Given an open SingleSelect with options is rendered
+        Given a SingleSelect with options is rendered
+        And the SingleSelect is open
         When the user clicks the backdrop
         Then the options are not displayed
 
     Scenario: The user presses the escape key to hide the options
-        Given an open SingleSelect with options is rendered
+        Given a SingleSelect with options is rendered
+        And the SingleSelect is open
         And the SingleSelect is focused
         When the escape key is pressed on the focused element
         Then the options are not displayed

--- a/cypress/integration/SingleSelect/opening_and_closing/index.js
+++ b/cypress/integration/SingleSelect/opening_and_closing/index.js
@@ -1,16 +1,10 @@
+import '../common'
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
-Given('a closed SingleSelect with options is rendered', () => {
-    cy.visitStory('SingleSelect', 'With options')
-})
-
-Given('an open SingleSelect with options is rendered', () => {
-    cy.visitStory('SingleSelect', 'With options')
-    cy.get('.select [tabIndex="0"]').click()
-
-    cy.contains('option one')
-    cy.contains('option two')
-    cy.contains('option three')
+Given('the SingleSelect is closed', () => {
+    cy.contains('option one').should('not.exist')
+    cy.contains('option two').should('not.exist')
+    cy.contains('option three').should('not.exist')
 })
 
 Given('the SingleSelect is focused', () => {
@@ -42,13 +36,7 @@ When('the escape key is pressed on the focused element', () => {
 })
 
 Then('the options are displayed', () => {
-    cy.contains('option one')
-    cy.contains('option two')
-    cy.contains('option three')
-})
-
-Then('the options are not displayed', () => {
-    cy.contains('option one').should('not.exist')
-    cy.contains('option two').should('not.exist')
-    cy.contains('option three').should('not.exist')
+    cy.contains('option one').should('exist')
+    cy.contains('option two').should('exist')
+    cy.contains('option three').should('exist')
 })

--- a/cypress/integration/SingleSelect/selecting.feature
+++ b/cypress/integration/SingleSelect/selecting.feature
@@ -1,0 +1,9 @@
+Feature: Selecting options
+
+    Scenario: The user clicks an option to select it
+        Given a SingleSelect with options is rendered
+        And an onChange handler is attached
+        And the SingleSelect is open
+        When an option is clicked
+        Then the clicked option is selected
+        And the options are not displayed

--- a/cypress/integration/SingleSelect/selecting/index.js
+++ b/cypress/integration/SingleSelect/selecting/index.js
@@ -1,0 +1,15 @@
+import '../common'
+import { When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+When('an option is clicked', () => {
+    cy.contains('option one').click()
+})
+
+Then('the clicked option is selected', () => {
+    cy.window().then(win => {
+        expect(win.onChange).to.be.calledOnce
+        expect(win.onChange).to.be.calledWith({
+            selected: { label: 'option one', value: '1' },
+        })
+    })
+})

--- a/cypress/integration/SingleSelect/show-selections.feature
+++ b/cypress/integration/SingleSelect/show-selections.feature
@@ -1,0 +1,5 @@
+Feature: Show current selections
+
+    Scenario: The singleselect has a selection
+        Given a SingleSelect with options and a selection is rendered
+        Then the selection is displayed

--- a/cypress/integration/SingleSelect/show-selections/index.js
+++ b/cypress/integration/SingleSelect/show-selections/index.js
@@ -1,0 +1,6 @@
+import '../common'
+import { Then } from 'cypress-cucumber-preprocessor/steps'
+
+Then('the selection is displayed', () => {
+    cy.contains('option one').should('exist')
+})

--- a/stories/MultiSelect.stories.testing.js
+++ b/stories/MultiSelect.stories.testing.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { MultiSelect, MultiSelectOption } from '../src'
+
+storiesOf('MultiSelect', module)
+    .add('With options', () => (
+        <MultiSelect
+            className="select"
+            onChange={(...args) => window.onChange(...args)}
+        >
+            <MultiSelectOption value="1" label="option one" />
+            <MultiSelectOption value="2" label="option two" />
+            <MultiSelectOption value="3" label="option three" />
+        </MultiSelect>
+    ))
+    .add('With options and a selection', () => (
+        <MultiSelect
+            className="select"
+            selected={[{ value: '1', label: 'option one' }]}
+            onChange={(...args) => window.onChange(...args)}
+        >
+            <MultiSelectOption value="1" label="option one" />
+            <MultiSelectOption value="2" label="option two" />
+            <MultiSelectOption value="3" label="option three" />
+        </MultiSelect>
+    ))
+    .add('With options and multiple selections', () => (
+        <MultiSelect
+            className="select"
+            selected={[
+                { value: '1', label: 'option one' },
+                { value: '2', label: 'option two' },
+            ]}
+        >
+            <MultiSelectOption value="1" label="option one" />
+            <MultiSelectOption value="2" label="option two" />
+            <MultiSelectOption value="3" label="option three" />
+        </MultiSelect>
+    ))
+    .add('With clear button and selection', () => (
+        <MultiSelect
+            clearable
+            clearText="Clear"
+            className="select"
+            selected={[{ value: '1', label: 'option one' }]}
+            onChange={(...args) => window.onChange(...args)}
+        >
+            <MultiSelectOption value="1" label="option one" />
+            <MultiSelectOption value="2" label="option two" />
+            <MultiSelectOption value="3" label="option three" />
+        </MultiSelect>
+    ))
+    .add('With filter field', () => (
+        <MultiSelect filterable noMatchText="No match found" className="select">
+            <MultiSelectOption value="1" label="option one" />
+            <MultiSelectOption value="2" label="option two" />
+            <MultiSelectOption value="3" label="option three" />
+        </MultiSelect>
+    ))

--- a/stories/SingleSelect.stories.testing.js
+++ b/stories/SingleSelect.stories.testing.js
@@ -2,10 +2,49 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { SingleSelect, SingleSelectOption } from '../src'
 
-storiesOf('SingleSelect', module).add('With options', () => (
-    <SingleSelect className="select">
-        <SingleSelectOption value="1" label="option one" />
-        <SingleSelectOption value="2" label="option two" />
-        <SingleSelectOption value="3" label="option three" />
-    </SingleSelect>
-))
+storiesOf('SingleSelect', module)
+    .add('With options', () => (
+        <SingleSelect
+            className="select"
+            onChange={(...args) => window.onChange(...args)}
+        >
+            <SingleSelectOption value="1" label="option one" />
+            <SingleSelectOption value="2" label="option two" />
+            <SingleSelectOption value="3" label="option three" />
+        </SingleSelect>
+    ))
+    .add('With options and a selection', () => (
+        <SingleSelect
+            className="select"
+            selected={{ value: '1', label: 'option one' }}
+            onChange={(...args) => window.onChange(...args)}
+        >
+            <SingleSelectOption value="1" label="option one" />
+            <SingleSelectOption value="2" label="option two" />
+            <SingleSelectOption value="3" label="option three" />
+        </SingleSelect>
+    ))
+    .add('With clear button and selection', () => (
+        <SingleSelect
+            clearable
+            clearText="Clear"
+            className="select"
+            selected={{ value: '1', label: 'option one' }}
+            onChange={(...args) => window.onChange(...args)}
+        >
+            <SingleSelectOption value="1" label="option one" />
+            <SingleSelectOption value="2" label="option two" />
+            <SingleSelectOption value="3" label="option three" />
+        </SingleSelect>
+    ))
+    .add('With filter field', () => (
+        <SingleSelect
+            filterable
+            noMatchText="No match found"
+            className="select"
+        >
+            <SingleSelectOption value="1" label="option one" />
+            <SingleSelectOption value="2" label="option two" />
+            <SingleSelectOption value="3" label="option three" />
+        </SingleSelect>
+    ))


### PR DESCRIPTION
Improving the test coverage for the Select. Since it's such an intricate component it'd be good to fully test all the features. Note that some selectors used in the tests are a bit fragile. I'd love to use `data-test-*` attributes to make these more robust, but from what I can gather we've not arrived at a decision, so consider this an intermediate solution.

(I'll move the todo list below to the new PR once this has been merged)

Todo regular:

- [ ] clicking disabled options
- [ ] onBlur cb
- [ ] onFocus cb
- [ ] Placeholder
- [ ] Prefix
- [ ] Loading text
- [ ] Max-height
- [ ] Empty
- [ ] Initial focus
- [ ] Disabled
- [ ] Custom options

Todo *Field:

- [ ] Label
- [ ] Statuses
- [ ] Help text
- [ ] Required