### PR TITLE
test: add data-test attribute proposal

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -10,8 +10,8 @@ import { spacers } from './theme.js'
  * @example import { Field } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/field--default|Storybook}
  */
-const Field = ({ children, className }) => (
-    <div className={className}>
+const Field = ({ children, className, dataTest }) => (
+    <div className={className} data-test={dataTest}>
         {children}
         <style jsx>{`
             div {

--- a/src/Help.js
+++ b/src/Help.js
@@ -12,13 +12,14 @@ import { spacers, theme } from './theme.js'
  * @example import { Help } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/help--default|Storybook}
  */
-const Help = ({ children, valid, error, warning, className }) => (
+const Help = ({ children, valid, error, warning, className, dataTest }) => (
     <p
         className={cx(className, {
             valid,
             error,
             warning,
         })}
+        data-test={dataTest}
     >
         {children}
 

--- a/src/Label.js
+++ b/src/Label.js
@@ -37,10 +37,11 @@ const constructClassName = ({ required, disabled, className }) =>
  *
  * @example import { Label } from '@dhis2/ui-core'
  */
-export const Label = ({ htmlFor, children, required, disabled, className }) => (
+export const Label = ({ htmlFor, children, required, disabled, className, dataTest }) => (
     <label
         htmlFor={htmlFor}
         className={constructClassName({ className, required, disabled })}
+        data-test={dataTest}
     >
         <span>{children}</span>
         <style jsx>{styles}</style>

--- a/src/SingleSelect.js
+++ b/src/SingleSelect.js
@@ -45,6 +45,7 @@ const SingleSelect = ({
     noMatchText,
     initialFocus,
     dense,
+    dataTest
 }) => {
     // If the select is filterable, use a filterable menu
     const menu = filterable ? (
@@ -58,7 +59,7 @@ const SingleSelect = ({
     )
 
     return (
-        <div className="root">
+        <div className="root" dataTest={dataTest}>
             <div className="root-input">
                 <Select
                     className={className}

--- a/src/SingleSelectField.js
+++ b/src/SingleSelectField.js
@@ -53,12 +53,13 @@ class SingleSelectField extends React.Component {
             noMatchText,
             initialFocus,
             dense,
+            dataTest,
         } = this.props
 
         return (
-            <Field className={className}>
+            <Field className={className} dataTest={dataTest}>
                 {label && (
-                    <Label required={required} disabled={disabled}>
+                    <Label required={required} disabled={disabled} dataTest={`${dataTest}-label`}>
                         {label}
                     </Label>
                 )}
@@ -93,10 +94,10 @@ class SingleSelectField extends React.Component {
                     </SingleSelect>
                 </Constrictor>
 
-                {helpText && <Help>{helpText}</Help>}
+                {helpText && <Help dataTest={`${dataTest}-help`}>{helpText}</Help>}
 
                 {validationText && (
-                    <Help error={error} warning={warning} valid={valid}>
+                    <Help error={error} warning={warning} valid={valid} dataTest={`${dataTest}-validation`}>
                         {validationText}
                     </Help>
                 )}
@@ -107,6 +108,7 @@ class SingleSelectField extends React.Component {
 
 SingleSelectField.defaultProps = {
     selected: {},
+    dataTest: "dhis2-uicore-singleselectfield"
 }
 
 /**
@@ -149,6 +151,7 @@ SingleSelectField.propTypes = {
     className: propTypes.string,
     clearText: propTypes.requiredIf(props => props.clearable, propTypes.string),
     clearable: propTypes.bool,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     empty: propTypes.node,


### PR DESCRIPTION
A proposal for adding data-test attributes to our ui-core components. When talking about it I thought that static ones made sense, but since a lot of components are not regular html but react components, they still require that we implement a prop for it in certain areas.

So actually what @varl was suggesting is necessary for the `data-test` attr to be set on react components. To enable that we can add:

* A dataTest prop
* Have a default for it (so the Label has `dhis2-uicore-label` for example) that can be overridden

Though that doesn't mean that we can reach into a component's internals from the outside and add dataTest attrs there (otherwise we'd need to add and pass through a ton of props). What I've done so that child components can be targeted is use the dataTest string as a base. So `${dataTest}-label`, `${dataTest}-help`, etc.

To demonstrate I've quickly sketched how something like this would work for the SingleSelectField for example. Which would result in the following html:

<img width="731" alt="Screenshot 2019-12-02 at 16 06 05" src="https://user-images.githubusercontent.com/7355199/69970490-a1719880-151e-11ea-96f9-52024f510192.png">

(Note that this is just a sketch, so things are missing and it's not exhaustive, but just as a demonstration).