### PR TITLE
test: add data-test attributes

### DIFF
--- a/src/AlertBar.js
+++ b/src/AlertBar.js
@@ -102,6 +102,7 @@ class AlertBar extends Component {
             critical,
             icon,
             actions,
+            dataTest,
         } = this.props
         const { visible, hidden } = this.state
 
@@ -120,6 +121,7 @@ class AlertBar extends Component {
                     critical,
                     visible,
                 })}
+                data-test={dataTest}
                 onMouseEnter={this.stopDisplayTimeOut}
                 onMouseLeave={this.startDisplayTimeout}
             >
@@ -132,7 +134,7 @@ class AlertBar extends Component {
                 />
                 <Message>{children}</Message>
                 <Actions actions={actions} hide={this.hide} />
-                <Dismiss onClick={this.hide} />
+                <Dismiss onClick={this.hide} dataTest={`${dataTest}-dismiss`} />
 
                 <style jsx>{styles}</style>
             </div>
@@ -144,6 +146,12 @@ const alertTypePropType = propTypes.mutuallyExclusive(
     ['success', 'warning', 'critical'],
     propTypes.bool
 )
+
+AlertBar.defaultProps = {
+    duration: 8000,
+    dataTest: 'dhis2-uicore-alertbar',
+    icon: true,
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -162,23 +170,20 @@ const alertTypePropType = propTypes.mutuallyExclusive(
  * @prop {boolean} [permanent]
  * @prop {Array} [actions] An array of 0-2 action objects with the shape: `{ label: {string}, onClick: {function} }`
  * @prop {function} [onHidden]
+ * @prop {string} [dataTest]
  */
 AlertBar.propTypes = {
     children: propTypes.string.isRequired,
     actions: actionsPropType,
     className: propTypes.string,
     critical: alertTypePropType,
+    dataTest: propTypes.string,
     duration: propTypes.number,
     icon: iconPropType,
     permanent: propTypes.bool,
     success: alertTypePropType,
     warning: alertTypePropType,
     onHidden: propTypes.func,
-}
-
-AlertBar.defaultProps = {
-    icon: true,
-    duration: 8000,
 }
 
 export { AlertBar }

--- a/src/AlertBar/Dismiss.js
+++ b/src/AlertBar/Dismiss.js
@@ -3,8 +3,8 @@ import propTypes from '@dhis2/prop-types'
 import { spacers } from '../theme.js'
 import { Close } from '../icons/Close.js'
 
-const Dismiss = ({ onClick }) => (
-    <div onClick={onClick}>
+const Dismiss = ({ onClick, dataTest }) => (
+    <div onClick={onClick} data-test={dataTest}>
         <Close />
         <style jsx>{`
             div {
@@ -22,6 +22,7 @@ const Dismiss = ({ onClick }) => (
 )
 
 Dismiss.propTypes = {
+    dataTest: propTypes.string.isRequired,
     onClick: propTypes.func.isRequired,
 }
 

--- a/src/AlertStack.js
+++ b/src/AlertStack.js
@@ -13,9 +13,9 @@ import { layers } from './theme.js'
  * @example import { AlertStack } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/alertstack--default|Storybook}
  */
-const AlertStack = ({ className, children }) =>
+const AlertStack = ({ className, children, dataTest }) =>
     createPortal(
-        <div className={cx(className)}>
+        <div className={cx(className)} data-test={dataTest}>
             {children}
             <style jsx>{`
                 div {
@@ -38,15 +38,21 @@ const AlertStack = ({ className, children }) =>
         document.body
     )
 
+AlertStack.defaultProps = {
+    dataTest: 'dhis2-uicore-alertstack',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {string} [className]
  * @prop {Array.<AlertBar>} [children]
+ * @prop {string} [dataTest]
  */
 AlertStack.propTypes = {
     children: propTypes.arrayOf(propTypes.element),
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
 export { AlertStack }

--- a/src/Backdrop.js
+++ b/src/Backdrop.js
@@ -11,13 +11,21 @@ import { Layer } from './LayerContext.js'
  * @param {Object} PropTypes
  * @returns {React.Component}
  */
-const Backdrop = ({ onClick, transparent, children, zIndex, className }) => {
+const Backdrop = ({
+    onClick,
+    transparent,
+    children,
+    zIndex,
+    className,
+    dataTest,
+}) => {
     return (
         <Layer zIndex={zIndex}>
             {zIndexComputed => (
                 <div
                     className={cx('backdrop', className)}
                     onClick={event => onClick && onClick({}, event)}
+                    data-test={dataTest}
                 >
                     <div
                         onClick={e => {
@@ -54,6 +62,10 @@ const Backdrop = ({ onClick, transparent, children, zIndex, className }) => {
     )
 }
 
+Backdrop.defaultProps = {
+    dataTest: 'dhis2-uicore-backdrop',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -62,10 +74,12 @@ const Backdrop = ({ onClick, transparent, children, zIndex, className }) => {
  * @prop {Node} children
  * @prop {number} zIndex
  * @prop {string} className
+ * @prop {string} [dataTest]
  */
 Backdrop.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
     transparent: propTypes.bool,
     zIndex: propTypes.number,
     onClick: propTypes.func,

--- a/src/Button.js
+++ b/src/Button.js
@@ -40,6 +40,7 @@ export class Button extends Component {
             destructive,
             small,
             large,
+            dataTest,
         } = this.props
 
         return (
@@ -60,6 +61,7 @@ export class Button extends Component {
                 value={value}
                 ref={this.buttonRef}
                 tabIndex={tabIndex}
+                data-test={dataTest}
             >
                 {icon && <span className="button-icon">{icon}</span>}
                 {children}
@@ -72,6 +74,7 @@ export class Button extends Component {
 
 Button.defaultProps = {
     type: 'button',
+    dataTest: 'dhis2-uicore-button',
 }
 
 /**
@@ -98,27 +101,25 @@ Button.defaultProps = {
  * @prop {boolean} [disabled] Disable the button
  * @prop {Element} [icon]
  *
+ * @prop {string} [dataTest]
  * @prop {boolean} [initialFocus] Grants the button the initial focus
  * state
  */
 Button.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
-
+    dataTest: propTypes.string,
     destructive: buttonVariantPropType,
     disabled: propTypes.bool,
     icon: propTypes.element,
     initialFocus: propTypes.bool,
     large: sizePropType,
     name: propTypes.string,
-
     primary: buttonVariantPropType,
     secondary: buttonVariantPropType,
-
     small: sizePropType,
     tabIndex: propTypes.string,
     type: propTypes.oneOf(['submit', 'reset', 'button']),
-
     value: propTypes.string,
     onClick: propTypes.func,
 }

--- a/src/ButtonStrip.js
+++ b/src/ButtonStrip.js
@@ -12,8 +12,8 @@ import { spacers } from './theme.js'
  * @example import { ButtonStrip } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/buttonstrip--default|Storybook}
  */
-const ButtonStrip = ({ className, children, middle, end }) => (
-    <div className={cx(className, { middle, end })}>
+const ButtonStrip = ({ className, children, middle, end, dataTest }) => (
+    <div className={cx(className, { middle, end })} data-test={dataTest}>
         {children}
 
         <style jsx>{`
@@ -38,6 +38,10 @@ const alignmentPropType = propTypes.mutuallyExclusive(
     propTypes.bool
 )
 
+ButtonStrip.defaultProps = {
+    dataTest: 'dhis2-uicore-buttonstrip',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -47,10 +51,12 @@ const alignmentPropType = propTypes.mutuallyExclusive(
  * @prop {boolean} [middle] - The props `middle`, and `end` are
  * mutually exlusive
  * @prop {boolean} [end]
+ * @prop {string} [dataTest]
  */
 ButtonStrip.propTypes = {
     children: propTypes.arrayOf(propTypes.element),
     className: propTypes.string,
+    dataTest: propTypes.string,
     end: alignmentPropType,
     middle: alignmentPropType,
 }

--- a/src/Card.js
+++ b/src/Card.js
@@ -13,8 +13,8 @@ import { colors } from './theme.js'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/card.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/card--default|Storybook}
  */
-const Card = ({ className, children }) => (
-    <div className={cx(className)}>
+const Card = ({ className, children, dataTest }) => (
+    <div className={cx(className)} data-test={dataTest}>
         {children}
 
         <style jsx>{`
@@ -34,16 +34,22 @@ const Card = ({ className, children }) => (
     </div>
 )
 
+Card.defaultProps = {
+    dataTest: 'dhis2-uicore-card',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  *
  * @prop {string} [className]
  * @prop {Node} [children]
+ * @prop {string} [dataTest]
  */
 Card.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
 export { Card }

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -67,6 +67,7 @@ class Checkbox extends Component {
             value,
             warning,
             dense,
+            dataTest,
         } = this.props
 
         const classes = cx({
@@ -84,6 +85,7 @@ class Checkbox extends Component {
                     disabled,
                     dense,
                 })}
+                data-test={dataTest}
             >
                 <input
                     type="checkbox"
@@ -169,6 +171,10 @@ class Checkbox extends Component {
     }
 }
 
+Checkbox.defaultProps = {
+    dataTest: 'dhis2-uicore-checkbox',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -193,6 +199,7 @@ class Checkbox extends Component {
  *
  * @prop {function} [onFocus]
  * @prop {function} [onBlur]
+ * @prop {string} [dataTest]
  */
 
 const uniqueOnStatePropType = propTypes.mutuallyExclusive(
@@ -203,24 +210,20 @@ const uniqueOnStatePropType = propTypes.mutuallyExclusive(
 Checkbox.propTypes = {
     label: propTypes.node.isRequired,
     checked: uniqueOnStatePropType,
-
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
-
     error: statusPropType,
     indeterminate: uniqueOnStatePropType,
     initialFocus: propTypes.bool,
-
     name: propTypes.string,
     tabIndex: propTypes.string,
     valid: statusPropType,
     value: propTypes.string,
     warning: statusPropType,
     onBlur: propTypes.func,
-
     onChange: propTypes.func,
-
     onFocus: propTypes.func,
 }
 

--- a/src/CheckboxField.js
+++ b/src/CheckboxField.js
@@ -36,6 +36,7 @@ const CheckboxField = ({
     required,
     helpText,
     validationText,
+    dataTest,
 }) => (
     <ToggleField
         value={value}
@@ -57,8 +58,13 @@ const CheckboxField = ({
         required={required}
         helpText={helpText}
         validationText={validationText}
+        dataTest={dataTest}
     />
 )
+
+CheckboxField.defaultProps = {
+    dataTest: 'dhis2-uicore-checkboxfield',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -87,11 +93,13 @@ const CheckboxField = ({
  * @prop {boolean} [required]
  * @prop {string} [helpText]
  * @prop {string} [validationText]
+ * @prop {string} [dataTest]
  */
 CheckboxField.propTypes = {
     label: propTypes.node.isRequired,
     checked: propTypes.bool,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,

--- a/src/CheckboxGroup.js
+++ b/src/CheckboxGroup.js
@@ -27,6 +27,7 @@ const CheckboxGroup = ({
     warning,
     error,
     dense,
+    dataTest,
 }) => (
     <ToggleGroup
         onChange={onChange}
@@ -38,10 +39,15 @@ const CheckboxGroup = ({
         warning={warning}
         error={error}
         dense={dense}
+        dataTest={dataTest}
     >
         {children}
     </ToggleGroup>
 )
+
+CheckboxGroup.defaultProps = {
+    dataTest: 'dhis2-uicore-checkboxgroup',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -60,10 +66,12 @@ const CheckboxGroup = ({
  * @prop {boolean} [error]
  *
  * @prop {boolean} [dense]
+ * @prop {string} [dataTest]
  */
 CheckboxGroup.propTypes = {
     children: propTypes.arrayOf(propTypes.element).isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,

--- a/src/CheckboxGroupField.js
+++ b/src/CheckboxGroupField.js
@@ -30,6 +30,7 @@ const CheckboxGroupField = ({
     helpText,
     validationText,
     required,
+    dataTest,
 }) => (
     <ToggleGroupField
         onChange={onChange}
@@ -45,10 +46,15 @@ const CheckboxGroupField = ({
         helpText={helpText}
         validationText={validationText}
         required={required}
+        dataTest={dataTest}
     >
         {children}
     </ToggleGroupField>
 )
+
+CheckboxGroupField.defaultProps = {
+    dataTest: 'dhis2-uicore-checkboxgroupfield',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -71,10 +77,12 @@ const CheckboxGroupField = ({
  * @prop {string} [helpText]
  * @prop {string} [validationText]
  * @prop {boolean} [required]
+ * @prop {string} [dataTest]
  */
 CheckboxGroupField.propTypes = {
     children: propTypes.arrayOf(propTypes.element).isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,

--- a/src/Chip.js
+++ b/src/Chip.js
@@ -26,6 +26,7 @@ const Chip = ({
     onRemove,
     onClick,
     icon,
+    dataTest,
 }) => (
     <span
         onClick={e => {
@@ -38,10 +39,11 @@ const Chip = ({
             disabled,
             dragging,
         })}
+        data-test={dataTest}
     >
         <Icon icon={icon} />
         <Content overflow={overflow}>{children}</Content>
-        <Remove onRemove={onRemove} />
+        <Remove onRemove={onRemove} dataTest={`${dataTest}-remove`} />
 
         <style jsx>{`
             span {
@@ -95,6 +97,10 @@ const Chip = ({
     </span>
 )
 
+Chip.defaultProps = {
+    dataTest: 'dhis2-uicore-chip',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -107,15 +113,15 @@ const Chip = ({
  * @prop {boolean} [disabled]
  * @prop {boolean} [dragging]
  * @prop {boolean} [overflow]
+ * @prop {string} [dataTest]
  */
 Chip.propTypes = {
     children: propTypes.string.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     disabled: propTypes.bool,
-
     dragging: propTypes.bool,
     icon: propTypes.element,
-
     overflow: propTypes.bool,
     selected: propTypes.bool,
     onClick: propTypes.func,

--- a/src/Chip/Remove.js
+++ b/src/Chip/Remove.js
@@ -29,7 +29,7 @@ const removeIcon = resolve`
     }
 `
 
-export const Remove = ({ onRemove }) => {
+export const Remove = ({ onRemove, dataTest }) => {
     if (!onRemove) {
         return null
     }
@@ -40,6 +40,7 @@ export const Remove = ({ onRemove }) => {
                 e.stopPropagation() // stop onRemove from triggering onClick on container
                 onRemove({}, e)
             }}
+            data-test={dataTest}
         >
             <Cancel className={removeIcon.className} />
             {removeIcon.styles}
@@ -50,5 +51,6 @@ export const Remove = ({ onRemove }) => {
 }
 
 Remove.propTypes = {
+    dataTest: propTypes.string.isRequired,
     onRemove: propTypes.func,
 }

--- a/src/CircularLoader.js
+++ b/src/CircularLoader.js
@@ -14,13 +14,14 @@ import { theme, spacers } from './theme.js'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/loading.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/circularloader--default|Storybook}
  */
-const CircularLoader = ({ small, large, className }) => (
+const CircularLoader = ({ small, large, className, dataTest }) => (
     <div
         role="progressbar"
         className={cx(className, {
             small,
             large,
         })}
+        data-test={dataTest}
     >
         <svg viewBox="22 22 44 44">
             <circle
@@ -84,15 +85,21 @@ const CircularLoader = ({ small, large, className }) => (
     </div>
 )
 
+CircularLoader.defaultProps = {
+    dataTest: 'dhis2-uicore-circularloader',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {string} [className]
  * @prop {boolean} [small] - `small` and `large` are mutually exclusive.
  * @prop {boolean} [large]
+ * @prop {string} [dataTest]
  */
 CircularLoader.propTypes = {
     className: propTypes.string,
+    dataTest: propTypes.string,
     large: sizePropType,
     small: sizePropType,
 }

--- a/src/ComponentCover.js
+++ b/src/ComponentCover.js
@@ -10,8 +10,8 @@ import { layers } from './theme.js'
  * @example import { ComponentCover } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/componentcover--circularloader|Storybook}
  */
-const ComponentCover = ({ children, className }) => (
-    <div className={className}>
+const ComponentCover = ({ children, className, dataTest }) => (
+    <div className={className} data-test={dataTest}>
         {children}
         <style jsx>{`
             div {
@@ -31,15 +31,21 @@ const ComponentCover = ({ children, className }) => (
     </div>
 )
 
+ComponentCover.defaultProps = {
+    dataTest: 'dhis2-uicore-componentcover',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {string} [className]
  * @prop {Node} [children]
+ * @prop {string} [dataTest]
  */
 ComponentCover.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
 export { ComponentCover }

--- a/src/Constrictor.js
+++ b/src/Constrictor.js
@@ -12,8 +12,14 @@ import React from 'react'
  * 2: a snake (such as a boa constrictor) that coils around and compresses prey
  * 3: one that constricts
  */
-export const Constrictor = ({ width, minWidth, maxWidth, children }) => (
-    <div>
+export const Constrictor = ({
+    width,
+    minWidth,
+    maxWidth,
+    children,
+    dataTest,
+}) => (
+    <div data-test={dataTest}>
         {children}
         <style jsx>{`
             div {
@@ -25,6 +31,10 @@ export const Constrictor = ({ width, minWidth, maxWidth, children }) => (
     </div>
 )
 
+Constrictor.defaultProps = {
+    dataTest: 'dhis2-uicore-constrictor',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -32,9 +42,11 @@ export const Constrictor = ({ width, minWidth, maxWidth, children }) => (
  * @prop {string} [width]
  * @prop {string} [minWidth]
  * @prop {string} [maxWidth]
+ * @prop {string} [dataTest]
  */
 Constrictor.propTypes = {
     children: propTypes.node,
+    dataTest: propTypes.string,
     maxWidth: propTypes.string,
     minWidth: propTypes.string,
     width: propTypes.string,

--- a/src/Divider.js
+++ b/src/Divider.js
@@ -10,8 +10,8 @@ import { colors, spacers } from './theme.js'
  * @returns {React.Component}
  * @example import { Divider } from @dhis2/ui-core
  */
-const Divider = ({ margin, className }) => (
-    <div className={className}>
+const Divider = ({ margin, className, dataTest }) => (
+    <div className={className} data-test={dataTest}>
         <style jsx>{`
             div {
                 display: inline-block;
@@ -30,6 +30,7 @@ const Divider = ({ margin, className }) => (
 
 Divider.defaultProps = {
     margin: `${spacers.dp8} 0`,
+    dataTest: 'dhis2-uicore-divider',
 }
 
 /**
@@ -37,9 +38,11 @@ Divider.defaultProps = {
  * @static
  * @prop {string} [className]
  * @prop {string} [margin="${spacers.dp8} 0"] - A CSS shorthand declaration for margin
+ * @prop {string} [dataTest]
  */
 Divider.propTypes = {
     className: propTypes.string,
+    dataTest: propTypes.string,
     margin: propTypes.string,
 }
 

--- a/src/DropMenu.js
+++ b/src/DropMenu.js
@@ -69,13 +69,17 @@ class DropMenu extends Component {
     }
 
     render() {
-        const { className, component, zIndex } = this.props
+        const { className, component, zIndex, dataTest } = this.props
         const { top, left } = this.state
 
         return ReactDOM.createPortal(
             <Layer zIndex={zIndex}>
                 {zIndexComputed => (
-                    <div className={className} ref={this.elContainer}>
+                    <div
+                        className={className}
+                        ref={this.elContainer}
+                        data-test={dataTest}
+                    >
                         {component}
 
                         <style jsx>{`
@@ -96,6 +100,7 @@ class DropMenu extends Component {
 
 DropMenu.defaultProps = {
     zIndex: layers.appliationTop,
+    dataTest: 'dhis2-uicore-dropmenu',
 }
 
 /**
@@ -108,6 +113,7 @@ DropMenu.defaultProps = {
  * @prop {Object} [anchorEl] - DOM node to position itself against,
  * needs to have the `getBoundingClientRect` function on its
  * `prototype`.
+ * @prop {string} [dataTest]
  */
 DropMenu.propTypes = {
     anchorEl: propTypes.shape({
@@ -115,6 +121,7 @@ DropMenu.propTypes = {
     }),
     className: propTypes.string,
     component: propTypes.element,
+    dataTest: propTypes.string,
     stayOpen: propTypes.bool,
     zIndex: propTypes.number,
     onClose: propTypes.func,

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -53,12 +53,13 @@ class DropdownButton extends Component {
             tabIndex,
             type,
             initialFocus,
+            dataTest,
         } = this.props
 
         const ArrowIcon = open ? <ArrowUp /> : <ArrowDown />
 
         return (
-            <div ref={this.anchorRef}>
+            <div ref={this.anchorRef} data-test={dataTest}>
                 <Button
                     className={className}
                     destructive={destructive}
@@ -101,6 +102,10 @@ class DropdownButton extends Component {
     }
 }
 
+DropdownButton.defaultProps = {
+    dataTest: 'dhis2-uicore-dropdownbutton',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -127,11 +132,13 @@ class DropdownButton extends Component {
  * @prop {Element} [icon]
  *
  * @prop {boolean} [initialFocus] Grants the button the initial focus
+ * @prop {string} [dataTest]
  */
 DropdownButton.propTypes = {
     component: propTypes.element.isRequired,
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
     destructive: buttonVariantPropType,
     disabled: propTypes.bool,
     icon: propTypes.element,

--- a/src/Field.js
+++ b/src/Field.js
@@ -11,8 +11,8 @@ import { spacers } from './theme.js'
  * @example import { Field } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/field--default|Storybook}
  */
-const Field = ({ children, className }) => (
-    <div className={className}>
+const Field = ({ children, className, dataTest }) => (
+    <div className={className} data-test={dataTest}>
         {children}
         <style jsx>{`
             div {
@@ -22,15 +22,21 @@ const Field = ({ children, className }) => (
     </div>
 )
 
+Field.defaultProps = {
+    dataTest: 'dhis2-uicore-field',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {Node} children
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 Field.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
 export { Field }

--- a/src/FieldSet.js
+++ b/src/FieldSet.js
@@ -8,8 +8,8 @@ import propTypes from '@dhis2/prop-types'
  * @example import { FieldSet } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/fieldset--default}
  */
-const FieldSet = ({ className, children }) => (
-    <fieldset className={className}>
+const FieldSet = ({ className, children, dataTest }) => (
+    <fieldset className={className} data-test={dataTest}>
         {children}
         <style jsx>{`
             fieldset {
@@ -21,15 +21,21 @@ const FieldSet = ({ className, children }) => (
     </fieldset>
 )
 
+FieldSet.defaultProps = {
+    dataTest: 'dhis2-uicore-fieldset',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {Node} children
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 FieldSet.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
 export { FieldSet }

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -55,10 +55,11 @@ class FileInput extends Component {
             large,
             disabled,
             tabIndex,
+            dataTest,
         } = this.props
 
         return (
-            <div className={cx('file-input', className)}>
+            <div className={cx('file-input', className)} data-test={dataTest}>
                 <input
                     id={name}
                     name={name}
@@ -104,6 +105,11 @@ class FileInput extends Component {
     }
 }
 
+FileInput.defaultProps = {
+    accept: '*',
+    dataTest: 'dhis2-uicore-fileinput',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -125,28 +131,23 @@ class FileInput extends Component {
  *
  * @prop {string} [accept=*] - the `accept` attribute of the native file input https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept
  * @prop {boolean} [multiple] - the `multiple` attribute of the native file input https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#multiple
+ * @prop {string} [dataTest]
  */
 FileInput.propTypes = {
     accept: propTypes.string,
     buttonLabel: propTypes.string,
     className: propTypes.string,
-
+    dataTest: propTypes.string,
     disabled: propTypes.bool,
     error: statusPropType,
-
     large: sizePropType,
     multiple: propTypes.bool,
     name: propTypes.string,
     small: sizePropType,
     tabIndex: propTypes.string,
     valid: statusPropType,
-
     warning: statusPropType,
     onChange: propTypes.func,
-}
-
-FileInput.defaultProps = {
-    accept: '*',
 }
 
 export { FileInput }

--- a/src/FileInputField.js
+++ b/src/FileInputField.js
@@ -40,8 +40,9 @@ const FileInputField = ({
     disabled,
     accept,
     multiple,
+    dataTest,
 }) => (
-    <Field className={className}>
+    <Field className={className} dataTest={dataTest}>
         {label && (
             <Label required={required} disabled={disabled} htmlFor={name}>
                 {label}
@@ -64,10 +65,15 @@ const FileInputField = ({
             name={name}
         />
 
-        {helpText && <Help>{helpText}</Help>}
+        {helpText && <Help dataTest={`${dataTest}-help`}>{helpText}</Help>}
 
         {validationText && (
-            <Help error={error} warning={warning} valid={valid}>
+            <Help
+                error={error}
+                warning={warning}
+                valid={valid}
+                dataTest={`${dataTest}-validation`}
+            >
                 {validationText}
             </Help>
         )}
@@ -81,6 +87,11 @@ const FileInputField = ({
         </FileList>
     </Field>
 )
+
+FileInputField.defaultProps = {
+    accept: '*',
+    dataTest: 'dhis2-uicore-fileinputfield',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -110,12 +121,14 @@ const FileInputField = ({
  * @prop {FileListItem|Array.<FileListItem>} [children]
  * @prop {string} [accept=*] - the `accept` attribute of the native file input https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept
  * @prop {boolean} [multiple] - the `multiple` attribute of the native file input https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#multiple
+ * @prop {string} [dataTest]
  */
 FileInputField.propTypes = {
     accept: propTypes.string,
     buttonLabel: propTypes.string,
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
     disabled: propTypes.bool,
     error: statusPropType,
     helpText: propTypes.string,
@@ -131,10 +144,6 @@ FileInputField.propTypes = {
     validationText: propTypes.string,
     warning: statusPropType,
     onChange: propTypes.func,
-}
-
-FileInputField.defaultProps = {
-    accept: '*',
 }
 
 export { FileInputField }

--- a/src/FileList.js
+++ b/src/FileList.js
@@ -8,8 +8,8 @@ import propTypes from '@dhis2/prop-types'
  *
  * @example import { FileList } from '@dhis2/ui-core'
  */
-const FileList = ({ children, className }) => (
-    <div className={className}>
+const FileList = ({ children, className, dataTest }) => (
+    <div className={className} data-test={dataTest}>
         {children}
         <style jsx>{`
             div {
@@ -22,16 +22,22 @@ const FileList = ({ children, className }) => (
     </div>
 )
 
+FileList.defaultProps = {
+    dataTest: 'dhis2-uicore-filelist',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  *
  * @prop {string} [className]
  * @prop {FileListPlaceholder|FileListItem|Array.<FileListItem>} [children]
+ * @prop {string} [dataTest]
  */
 FileList.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
 export { FileList }

--- a/src/FileListItem.js
+++ b/src/FileListItem.js
@@ -25,8 +25,9 @@ const FileListItem = ({
     loading,
     onCancel,
     cancelText,
+    dataTest,
 }) => (
-    <p className={cx('selected-file', className)}>
+    <p className={cx('selected-file', className)} data-test={dataTest}>
         <span className="icon">{loading ? <Loading /> : <AttachFile />}</span>
 
         <span className="text">
@@ -86,6 +87,10 @@ const FileListItem = ({
     </p>
 )
 
+FileListItem.defaultProps = {
+    dataTest: 'dhis2-uicore-filelistitem',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -97,6 +102,7 @@ const FileListItem = ({
  * @prop {boolean} [loading]
  * @prop {function} [onCancel]
  * @prop {string} [cancelText]
+ * @prop {string} [dataTest]
  */
 FileListItem.propTypes = {
     label: propTypes.string.isRequired,
@@ -104,6 +110,7 @@ FileListItem.propTypes = {
     onRemove: propTypes.func.isRequired,
     cancelText: propTypes.string,
     className: propTypes.string,
+    dataTest: propTypes.string,
     loading: propTypes.bool,
     onCancel: propTypes.func,
 }

--- a/src/FileListPlaceholder.js
+++ b/src/FileListPlaceholder.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
+
 import { colors, spacers } from './theme.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
@@ -10,8 +11,8 @@ import { colors, spacers } from './theme.js'
  *
  * @example import { FileListPlaceholder } from '@dhis2/ui-core'
  */
-const FileListPlaceholder = ({ children }) => (
-    <p>
+const FileListPlaceholder = ({ children, dataTest }) => (
+    <p data-test={dataTest}>
         {children}
         <style jsx>{`
             p {
@@ -24,14 +25,20 @@ const FileListPlaceholder = ({ children }) => (
     </p>
 )
 
+FileListPlaceholder.defaultProps = {
+    dataTest: 'dhis2-uicore-filelistplaceholder',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  *
  * @prop {string} [children]
+ * @prop {string} [dataTest]
  */
 FileListPlaceholder.propTypes = {
     children: propTypes.string,
+    dataTest: propTypes.string,
 }
 
 export { FileListPlaceholder }

--- a/src/Help.js
+++ b/src/Help.js
@@ -13,13 +13,14 @@ import { spacers, theme } from './theme.js'
  * @example import { Help } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/help--default|Storybook}
  */
-const Help = ({ children, valid, error, warning, className }) => (
+const Help = ({ children, valid, error, warning, className, dataTest }) => (
     <p
         className={cx(className, {
             valid,
             error,
             warning,
         })}
+        data-test={dataTest}
     >
         {children}
 
@@ -50,6 +51,10 @@ const Help = ({ children, valid, error, warning, className }) => (
     </p>
 )
 
+Help.defaultProps = {
+    dataTest: 'dhis2-uicore-help',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -58,10 +63,12 @@ const Help = ({ children, valid, error, warning, className }) => (
  * @prop {boolean} [valid] - `valid`, `warning`, and `error`, are mutually exclusive
  * @prop {boolean} [warning]
  * @prop {boolean} [error]
+ * @prop {string} [dataTest]
  */
 Help.propTypes = {
     children: propTypes.string.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     error: statusPropType,
     valid: statusPropType,
     warning: statusPropType,

--- a/src/Input.js
+++ b/src/Input.js
@@ -133,10 +133,11 @@ export class Input extends Component {
             loading,
             value,
             tabIndex,
+            dataTest,
         } = this.props
 
         return (
-            <div className={cx('input', className)}>
+            <div className={cx('input', className)} data-test={dataTest}>
                 <input
                     id={name}
                     name={name}
@@ -182,6 +183,7 @@ export class Input extends Component {
 
 Input.defaultProps = {
     type: 'text',
+    dataTest: 'dhis2-uicore-input',
 }
 
 /**
@@ -208,21 +210,19 @@ Input.defaultProps = {
  * @prop {boolean} [warning]
  * @prop {boolean} [error]
  * @prop {boolean} [loading]
+ * @prop {string} [dataTest]
  */
 Input.propTypes = {
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
-
     disabled: propTypes.bool,
-
     error: statusPropType,
     initialFocus: propTypes.bool,
     loading: propTypes.bool,
-
     name: propTypes.string,
     placeholder: propTypes.string,
     readOnly: propTypes.bool,
-
     tabIndex: propTypes.string,
     type: propTypes.oneOf([
         'text',
@@ -240,11 +240,9 @@ Input.propTypes = {
         'search',
     ]),
     valid: statusPropType,
-
     value: propTypes.string,
     warning: statusPropType,
     onBlur: propTypes.func,
     onChange: propTypes.func,
-
     onFocus: propTypes.func,
 }

--- a/src/InputField.js
+++ b/src/InputField.js
@@ -2,7 +2,6 @@ import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
 import { statusPropType } from './common-prop-types.js'
-
 import { Field } from './Field.js'
 import { Label } from './Label.js'
 import { Input } from './Input.js'
@@ -45,10 +44,11 @@ class InputField extends React.Component {
             helpText,
             validationText,
             inputWidth,
+            dataTest,
         } = this.props
 
         return (
-            <Field className={className}>
+            <Field className={className} dataTest={dataTest}>
                 {label && (
                     <Label
                         required={required}
@@ -80,16 +80,27 @@ class InputField extends React.Component {
                     />
                 </Constrictor>
 
-                {helpText && <Help>{helpText}</Help>}
+                {helpText && (
+                    <Help dataTest={`${dataTest}-help`}>{helpText}</Help>
+                )}
 
                 {validationText && (
-                    <Help error={error} warning={warning} valid={valid}>
+                    <Help
+                        error={error}
+                        warning={warning}
+                        valid={valid}
+                        dataTest={`${dataTest}-validation`}
+                    >
                         {validationText}
                     </Help>
                 )}
             </Field>
         )
     }
+}
+
+InputField.defaultProps = {
+    dataTest: 'dhis2-uicore-inputfield',
 }
 
 /**
@@ -122,19 +133,19 @@ class InputField extends React.Component {
  *
  * @prop {string} [validationText]
  * @prop {string} [helpText]
+ * @prop {string} [dataTest]
  */
 InputField.propTypes = {
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,
     helpText: propTypes.string,
-
     initialFocus: propTypes.bool,
     inputWidth: propTypes.string,
     label: propTypes.string,
     loading: propTypes.bool,
-
     name: propTypes.string,
     placeholder: propTypes.string,
     readOnly: propTypes.bool,
@@ -144,10 +155,8 @@ InputField.propTypes = {
     valid: statusPropType,
     validationText: propTypes.string,
     value: propTypes.string,
-
     warning: statusPropType,
     onBlur: propTypes.func,
-
     onChange: propTypes.func,
     onFocus: propTypes.func,
 }

--- a/src/Label.js
+++ b/src/Label.js
@@ -37,15 +37,27 @@ const constructClassName = ({ required, disabled, className }) =>
  *
  * @example import { Label } from '@dhis2/ui-core'
  */
-export const Label = ({ htmlFor, children, required, disabled, className }) => (
+export const Label = ({
+    htmlFor,
+    children,
+    required,
+    disabled,
+    className,
+    dataTest,
+}) => (
     <label
         htmlFor={htmlFor}
         className={constructClassName({ className, required, disabled })}
+        data-test={dataTest}
     >
         <span>{children}</span>
         <style jsx>{styles}</style>
     </label>
 )
+
+Label.defaultProps = {
+    dataTest: 'dhis2-uicore-label',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -56,10 +68,12 @@ export const Label = ({ htmlFor, children, required, disabled, className }) => (
  * @prop {string} [className]
  * @prop {boolean} [required]
  * @prop {boolean} [disabled]
+ * @prop {string} [dataTest]
  */
 Label.propTypes = {
     children: propTypes.string,
     className: propTypes.string,
+    dataTest: propTypes.string,
     disabled: propTypes.bool,
     htmlFor: propTypes.string,
     required: propTypes.bool,

--- a/src/Legend.js
+++ b/src/Legend.js
@@ -14,8 +14,8 @@ import { colors, spacers } from './theme.js'
  *
  * @see Live demo: {@link /demo/?path=/story/legend--default|Storybook}
  */
-const Legend = ({ className, children, required }) => (
-    <legend className={cx(className, { required })}>
+const Legend = ({ className, children, required, dataTest }) => (
+    <legend className={cx(className, { required })} data-test={dataTest}>
         {children}
         <style jsx>{`
             legend {
@@ -31,16 +31,22 @@ const Legend = ({ className, children, required }) => (
     </legend>
 )
 
+Legend.defaultProps = {
+    dataTest: 'dhis2-uicore-legend',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {Node} children
  * @prop {string} [className]
  * @prop {boolean} [required]
+ * @prop {string} [dataTest]
  */
 Legend.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     required: propTypes.bool,
 }
 

--- a/src/LinearLoader.js
+++ b/src/LinearLoader.js
@@ -20,6 +20,7 @@ const Progress = ({ amount }) => {
         </div>
     )
 }
+
 Progress.propTypes = {
     amount: propTypes.number.isRequired,
 }
@@ -34,9 +35,9 @@ Progress.propTypes = {
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/loading.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/linearloader--determinate|Storybook}
  */
-const LinearLoader = ({ amount, width, margin, className }) => {
+const LinearLoader = ({ amount, width, margin, className, dataTest }) => {
     return (
-        <div role="progressbar" className={className}>
+        <div role="progressbar" className={className} data-test={dataTest}>
             <Progress amount={amount} />
 
             <style jsx>{`
@@ -61,6 +62,7 @@ const LinearLoader = ({ amount, width, margin, className }) => {
 LinearLoader.defaultProps = {
     margin: spacers.dp12,
     width: '300px',
+    dataTest: 'dhis2-uicore-linearloader',
 }
 
 /**
@@ -71,10 +73,12 @@ LinearLoader.defaultProps = {
  * @prop {number} [amount] - The progression in percent without the '%' sign
  * @prop {string} [margin=spacers.dp12] - The margin around the loader, can be a full shorthand
  * @prop {string} [width=300px] - The width of the entire indicator, e.g. '100%' or '300px'
+ * @prop {string} [dataTest]
  */
 LinearLoader.propTypes = {
     amount: propTypes.number.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     margin: propTypes.string,
     width: propTypes.string,
 }

--- a/src/Logo.js
+++ b/src/Logo.js
@@ -20,6 +20,7 @@ import { LogoIconSvg } from './Logo/LogoIconSvg'
  * @typedef {Object} PropTypes
  * @static
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 
 /*
@@ -35,30 +36,64 @@ const blue = '#0080d4'
 const white = '#ffffff'
 const dark = '#212225'
 
-export const LogoIcon = ({ className }) => (
-    <LogoIconSvg iconColor={blue} className={className} />
+export const LogoIcon = ({ className, dataTest }) => (
+    <LogoIconSvg iconColor={blue} className={className} dataTest={dataTest} />
 )
+
+LogoIcon.defaultProps = {
+    dataTest: 'dhis2-uicore-logoicon',
+}
+
 LogoIcon.propTypes = {
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
-export const LogoIconWhite = ({ className }) => (
-    <LogoIconSvg iconColor={white} className={className} />
+export const LogoIconWhite = ({ className, dataTest }) => (
+    <LogoIconSvg iconColor={white} className={className} dataTest={dataTest} />
 )
+
+LogoIconWhite.defaultProps = {
+    dataTest: 'dhis2-uicore-logoiconwhite',
+}
+
 LogoIconWhite.propTypes = {
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
-export const Logo = ({ className }) => (
-    <LogoSvg iconColor={blue} textColor={dark} className={className} />
+export const Logo = ({ className, dataTest }) => (
+    <LogoSvg
+        iconColor={blue}
+        textColor={dark}
+        className={className}
+        dataTest={dataTest}
+    />
 )
+
+Logo.defaultProps = {
+    dataTest: 'dhis2-uicore-logo',
+}
+
 Logo.propTypes = {
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
-export const LogoWhite = ({ className }) => (
-    <LogoSvg iconColor={white} textColor={white} className={className} />
+export const LogoWhite = ({ className, dataTest }) => (
+    <LogoSvg
+        iconColor={white}
+        textColor={white}
+        className={className}
+        dataTest={dataTest}
+    />
 )
+
+LogoWhite.defaultProps = {
+    dataTest: 'dhis2-uicore-logowhite',
+}
+
 LogoWhite.propTypes = {
     className: propTypes.string,
+    dataTest: propTypes.string,
 }

--- a/src/Logo/LogoIconSvg.js
+++ b/src/Logo/LogoIconSvg.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
-export function LogoIconSvg({ iconColor, className }) {
+export function LogoIconSvg({ iconColor, className, dataTest }) {
     return (
         <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 200 182"
             className={className}
+            data-test={dataTest}
         >
             <defs />
             <path
@@ -28,4 +29,5 @@ export function LogoIconSvg({ iconColor, className }) {
 LogoIconSvg.propTypes = {
     iconColor: propTypes.string.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }

--- a/src/Logo/LogoSvg.js
+++ b/src/Logo/LogoSvg.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
-export function LogoSvg({ iconColor, textColor, className }) {
+export function LogoSvg({ iconColor, textColor, className, dataTest }) {
     return (
         <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 600 182"
             className={className}
+            data-test={dataTest}
         >
             <path
                 fill={iconColor}
@@ -55,4 +56,5 @@ LogoSvg.propTypes = {
     iconColor: propTypes.string.isRequired,
     textColor: propTypes.string.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -16,8 +16,8 @@ import { spacers } from './theme.js'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/menu.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/menu--default|Storybook}
  */
-const Menu = ({ children, className }) => (
-    <div className={className}>
+const Menu = ({ children, className, dataTest }) => (
+    <div className={className} data-test={dataTest}>
         <Card>
             <div className="menu-list-wrapper">
                 <MenuList>{children}</MenuList>
@@ -32,16 +32,22 @@ const Menu = ({ children, className }) => (
     </div>
 )
 
+Menu.defaultProps = {
+    dataTest: 'dhis2-uicore-menu',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  *
  * @prop {*} [children]
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 Menu.propTypes = {
     children: MenuList.propTypes.children,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
 export { Menu }

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -4,7 +4,6 @@ import cx from 'classnames'
 import css from 'styled-jsx/css'
 
 import { ChevronRight } from './icons/Chevron.js'
-
 import styles from './MenuItem/styles.js'
 
 const subChevron = css.resolve`
@@ -69,6 +68,7 @@ const MenuItem = ({
     dense,
     onClick,
     className,
+    dataTest,
 }) => {
     const hasMenu = !!children
     const isClickable = href || onClick
@@ -87,6 +87,7 @@ const MenuItem = ({
                 dense,
                 active,
             })}
+            data-test={dataTest}
         >
             <LinkElement className="link" {...linkElementProps}>
                 {icon}
@@ -106,6 +107,10 @@ const MenuItem = ({
     )
 }
 
+MenuItem.defaultProps = {
+    dataTest: 'dhis2-uicore-menuitem',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -120,18 +125,17 @@ const MenuItem = ({
  * @prop {boolean} [dense]
  * @prop {boolean} [active]
  * @prop {boolean} [disabled]
+ * @prop {string} [dataTest]
  */
 MenuItem.propTypes = {
     label: propTypes.oneOfType([propTypes.string, propTypes.node]).isRequired,
-
     active: propTypes.bool,
     children: propTypes.element,
     className: propTypes.string,
-
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     href: propTypes.string,
-
     icon: propTypes.element,
     value: propTypes.string,
     onClick: propTypes.func,

--- a/src/MenuList.js
+++ b/src/MenuList.js
@@ -11,8 +11,8 @@ import propTypes from '@dhis2/prop-types'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/menu.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/menulist--default|Storybook}
  */
-const MenuList = ({ children, className }) => (
-    <ul className={className}>
+const MenuList = ({ children, className, dataTest }) => (
+    <ul className={className} data-test={dataTest}>
         {children}
 
         <style jsx>{`
@@ -29,16 +29,22 @@ const MenuList = ({ children, className }) => (
     </ul>
 )
 
+MenuList.defaultProps = {
+    dataTest: 'dhis2-uicore-menulist',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  *
  * @prop {Node} children
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 MenuList.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }
 
 export { MenuList }

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -4,7 +4,6 @@ import { createPortal } from 'react-dom'
 
 import { sizePropType } from './common-prop-types.js'
 import { ScreenCover } from './ScreenCover.js'
-
 import { ModalCard } from './Modal/ModalCard.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
@@ -37,15 +36,28 @@ import { ModalCard } from './Modal/ModalCard.js'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/modal.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/modal--small-title-content-action|Storybook}
  */
-export const Modal = ({ children, onClose, small, large, className }) =>
+export const Modal = ({
+    children,
+    onClose,
+    small,
+    large,
+    className,
+    dataTest,
+}) =>
     createPortal(
         <ScreenCover onClick={onClose} className={className}>
-            <ModalCard small={small} large={large}>
-                {children}
-            </ModalCard>
+            <aside data-test={dataTest}>
+                <ModalCard small={small} large={large}>
+                    {children}
+                </ModalCard>
+            </aside>
         </ScreenCover>,
         document.body
     )
+
+Modal.defaultProps = {
+    dataTest: 'dhis2-uicore-modal',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -56,15 +68,14 @@ export const Modal = ({ children, onClose, small, large, className }) =>
  * @prop {Function} onClose
  * @prop {bool} small
  * @prop {bool} large
+ * @prop {string} [dataTest]
  */
 Modal.propTypes = {
     children: propTypes.node.isRequired,
-
     className: propTypes.string,
-
-    // Callback used when clicking on the screen cover
+    dataTest: propTypes.string,
     large: sizePropType,
-
     small: sizePropType,
+    // Callback used when clicking on the screen cover
     onClose: propTypes.func,
 }

--- a/src/ModalActions.js
+++ b/src/ModalActions.js
@@ -10,8 +10,8 @@ import { spacers } from './theme.js'
  * @param {ModalActions.PropTypes} props
  * @returns {React.Component}
  */
-export const ModalActions = ({ children }) => (
-    <div>
+export const ModalActions = ({ children, dataTest }) => (
+    <div data-test={dataTest}>
         {children}
 
         <style jsx>{`
@@ -24,11 +24,17 @@ export const ModalActions = ({ children }) => (
     </div>
 )
 
+ModalActions.defaultProps = {
+    dataTest: 'dhis2-uicore-modalactions',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {Object} children - Accepts one or more `Element`s
+ * @prop {string} [dataTest]
  */
 ModalActions.propTypes = {
     children: propTypes.node.isRequired,
+    dataTest: propTypes.string,
 }

--- a/src/ModalContent.js
+++ b/src/ModalContent.js
@@ -10,8 +10,8 @@ import { spacers } from './theme.js'
  * @param {ModalContent.PropTypes} props
  * @returns {React.Component}
  */
-export const ModalContent = ({ children, className }) => (
-    <div className={className}>
+export const ModalContent = ({ children, className, dataTest }) => (
+    <div className={className} data-test={dataTest}>
         {children}
 
         <style jsx>{`
@@ -25,13 +25,19 @@ export const ModalContent = ({ children, className }) => (
     </div>
 )
 
+ModalContent.defaultProps = {
+    dataTest: 'dhis2-uicore-modalcontent',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {Node} children
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 ModalContent.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }

--- a/src/ModalTitle.js
+++ b/src/ModalTitle.js
@@ -10,8 +10,8 @@ import { spacers } from './theme.js'
  * @param {ModalTitle.PropTypes} props
  * @returns {React.Component}
  */
-export const ModalTitle = ({ children }) => (
-    <h1 className={cx('title')}>
+export const ModalTitle = ({ children, dataTest }) => (
+    <h1 className={cx('title')} data-test={dataTest}>
         {children}
 
         <style jsx>{`
@@ -26,11 +26,17 @@ export const ModalTitle = ({ children }) => (
     </h1>
 )
 
+ModalTitle.defaultProps = {
+    dataTest: 'dhis2-uicore-modaltitle',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {string} children
+ * @prop {string} [dataTest]
  */
 ModalTitle.propTypes = {
     children: propTypes.string.isRequired,
+    dataTest: propTypes.string,
 }

--- a/src/MultiSelect.js
+++ b/src/MultiSelect.js
@@ -46,6 +46,7 @@ const MultiSelect = ({
     noMatchText,
     initialFocus,
     dense,
+    dataTest,
 }) => {
     // If the select is filterable, use a filterable menu
     const menu = filterable ? (
@@ -59,7 +60,7 @@ const MultiSelect = ({
     )
 
     return (
-        <div className="root">
+        <div className="root" data-test={dataTest}>
             <div className="root-input">
                 <Select
                     className={className}
@@ -108,6 +109,7 @@ const MultiSelect = ({
 
 MultiSelect.defaultProps = {
     selected: [],
+    dataTest: 'dhis2-uicore-multiselect',
 }
 
 /**
@@ -139,12 +141,14 @@ MultiSelect.defaultProps = {
  * @prop {string} [noMatchText] - Only required if filterable is true
  * @prop {string} [placeholder]
  * @prop {string} [prefix]
+ * @prop {string} [dataTest]
  */
 MultiSelect.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     clearText: propTypes.requiredIf(props => props.clearable, propTypes.string),
     clearable: propTypes.bool,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     empty: propTypes.node,

--- a/src/MultiSelectField.js
+++ b/src/MultiSelectField.js
@@ -2,7 +2,6 @@ import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
 import { statusPropType, multiSelectedPropType } from './common-prop-types.js'
-
 import { Field } from './Field.js'
 import { Label } from './Label.js'
 import { Help } from './Help.js'
@@ -54,10 +53,11 @@ class MultiSelectField extends React.Component {
             noMatchText,
             initialFocus,
             dense,
+            dataTest,
         } = this.props
 
         return (
-            <Field className={className}>
+            <Field className={className} dataTest={dataTest}>
                 {label && (
                     <Label required={required} disabled={disabled}>
                         {label}
@@ -94,10 +94,17 @@ class MultiSelectField extends React.Component {
                     </MultiSelect>
                 </Constrictor>
 
-                {helpText && <Help>{helpText}</Help>}
+                {helpText && (
+                    <Help dataTest={`${dataTest}-help`}>{helpText}</Help>
+                )}
 
                 {validationText && (
-                    <Help error={error} warning={warning} valid={valid}>
+                    <Help
+                        error={error}
+                        warning={warning}
+                        valid={valid}
+                        dataTest={`${dataTest}-validation`}
+                    >
                         {validationText}
                     </Help>
                 )}
@@ -108,6 +115,7 @@ class MultiSelectField extends React.Component {
 
 MultiSelectField.defaultProps = {
     selected: [],
+    dataTest: 'dhis2-uicore-multiselectfield',
 }
 
 /**
@@ -144,6 +152,7 @@ MultiSelectField.defaultProps = {
  * @prop {string} [noMatchText] - Only required if filterable is true
  * @prop {string} [placeholder]
  * @prop {string} [prefix]
+ * @prop {string} [dataTest]
  */
 MultiSelectField.propTypes = {
     selected: multiSelectedPropType.isRequired,
@@ -151,6 +160,7 @@ MultiSelectField.propTypes = {
     className: propTypes.string,
     clearText: propTypes.requiredIf(props => props.clearable, propTypes.string),
     clearable: propTypes.bool,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     empty: propTypes.node,

--- a/src/MultiSelectOption.js
+++ b/src/MultiSelectOption.js
@@ -20,8 +20,15 @@ const { styles, className: checkboxClassname } = resolve`
  *
  */
 
-const MultiSelectOption = ({ label, active, disabled, onClick, className }) => (
-    <div className={cx(className, { disabled })}>
+const MultiSelectOption = ({
+    label,
+    active,
+    disabled,
+    onClick,
+    className,
+    dataTest,
+}) => (
+    <div className={cx(className, { disabled })} data-test={dataTest}>
         <Checkbox
             name={label}
             className={checkboxClassname}
@@ -46,6 +53,10 @@ const MultiSelectOption = ({ label, active, disabled, onClick, className }) => (
     </div>
 )
 
+MultiSelectOption.defaultProps = {
+    dataTest: 'dhis2-uicore-multiselectoption',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -57,6 +68,7 @@ const MultiSelectOption = ({ label, active, disabled, onClick, className }) => (
  * @prop {function} [onClick]
  * @prop {boolean} [active]
  * @prop {boolean} [disabled]
+ * @prop {string} [dataTest]
  */
 MultiSelectOption.propTypes = {
     label: propTypes.string.isRequired,
@@ -65,6 +77,7 @@ MultiSelectOption.propTypes = {
     value: propTypes.string.isRequired,
     active: propTypes.bool,
     className: propTypes.string,
+    dataTest: propTypes.string,
     disabled: propTypes.bool,
     onClick: propTypes.func,
 }

--- a/src/Node.js
+++ b/src/Node.js
@@ -22,13 +22,19 @@ export const Node = ({
     children,
     onOpen,
     onClose,
+    dataTest,
 }) => {
     const hasLeaves = !!React.Children.toArray(children).filter(i => i).length
 
     return (
-        <div className={className}>
+        <div className={className} data-test={dataTest}>
             {hasLeaves ? (
-                <Arrow open={open} onOpen={onOpen} onClose={onClose} />
+                <Arrow
+                    open={open}
+                    onOpen={onOpen}
+                    onClose={onClose}
+                    dataTest={`${dataTest}-arrow`}
+                />
             ) : (
                 <Spacer />
             )}
@@ -46,6 +52,10 @@ export const Node = ({
     )
 }
 
+Node.defaultProps = {
+    dataTest: 'dhis2-uicore-node',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -55,11 +65,13 @@ export const Node = ({
  * @prop {boolean} [open]
  * @prop {function} [onOpen]
  * @prop {funtion} [onClose]
+ * @prop {string} [dataTest]
  */
 Node.propTypes = {
     component: propTypes.element.isRequired,
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
     open: propTypes.bool,
     onClose: propTypes.func,
     onOpen: propTypes.func,

--- a/src/Node/Arrow.js
+++ b/src/Node/Arrow.js
@@ -5,11 +5,11 @@ import cx from 'classnames'
 import { ArrowDown } from '../icons/Arrow.js'
 import { colors } from '../theme.js'
 
-export const Arrow = ({ open, onOpen, onClose }) => {
+export const Arrow = ({ open, onOpen, onClose, dataTest }) => {
     const onClick = open ? onClose : onOpen
 
     return (
-        <div className={cx({ open })}>
+        <div className={cx({ open })} data-test={dataTest}>
             <span onClick={event => onClick && onClick({ open: !open }, event)}>
                 <ArrowDown />
             </span>
@@ -51,6 +51,7 @@ export const Arrow = ({ open, onOpen, onClose }) => {
 }
 
 Arrow.propTypes = {
+    dataTest: propTypes.string.isRequired,
     open: propTypes.bool,
     onClose: propTypes.func,
     onOpen: propTypes.func,

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -66,6 +66,7 @@ class Radio extends Component {
             value,
             warning,
             dense,
+            dataTest,
         } = this.props
 
         const classes = cx({
@@ -82,6 +83,7 @@ class Radio extends Component {
                     disabled,
                     dense,
                 })}
+                data-test={dataTest}
             >
                 <input
                     type="radio"
@@ -166,6 +168,10 @@ class Radio extends Component {
     }
 }
 
+Radio.defaultProps = {
+    dataTest: 'dhis2-uicore-radio',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -189,27 +195,24 @@ class Radio extends Component {
  *
  * @prop {function} [onFocus]
  * @prop {function} [onBlur]
+ * @prop {string} [dataTest]
  */
 Radio.propTypes = {
     label: propTypes.node.isRequired,
     value: propTypes.string.isRequired,
-
     checked: propTypes.bool,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
-
     disabled: propTypes.bool,
     error: statusPropType,
     initialFocus: propTypes.bool,
-
     name: propTypes.string,
     tabIndex: propTypes.string,
     valid: statusPropType,
     warning: statusPropType,
     onBlur: propTypes.func,
-
     onChange: propTypes.func,
-
     onFocus: propTypes.func,
 }
 

--- a/src/RadioGroup.js
+++ b/src/RadioGroup.js
@@ -27,6 +27,7 @@ const RadioGroup = ({
     warning,
     error,
     dense,
+    dataTest,
 }) => (
     <ToggleGroup
         onChange={onChange}
@@ -38,10 +39,15 @@ const RadioGroup = ({
         warning={warning}
         error={error}
         dense={dense}
+        dataTest={dataTest}
     >
         {children}
     </ToggleGroup>
 )
+
+RadioGroup.defaultProps = {
+    dataTest: 'dhis2-uicore-radiogroup',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -60,10 +66,12 @@ const RadioGroup = ({
  * @prop {boolean} [error]
  *
  * @prop {boolean} [dense]
+ * @prop {string} [dataTest]
  */
 RadioGroup.propTypes = {
     children: propTypes.arrayOf(propTypes.element).isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,

--- a/src/RadioGroupField.js
+++ b/src/RadioGroupField.js
@@ -31,6 +31,7 @@ const RadioGroupField = ({
     helpText,
     validationText,
     required,
+    dataTest,
 }) => (
     <ToggleGroupField
         onChange={onChange}
@@ -46,10 +47,15 @@ const RadioGroupField = ({
         helpText={helpText}
         validationText={validationText}
         required={required}
+        dataTest={dataTest}
     >
         {children}
     </ToggleGroupField>
 )
+
+RadioGroupField.defaultProps = {
+    dataTest: 'dhis2-uicore-radiogroupfield',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -72,10 +78,12 @@ const RadioGroupField = ({
  * @prop {string} [helpText]
  * @prop {string} [validationText]
  * @prop {boolean} [required]
+ * @prop {string} [dataTest]
  */
 RadioGroupField.propTypes = {
     children: propTypes.arrayOf(propTypes.element).isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,

--- a/src/ScreenCover.js
+++ b/src/ScreenCover.js
@@ -34,16 +34,21 @@ Content.propTypes = {
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/principles/spacing-alignment.md#stacking|Design system}
  * @see Live demo: {@link /demo/?path=/story/screencover--default|Storybook}
  */
-const ScreenCover = ({ children, onClick, className }) => {
+const ScreenCover = ({ children, onClick, className, dataTest }) => {
     return (
         <Backdrop
             onClick={onClick}
             zIndex={layers.blocking}
             className={className}
+            dataTest={dataTest}
         >
             <Content>{children}</Content>
         </Backdrop>
     )
+}
+
+ScreenCover.defaultProps = {
+    dataTest: 'dhis2-uicore-screencover',
 }
 
 /**
@@ -52,10 +57,12 @@ const ScreenCover = ({ children, onClick, className }) => {
  * @prop {function} [onClick]
  * @prop {string} [className]
  * @prop {Node} [children]
+ * @prop {string} [dataTest]
  */
 ScreenCover.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
     onClick: propTypes.func,
 }
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -169,6 +169,7 @@ export class Select extends Component {
             valid,
             disabled,
             dense,
+            dataTest,
         } = this.props
 
         // We need to update the menu's position on selection because
@@ -203,6 +204,7 @@ export class Select extends Component {
                 ref={this.selectRef}
                 onFocus={this.onFocus}
                 onKeyDown={this.onKeyDown}
+                data-test={dataTest}
             >
                 <InputWrapper
                     onToggle={this.onToggle}
@@ -225,6 +227,7 @@ export class Select extends Component {
                         menuTop={menuTop}
                         menuLeft={menuLeft}
                         menuWidth={menuWidth}
+                        dataTest={`${dataTest}-menu`}
                     >
                         {menu}
                     </MenuWrapper>
@@ -232,6 +235,10 @@ export class Select extends Component {
             </div>
         )
     }
+}
+
+Select.defaultProps = {
+    dataTest: 'dhis2-uicore-select',
 }
 
 Select.propTypes = {
@@ -243,6 +250,7 @@ Select.propTypes = {
     ]).isRequired,
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,

--- a/src/Select/MenuWrapper.js
+++ b/src/Select/MenuWrapper.js
@@ -16,6 +16,7 @@ const MenuWrapper = ({
     menuWidth,
     zIndex,
     onClick,
+    dataTest,
 }) => {
     const { styles, className: cardClassName } = resolve`
         height: auto;
@@ -24,7 +25,7 @@ const MenuWrapper = ({
     `
     return ReactDOM.createPortal(
         <Backdrop onClick={onClick} transparent zIndex={zIndex}>
-            <div className={className} ref={menuRef}>
+            <div className={className} ref={menuRef} dataTest={dataTest}>
                 <Card className={cardClassName}>{children}</Card>
 
                 {styles}
@@ -49,6 +50,7 @@ MenuWrapper.defaultProps = {
 }
 
 MenuWrapper.propTypes = {
+    dataTest: propTypes.string.isRequired,
     menuLeft: propTypes.string.isRequired,
     menuRef: propTypes.object.isRequired,
     menuTop: propTypes.string.isRequired,

--- a/src/SingleSelect.js
+++ b/src/SingleSelect.js
@@ -46,6 +46,7 @@ const SingleSelect = ({
     noMatchText,
     initialFocus,
     dense,
+    dataTest,
 }) => {
     // If the select is filterable, use a filterable menu
     const menu = filterable ? (
@@ -59,7 +60,7 @@ const SingleSelect = ({
     )
 
     return (
-        <div className="root">
+        <div className="root" data-test={dataTest}>
             <div className="root-input">
                 <Select
                     className={className}
@@ -108,6 +109,7 @@ const SingleSelect = ({
 
 SingleSelect.defaultProps = {
     selected: {},
+    dataTest: 'dhis2-uicore-singleselect',
 }
 
 /**
@@ -139,12 +141,14 @@ SingleSelect.defaultProps = {
  * @prop {string} [noMatchText] - Only required if filterable is true
  * @prop {string} [placeholder]
  * @prop {string} [prefix]
+ * @prop {string} [dataTest]
  */
 SingleSelect.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     clearText: propTypes.requiredIf(props => props.clearable, propTypes.string),
     clearable: propTypes.bool,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     empty: propTypes.node,

--- a/src/SingleSelectField.js
+++ b/src/SingleSelectField.js
@@ -2,7 +2,6 @@ import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
 import { statusPropType, singleSelectedPropType } from './common-prop-types.js'
-
 import { Field } from './Field.js'
 import { Label } from './Label.js'
 import { Help } from './Help.js'
@@ -54,10 +53,11 @@ class SingleSelectField extends React.Component {
             noMatchText,
             initialFocus,
             dense,
+            dataTest,
         } = this.props
 
         return (
-            <Field className={className}>
+            <Field className={className} dataTest={dataTest}>
                 {label && (
                     <Label required={required} disabled={disabled}>
                         {label}
@@ -94,10 +94,17 @@ class SingleSelectField extends React.Component {
                     </SingleSelect>
                 </Constrictor>
 
-                {helpText && <Help>{helpText}</Help>}
+                {helpText && (
+                    <Help dataTest={`${dataTest}-help`}>{helpText}</Help>
+                )}
 
                 {validationText && (
-                    <Help error={error} warning={warning} valid={valid}>
+                    <Help
+                        error={error}
+                        warning={warning}
+                        valid={valid}
+                        dataTest={`${dataTest}-validation`}
+                    >
                         {validationText}
                     </Help>
                 )}
@@ -108,6 +115,7 @@ class SingleSelectField extends React.Component {
 
 SingleSelectField.defaultProps = {
     selected: {},
+    dataTest: 'dhis2-uicore-singleselectfield',
 }
 
 /**
@@ -144,12 +152,14 @@ SingleSelectField.defaultProps = {
  * @prop {string} [noMatchText] - Only required if filterable is true
  * @prop {string} [placeholder]
  * @prop {string} [prefix]
+ * @prop {string} [dataTest]
  */
 SingleSelectField.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     clearText: propTypes.requiredIf(props => props.clearable, propTypes.string),
     clearable: propTypes.bool,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     empty: propTypes.node,

--- a/src/SingleSelectOption.js
+++ b/src/SingleSelectOption.js
@@ -20,6 +20,7 @@ const SingleSelectOption = ({
     disabled,
     onClick,
     className,
+    dataTest,
 }) => (
     <div
         className={cx(className, {
@@ -27,6 +28,7 @@ const SingleSelectOption = ({
             active,
         })}
         onClick={e => onClick({}, e)}
+        data-test={dataTest}
     >
         {label}
 
@@ -63,6 +65,10 @@ const SingleSelectOption = ({
     </div>
 )
 
+SingleSelectOption.defaultProps = {
+    dataTest: 'dhis2-uicore-singleselectoption',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -73,6 +79,7 @@ const SingleSelectOption = ({
  * @prop {function} [onClick]
  * @prop {boolean} [active]
  * @prop {boolean} [disabled]
+ * @prop {string} [dataTest]
  */
 SingleSelectOption.propTypes = {
     label: propTypes.string.isRequired,
@@ -81,6 +88,7 @@ SingleSelectOption.propTypes = {
     value: propTypes.string.isRequired,
     active: propTypes.bool,
     className: propTypes.string,
+    dataTest: propTypes.string,
     disabled: propTypes.bool,
     onClick: propTypes.func,
 }

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -64,13 +64,14 @@ class SplitButton extends Component {
             disabled,
             type,
             tabIndex,
+            dataTest,
             initialFocus,
         } = this.props
 
         const arrow = open ? <ArrowUp /> : <ArrowDown />
 
         return (
-            <div ref={this.anchorRef}>
+            <div ref={this.anchorRef} data-test={dataTest}>
                 <Button
                     name={name}
                     value={value}
@@ -86,6 +87,7 @@ class SplitButton extends Component {
                     tabIndex={tabIndex}
                     className={cx(className)}
                     initialFocus={initialFocus}
+                    dataTest={`${dataTest}-button`}
                 >
                     {children}
                 </Button>
@@ -104,6 +106,7 @@ class SplitButton extends Component {
                     type={type}
                     tabIndex={tabIndex}
                     className={cx(className, rightButton.className)}
+                    dataTest={`${dataTest}-toggle`}
                 >
                     {arrow}
                 </Button>
@@ -142,6 +145,10 @@ class SplitButton extends Component {
     }
 }
 
+SplitButton.defaultProps = {
+    dataTest: 'dhis2-uicore-splitbutton',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -163,11 +170,13 @@ class SplitButton extends Component {
  * @prop {boolean } [destructive]
  * @prop {boolean } [disabled]
  * @prop {boolean} [initialFocus] Grants the button the initial focus
+ * @prop {string} [dataTest]
  */
 SplitButton.propTypes = {
     component: propTypes.element.isRequired,
     children: propTypes.string,
     className: propTypes.string,
+    dataTest: propTypes.string,
     destructive: buttonVariantPropType,
     disabled: propTypes.bool,
     icon: propTypes.element,

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -66,6 +66,7 @@ class Switch extends Component {
             value,
             warning,
             dense,
+            dataTest,
         } = this.props
 
         const classes = cx({
@@ -83,6 +84,7 @@ class Switch extends Component {
                     disabled,
                     dense,
                 })}
+                data-test={dataTest}
             >
                 <input
                     type="checkbox"
@@ -164,6 +166,10 @@ class Switch extends Component {
     }
 }
 
+Switch.defaultProps = {
+    dataTest: 'dhis2-uicore-switch',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -187,27 +193,24 @@ class Switch extends Component {
  *
  * @prop {function} [onFocus]
  * @prop {function} [onBlur]
+ * @prop {string} [dataTest]
  */
 Switch.propTypes = {
     label: propTypes.node.isRequired,
     checked: propTypes.bool,
-
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
-
     error: statusPropType,
     initialFocus: propTypes.bool,
     name: propTypes.string,
-
     tabIndex: propTypes.string,
     valid: statusPropType,
     value: propTypes.string,
     warning: statusPropType,
     onBlur: propTypes.func,
-
     onChange: propTypes.func,
-
     onFocus: propTypes.func,
 }
 

--- a/src/SwitchField.js
+++ b/src/SwitchField.js
@@ -36,6 +36,7 @@ const SwitchField = ({
     required,
     helpText,
     validationText,
+    dataTest,
 }) => (
     <ToggleField
         toggleComponent={Switch}
@@ -57,8 +58,13 @@ const SwitchField = ({
         required={required}
         helpText={helpText}
         validationText={validationText}
+        dataTest={dataTest}
     />
 )
+
+SwitchField.defaultProps = {
+    dataTest: 'dhis2-uicore-switchfield',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -87,11 +93,13 @@ const SwitchField = ({
  * @prop {boolean} [required]
  * @prop {string} [helpText]
  * @prop {string} [validationText]
+ * @prop {string} [dataTest]
  */
 SwitchField.propTypes = {
     label: propTypes.node.isRequired,
     checked: propTypes.bool,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,

--- a/src/SwitchGroup.js
+++ b/src/SwitchGroup.js
@@ -27,6 +27,7 @@ const SwitchGroup = ({
     warning,
     error,
     dense,
+    dataTest,
 }) => (
     <ToggleGroup
         onChange={onChange}
@@ -38,10 +39,15 @@ const SwitchGroup = ({
         warning={warning}
         error={error}
         dense={dense}
+        dataTest={dataTest}
     >
         {children}
     </ToggleGroup>
 )
+
+SwitchGroup.defaultProps = {
+    dataTest: 'dhis2-uicore-switchgroup',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -60,10 +66,12 @@ const SwitchGroup = ({
  * @prop {boolean} [error]
  *
  * @prop {boolean} [dense]
+ * @prop {string} [dataTest]
  */
 SwitchGroup.propTypes = {
     children: propTypes.arrayOf(propTypes.element).isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,

--- a/src/SwitchGroupField.js
+++ b/src/SwitchGroupField.js
@@ -31,6 +31,7 @@ const SwitchGroupField = ({
     helpText,
     validationText,
     required,
+    dataTest,
 }) => (
     <ToggleGroupField
         onChange={onChange}
@@ -46,10 +47,15 @@ const SwitchGroupField = ({
         helpText={helpText}
         validationText={validationText}
         required={required}
+        dataTest={dataTest}
     >
         {children}
     </ToggleGroupField>
 )
+
+SwitchGroupField.defaultProps = {
+    dataTest: 'dhis2-uicore-switchgroupfield',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -72,10 +78,12 @@ const SwitchGroupField = ({
  * @prop {string} [helpText]
  * @prop {string} [validationText]
  * @prop {boolean} [required]
+ * @prop {string} [dataTest]
  */
 SwitchGroupField.propTypes = {
     children: propTypes.arrayOf(propTypes.element).isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -14,13 +14,22 @@ import { colors, theme } from './theme.js'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/tab.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/tabs--default-fluid|Storybook}
  */
-const Tab = ({ icon, onClick, selected, disabled, children, className }) => (
+const Tab = ({
+    icon,
+    onClick,
+    selected,
+    disabled,
+    children,
+    className,
+    dataTest,
+}) => (
     <button
         className={`${cx('tab', className, {
             selected,
             disabled,
         })}`}
         onClick={disabled ? undefined : event => onClick({}, event)}
+        data-test={dataTest}
     >
         {icon}
         <span>{children}</span>
@@ -120,6 +129,10 @@ const Tab = ({ icon, onClick, selected, disabled, children, className }) => (
     </button>
 )
 
+Tab.defaultProps = {
+    dataTest: 'dhis2-uicore-tab',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
@@ -129,10 +142,12 @@ const Tab = ({ icon, onClick, selected, disabled, children, className }) => (
  * @prop {boolean} [disabled]
  * @prop {Node} [children]
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 Tab.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
     disabled: propTypes.bool,
     icon: propTypes.element,
     selected: propTypes.bool,

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
-import cx from 'classnames'
 
-import { colors } from './theme.js'
 import { ScrollBar } from './TabBar/ScrollBar.js'
+import { Tabs } from './TabBar/Tabs.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -16,28 +15,30 @@ import { ScrollBar } from './TabBar/ScrollBar.js'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/tab.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/tabs--default-fluid|Storybook}
  */
-const TabBar = ({ fixed, children, className, scrollable }) => {
-    const Container = scrollable ? ScrollBar : React.Fragment
-    return (
-        <Container>
-            <div className={cx('tab-bar', className, { fixed })}>
-                {children}
-
-                <style jsx>{`
-                    div {
-                        display: flex;
-                        align-items: flex-start;
-                        position: relative;
-                        overflow: hidden;
-                        box-shadow: inset 0 -1px 0 0 ${colors.grey400};
-                        flex-wrap: nowrap;
-                        flex-grow: 1;
-                        background: ${colors.white};
-                    }
-                `}</style>
+const TabBar = ({ fixed, children, className, scrollable, dataTest }) => {
+    if (scrollable) {
+        return (
+            <div className={className} data-test={dataTest}>
+                <ScrollBar dataTest={`${dataTest}-scrollbar`}>
+                    <Tabs fixed={fixed} dataTest={`${dataTest}-tabs`}>
+                        {children}
+                    </Tabs>
+                </ScrollBar>
             </div>
-        </Container>
+        )
+    }
+
+    return (
+        <div className={className} data-test={dataTest}>
+            <Tabs fixed={fixed} dataTest={`${dataTest}-tabs`}>
+                {children}
+            </Tabs>
+        </div>
     )
+}
+
+TabBar.defaultProps = {
+    dataTest: 'dhis2-uicore-tabbar',
 }
 
 /**
@@ -47,10 +48,13 @@ const TabBar = ({ fixed, children, className, scrollable }) => {
  * @prop {string} [className]
  * @prop {boolean} [fixed]
  * @prop {boolean} [scrollable]
+ * @prop {string} [dataTest]
+ * @prop {string} [dataTest]
  */
 TabBar.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
     fixed: propTypes.bool,
     scrollable: propTypes.bool,
 }

--- a/src/TabBar/ScrollBar.js
+++ b/src/TabBar/ScrollBar.js
@@ -96,10 +96,10 @@ class ScrollBar extends Component {
 
     render() {
         const { scrolledToStart, scrolledToEnd } = this.state
+        const { children, className, dataTest } = this.props
 
-        const { children, className } = this.props
         return (
-            <div className={cx('scroll-bar', className)}>
+            <div className={cx('scroll-bar', className)} data-test={dataTest}>
                 <button
                     onClick={scrolledToStart ? undefined : this.scrollLeft}
                     className={cx('scroll-button', {
@@ -216,6 +216,7 @@ class ScrollBar extends Component {
  */
 ScrollBar.propTypes = {
     children: propTypes.node.isRequired,
+    dataTest: propTypes.string.isRequired,
     className: propTypes.string,
 }
 

--- a/src/TabBar/Tabs.js
+++ b/src/TabBar/Tabs.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+import cx from 'classnames'
+
+import { colors } from '../theme.js'
+
+/**
+ * @module
+ * @private
+ * @param {Object} PropTypes
+ * @returns {React.Component}
+ */
+const Tabs = ({ children, fixed, dataTest }) => (
+    <div className={cx({ fixed })} data-test={dataTest}>
+        {children}
+
+        <style jsx>{`
+            div {
+                display: flex;
+                align-items: flex-start;
+                position: relative;
+                overflow: hidden;
+                box-shadow: inset 0 -1px 0 0 ${colors.grey400};
+                flex-wrap: nowrap;
+                flex-grow: 1;
+                background: ${colors.white};
+            }
+        `}</style>
+    </div>
+)
+
+/**
+ * @typedef {Object} PropTypes
+ * @static
+ * @prop {Tab|Array.<Tab>} children
+ * @prop {boolean} [fixed]
+ * @prop {string} [dataTest]
+ */
+Tabs.propTypes = {
+    dataTest: propTypes.string.isRequired,
+    children: propTypes.oneOfType([
+        propTypes.element,
+        propTypes.arrayOf(propTypes.element),
+    ]),
+    fixed: propTypes.bool,
+}
+
+export { Tabs }

--- a/src/Table.js
+++ b/src/Table.js
@@ -20,21 +20,27 @@ const tableStyles = css`
  * @example import { Table } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const Table = ({ children, className }) => (
-    <table className={className}>
+export const Table = ({ children, className, dataTest }) => (
+    <table className={className} data-test={dataTest}>
         {children}
 
         <style jsx>{tableStyles}</style>
     </table>
 )
 
+Table.defaultProps = {
+    dataTest: 'dhis2-uicore-table',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {TableHead|TableBody|TableFoot|Array.<TableHead|TableBody|TableFoot>} children
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 Table.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -8,17 +8,25 @@ import propTypes from '@dhis2/prop-types'
  * @example import { TableBody } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableBody = ({ children, className }) => (
-    <tbody className={className}>{children}</tbody>
+export const TableBody = ({ children, className, dataTest }) => (
+    <tbody className={className} data-test={dataTest}>
+        {children}
+    </tbody>
 )
+
+TableBody.defaultProps = {
+    dataTest: 'dhis2-uicore-tablebody',
+}
 
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {TableRow|Array.<TableRow>} children
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 TableBody.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }

--- a/src/TableCell.js
+++ b/src/TableCell.js
@@ -25,17 +25,29 @@ const tableCellStyles = css`
  * @example import { TableCell } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableCell = ({ className, children, colSpan, rowSpan, dense }) => (
+export const TableCell = ({
+    className,
+    children,
+    colSpan,
+    rowSpan,
+    dense,
+    dataTest,
+}) => (
     <td
         colSpan={colSpan}
         rowSpan={rowSpan}
         className={cx({ dense }, className)}
+        data-test={dataTest}
     >
         {children}
 
         <style jsx>{tableCellStyles}</style>
     </td>
 )
+
+TableCell.defaultProps = {
+    dataTest: 'dhis2-uicore-tablecell',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -45,11 +57,13 @@ export const TableCell = ({ className, children, colSpan, rowSpan, dense }) => (
  * @prop {bool} [dense]
  * @prop {Node} [children]
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 TableCell.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     colSpan: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     rowSpan: propTypes.string,
 }

--- a/src/TableCellHead.js
+++ b/src/TableCellHead.js
@@ -31,17 +31,23 @@ export const TableCellHead = ({
     dense,
     children,
     className,
+    dataTest,
 }) => (
     <th
         colSpan={colSpan}
         rowSpan={rowSpan}
         className={cx({ dense }, className)}
+        data-test={dataTest}
     >
         {children}
 
         <style jsx>{tableCellHeadStyles}</style>
     </th>
 )
+
+TableCellHead.defaultProps = {
+    dataTest: 'dhis2-uicore-tablecellhead',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -51,11 +57,13 @@ export const TableCellHead = ({
  * @prop {bool} [dense]
  * @prop {Node} [children]
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 TableCellHead.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     colSpan: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     rowSpan: propTypes.string,
 }

--- a/src/TableFoot.js
+++ b/src/TableFoot.js
@@ -8,17 +8,25 @@ import propTypes from '@dhis2/prop-types'
  * @example import { TableFoot } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableFoot = ({ children, className }) => (
-    <tfoot className={className}>{children}</tfoot>
+export const TableFoot = ({ children, className, dataTest }) => (
+    <tfoot className={className} data-test={dataTest}>
+        {children}
+    </tfoot>
 )
+
+TableFoot.defaultProps = {
+    dataTest: 'dhis2-uicore-tablefoot',
+}
 
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {TableRow|Array.<TableRow>} children
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 TableFoot.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }

--- a/src/TableHead.js
+++ b/src/TableHead.js
@@ -8,17 +8,25 @@ import propTypes from '@dhis2/prop-types'
  * @example import { TableHead } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableHead = ({ children, className }) => (
-    <thead className={className}>{children}</thead>
+export const TableHead = ({ children, className, dataTest }) => (
+    <thead className={className} data-test={dataTest}>
+        {children}
+    </thead>
 )
+
+TableHead.defaultProps = {
+    dataTest: 'dhis2-uicore-tablehead',
+}
 
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {TableRowHead|Array.<TableRowHead>} children
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 TableHead.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -15,21 +15,27 @@ const tableRowStyles = css`
  * @example import { TableRow } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableRow = ({ children, className }) => (
-    <tr className={className}>
+export const TableRow = ({ children, className, dataTest }) => (
+    <tr className={className} data-test={dataTest}>
         {children}
 
         <style jsx>{tableRowStyles}</style>
     </tr>
 )
 
+TableRow.defaultProps = {
+    dataTest: 'dhis2-uicore-tablerow',
+}
+
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {TableCell|TableCellHead|Array.<TableCell|TableCellHead>} children
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 TableRow.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }

--- a/src/TableRowHead.js
+++ b/src/TableRowHead.js
@@ -11,17 +11,25 @@ import { TableRow } from './TableRow.js'
  * @example import { TableRowHead } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableRowHead = ({ children, className }) => (
-    <TableRow className={className}>{children}</TableRow>
+export const TableRowHead = ({ children, className, dataTest }) => (
+    <TableRow className={className} dataTest={dataTest}>
+        {children}
+    </TableRow>
 )
+
+TableRowHead.defaultProps = {
+    dataTest: 'dhis2-uicore-tablerowhead',
+}
 
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {TableCellHead|Array.<TableCellHead>} children
  * @prop {string} [className]
+ * @prop {string} [dataTest]
  */
 TableRowHead.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
 }

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -4,7 +4,6 @@ import cx from 'classnames'
 
 import { statusPropType } from './common-prop-types.js'
 import { StatusIcon } from './icons/Status.js'
-
 import { styles } from './TextArea/styles.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
@@ -128,11 +127,12 @@ export class TextArea extends Component {
             rows,
             width,
             resize,
+            dataTest,
         } = this.props
         const { height } = this.state
 
         return (
-            <div className={cx('textarea', className)}>
+            <div className={cx('textarea', className)} data-test={dataTest}>
                 <textarea
                     id={name}
                     name={name}
@@ -182,6 +182,7 @@ TextArea.defaultProps = {
     rows: 4,
     width: '100%',
     resize: 'vertical',
+    dataTest: 'dhis2-uicore-textarea',
 }
 
 /**
@@ -213,31 +214,26 @@ TextArea.defaultProps = {
  * one of `none`, `both`, `horizontal`, `vertical`
  * @prop {number} [rows=4]
  * @prop {string} [width]
+ * @prop {string} [dataTest]
  */
 TextArea.propTypes = {
     autoGrow: propTypes.bool,
-
     className: propTypes.string,
-
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,
-
     initialFocus: propTypes.bool,
     loading: propTypes.bool,
     name: propTypes.string,
-
     placeholder: propTypes.string,
     readOnly: propTypes.bool,
     resize: propTypes.oneOf(['none', 'both', 'horizontal', 'vertical']),
-
     rows: propTypes.number,
     tabIndex: propTypes.string,
     valid: statusPropType,
     value: propTypes.string,
-
     warning: statusPropType,
-
     width: propTypes.string,
     onBlur: propTypes.func,
     onChange: propTypes.func,

--- a/src/TextAreaField.js
+++ b/src/TextAreaField.js
@@ -2,7 +2,6 @@ import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
 import { statusPropType } from './common-prop-types.js'
-
 import { Field } from './Field.js'
 import { Label } from './Label.js'
 import { TextArea } from './TextArea.js'
@@ -45,8 +44,9 @@ const TextAreaField = ({
     resize,
     rows,
     inputWidth,
+    dataTest,
 }) => (
-    <Field className={className}>
+    <Field className={className} dataTest={dataTest}>
         {label && (
             <Label required={required} disabled={disabled} htmlFor={name}>
                 {label}
@@ -76,17 +76,27 @@ const TextAreaField = ({
             />
         </Constrictor>
 
-        {helpText && <Help>{helpText}</Help>}
+        {helpText && <Help dataTest={`${dataTest}-help`}>{helpText}</Help>}
 
         {validationText && (
-            <Help error={error} warning={warning} valid={valid}>
+            <Help
+                error={error}
+                warning={warning}
+                valid={valid}
+                dataTest={`${dataTest}-validation`}
+            >
                 {validationText}
             </Help>
         )}
     </Field>
 )
 
-TextAreaField.defaultProps = TextArea.defaultProps
+TextAreaField.defaultProps = {
+    rows: 4,
+    width: '100%',
+    resize: 'vertical',
+    dataTest: 'dhis2-uicore-textareafield',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -122,33 +132,30 @@ TextAreaField.defaultProps = TextArea.defaultProps
  * one of `none`, `both`, `horizontal`, `vertical`
  * @prop {number} [rows=4]
  * @prop {string} [inputWidth]
+ * @prop {string} [dataTest]
  */
 TextAreaField.propTypes = {
     autoGrow: propTypes.bool,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,
-
     helpText: propTypes.string,
     initialFocus: propTypes.bool,
     inputWidth: propTypes.string,
     label: propTypes.string,
-
     loading: propTypes.bool,
     name: propTypes.string,
     placeholder: propTypes.string,
-
     readOnly: propTypes.bool,
     required: propTypes.bool,
     resize: propTypes.oneOf(['none', 'both', 'horizontal', 'vertical']),
     rows: propTypes.number,
     tabIndex: propTypes.string,
     valid: statusPropType,
-
     validationText: propTypes.string,
     value: propTypes.string,
-
     warning: statusPropType,
     onBlur: propTypes.func,
     onChange: propTypes.func,

--- a/src/ToggleField.js
+++ b/src/ToggleField.js
@@ -34,10 +34,10 @@ const ToggleField = ({
     required,
     helpText,
     validationText,
-
+    dataTest,
     toggleComponent: ToggleComponent,
 }) => (
-    <Field className={className}>
+    <Field className={className} dataTest={dataTest}>
         <ToggleComponent
             value={value}
             label={label}
@@ -56,10 +56,15 @@ const ToggleField = ({
             initialFocus={initialFocus}
         />
 
-        {helpText && <Help>{helpText}</Help>}
+        {helpText && <Help dataTest={`${dataTest}-help`}>{helpText}</Help>}
 
         {validationText && (
-            <Help error={error} warning={warning} valid={valid}>
+            <Help
+                error={error}
+                warning={warning}
+                valid={valid}
+                dataTest={`${dataTest}-validation`}
+            >
                 {validationText}
             </Help>
         )}
@@ -67,6 +72,10 @@ const ToggleField = ({
         {labelStyles.styles}
     </Field>
 )
+
+ToggleField.defaultProps = {
+    dataTest: 'dhis2-uicore-togglefield',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -92,12 +101,14 @@ const ToggleField = ({
  * @prop {string} [helpText]
  * @prop {string} [validationText]
  * @prop {function} toggleComponent
+ * @prop {string} [dataTest]
  */
 ToggleField.propTypes = {
     label: propTypes.node.isRequired,
     toggleComponent: propTypes.func.isRequired,
     checked: propTypes.bool,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,

--- a/src/ToggleGroup.js
+++ b/src/ToggleGroup.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 import { Children, cloneElement } from 'react'
@@ -15,22 +16,30 @@ const ToggleGroup = ({
     error,
     dense,
     className,
-}) =>
-    Children.map(children, child =>
-        cloneElement(child, {
-            name,
-            onChange: child.props.onChange || onChange,
-            checked: Array.isArray(value)
-                ? value.indexOf(child.props.value) !== -1
-                : child.props.value === value,
-            disabled: child.props.disabled || disabled,
-            valid: child.props.valid || valid,
-            warning: child.props.warning || warning,
-            error: child.props.error || error,
-            dense: child.props.dense || dense,
-            className: cx(child.props.className, className, 'grouped'),
-        })
-    )
+    dataTest,
+}) => (
+    <div data-test={dataTest}>
+        {Children.map(children, child =>
+            cloneElement(child, {
+                name,
+                onChange: child.props.onChange || onChange,
+                checked: Array.isArray(value)
+                    ? value.indexOf(child.props.value) !== -1
+                    : child.props.value === value,
+                disabled: child.props.disabled || disabled,
+                valid: child.props.valid || valid,
+                warning: child.props.warning || warning,
+                error: child.props.error || error,
+                dense: child.props.dense || dense,
+                className: cx(child.props.className, className, 'grouped'),
+            })
+        )}
+    </div>
+)
+
+ToggleGroup.defaultProps = {
+    dataTest: 'dhis2-uicore-togglegroup',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -47,15 +56,15 @@ const ToggleGroup = ({
  * @prop {boolean} [warning]
  * @prop {boolean} [error]
  * @prop {boolean} [dense]
+ * @prop {string} [dataTest]
  */
 ToggleGroup.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
-
     disabled: propTypes.bool,
     error: statusPropType,
-
     name: propTypes.string,
     valid: statusPropType,
     value: propTypes.oneOfType([
@@ -63,7 +72,6 @@ ToggleGroup.propTypes = {
         propTypes.arrayOf(propTypes.string),
     ]),
     warning: statusPropType,
-
     onChange: propTypes.func,
 }
 

--- a/src/ToggleGroupField.js
+++ b/src/ToggleGroupField.js
@@ -23,8 +23,9 @@ const ToggleGroupField = ({
     helpText,
     validationText,
     required,
+    dataTest,
 }) => (
-    <Field classname={className}>
+    <Field classname={className} dataTest={dataTest}>
         <FieldSet>
             {label && <Legend required={required}>{label}</Legend>}
 
@@ -42,16 +43,25 @@ const ToggleGroupField = ({
                 {children}
             </ToggleGroup>
 
-            {helpText && <Help>{helpText}</Help>}
+            {helpText && <Help dataTest={`${dataTest}-help`}>{helpText}</Help>}
 
             {validationText && (
-                <Help error={error} warning={warning} valid={valid}>
+                <Help
+                    error={error}
+                    warning={warning}
+                    valid={valid}
+                    dataTest={`${dataTest}-validation`}
+                >
                     {validationText}
                 </Help>
             )}
         </FieldSet>
     </Field>
 )
+
+ToggleGroupField.defaultProps = {
+    dataTest: 'dhis2-uicore-togglegroupfield',
+}
 
 /**
  * @typedef {Object} PropTypes
@@ -73,10 +83,12 @@ const ToggleGroupField = ({
  * @prop {string} [helpText]
  * @prop {string} [validationText]
  * @prop {boolean} [required]
+ * @prop {string} [dataTest]
  */
 ToggleGroupField.propTypes = {
     children: propTypes.node.isRequired,
     className: propTypes.string,
+    dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
     error: statusPropType,


### PR DESCRIPTION
Adding data-test props to our components, which will set data-test attributes. I'm putting the data-test attr. on the root html element that gets rendered by our components. Feel free to comment and review, there's probably plenty that we need to decide on. See: 

* https://github.com/dhis2/ui-core/pull/640 (discussion before this PR)
* https://jira.dhis2.org/browse/TECH-261 (tracking issue)
* was blocked by: https://github.com/dhis2/ui-core/pull/652

Changes required:

~~- The TabBar is a bit of an exceptional case. If we attach the data-test attribute to the div with className `tab-bar` it'll consistently be attached to the same component. But since it wraps TabBar in the ScrollBar component if it's scrollable the data-attribute won't always be attached to the root component. And it won't be possible to target the ScrollBar through a data-test attribute. I propose we wrap the entire component, including the ScrollBar, in a div where we set the data-test attribute, to keep it consistent.~~
~~- For other components, which are returning an array of components directly, we might also have to add a wrapper to be able to add a sensible data-test attribute (CheckboxGroup, RadioGroup, SwitchGroup, ToggleGroup). I think I'd prefer doing that, as otherwise there's no way to add a correct data-test prop.~~

Notes:

- For components that use the `Layer` component, I've set the attribute on the first available child, since that component doesn't output html directly.
- I've removed spaces where I encountered them between the prop-types. They're alphabetically sorted, so the original grouping no longer applies.
- Some components we're spreading prop-types from others into their own. This prevents linting of unused props in eslint, as eslint doesn't evaluate those. It's also easier to accidentally add wrong proptypes when using spread (as happened with splitbutton). I can remove or extract this, as it's not directly related or crucial to the PR. Let me know what everyone prefers.
- I've not set a default for `dataTest` for child components that are not directly publicly exported. It won't ever be used as it'll always be set from the parent. So instead I made the `dataTest` prop required to indicate clearly that the parent should pass it.
- In adding the child data-test attributes I'm trying to add them based on functionality, not html structure. That way test will keep working if the html changes and functionality stays the same, but tests will fail if the functionality changes/was removed and a test still tries to use it. That seems the most useful to me.
- For now I've added child data-test attributes for children that: are action triggers (X's on chips, etc.), that have duplicate siblings (multiple help components, multiple buttons, etc.) or are rendered in portals. The other ones I thought we could add on-demand.

Tasks:

- [x] Finalize adding dataTest props for the components that need it
- [x] Set defaults for all dataTest props
- [x] We have a couple of components where we're spreading all props on a child. I can separate out the dataTest prop*
- [x] Extract splitbutton initialFocus fix
- [x] Add sub-dataTest attrs to children where necessary
- [x] Update jsdoc

Follow-up:

- [ ] Fix issue https://github.com/dhis2/ui-core/issues/669 (added by @HendrikThePendric)

---

_* However, would it not also be good to just be explicit about the props we're passing to the child? It's a one-time effort, but seems good to be more explicit (could take care of that in a separate PR)._