### PR TITLE
chore: use storybook helper for visiting stories in cypress

### DIFF
--- a/cypress/support/visitStory.js
+++ b/cypress/support/visitStory.js
@@ -1,12 +1,6 @@
-const urlEncodeStoryBookName = name =>
-    name
-        .replace(/\(|\)/g, '')
-        .replace(/[^a-zA-Z0-9]+/g, '-')
-        .toLowerCase()
+import { toId } from '@storybook/router'
 
 Cypress.Commands.add('visitStory', (namespace, storyName) => {
-    const formattedNamespace = urlEncodeStoryBookName(namespace)
-    const formattedStoryName = urlEncodeStoryBookName(storyName)
-    const id = `${formattedNamespace}--${formattedStoryName}`
+    const id = toId(namespace, storyName)
     cy.visit(`iframe.html?id=${id}`)
 })

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "@storybook/addons": "^5.2.8",
         "@storybook/components": "^5.2.8",
         "@storybook/react": "^5.2.8",
+        "@storybook/router": "^5.2.8",
         "@wertarbyte/react-props-md-table": "^1.1.1",
         "babel-loader": "^8.0.6",
         "concurrently": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1746,7 +1746,7 @@
     semver "^6.0.0"
     webpack "^4.33.0"
 
-"@storybook/router@5.2.8":
+"@storybook/router@5.2.8", "@storybook/router@^5.2.8":
   version "5.2.8"
   resolved "https://registry.yarnpkg.com/@storybook/router/-/router-5.2.8.tgz#d7de2d401701857c033e28560c30e16512f7f72f"
   integrity sha512-wnbyKESUMyv9fwo9W+n4Fev/jXylB8whpjtHrOttjguUOYX1zGSHdwNI66voPetbtVLxUeHyJteJwdyRDSirJg==


### PR DESCRIPTION
Closes #645

The obvious downside, is that this adds an entire new dev dependency for one function. But on-balance I think this is better than reverse engineering what storybook is doing. 

