### PR TITLE
refactor: pass props explicitly instead of spreading props

### DIFF
--- a/src/AlertBar.js
+++ b/src/AlertBar.js
@@ -109,7 +109,6 @@ class AlertBar extends Component {
         }
 
         const info = !critical && !success && !warning
-        const iconProps = { icon, critical, success, warning, info }
 
         return (
             <div
@@ -123,7 +122,13 @@ class AlertBar extends Component {
                 onMouseEnter={this.stopDisplayTimeOut}
                 onMouseLeave={this.startDisplayTimeout}
             >
-                <Icon {...iconProps} />
+                <Icon
+                    icon={icon}
+                    critical={critical}
+                    success={success}
+                    warning={warning}
+                    info={info}
+                />
                 <Message>{children}</Message>
                 <Actions actions={actions} hide={this.hide} />
                 <Dismiss onClick={this.hide} />

--- a/src/CheckboxField.js
+++ b/src/CheckboxField.js
@@ -14,8 +14,47 @@ import { Checkbox } from './Checkbox.js'
  * @see Live demo: {@link /demo/?path=/story/checkboxfield--default|Storybook}
  */
 
-const CheckboxField = props => (
-    <ToggleField {...props} toggleComponent={Checkbox} />
+const CheckboxField = ({
+    value,
+    label,
+    name,
+    className,
+    tabIndex,
+    onChange,
+    onFocus,
+    onBlur,
+    checked,
+    disabled,
+    valid,
+    warning,
+    error,
+    dense,
+    initialFocus,
+    required,
+    helpText,
+    validationText,
+}) => (
+    <ToggleField
+        value={value}
+        label={label}
+        name={name}
+        className={className}
+        toggleComponent={Checkbox}
+        tabIndex={tabIndex}
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        checked={checked}
+        disabled={disabled}
+        valid={valid}
+        warning={warning}
+        error={error}
+        dense={dense}
+        initialFocus={initialFocus}
+        required={required}
+        helpText={helpText}
+        validationText={validationText}
+    />
 )
 
 /**

--- a/src/CheckboxGroup.js
+++ b/src/CheckboxGroup.js
@@ -14,7 +14,32 @@ import { ToggleGroup } from './ToggleGroup.js'
  * @see Live demo: {@link /demo/?path=/story/checkboxgroup--default|Storybook}
  */
 
-const CheckboxGroup = props => <ToggleGroup {...props} />
+const CheckboxGroup = ({
+    children,
+    onChange,
+    name,
+    value,
+    className,
+    disabled,
+    valid,
+    warning,
+    error,
+    dense,
+}) => (
+    <ToggleGroup
+        onChange={onChange}
+        name={name}
+        value={value}
+        className={className}
+        disabled={disabled}
+        valid={valid}
+        warning={warning}
+        error={error}
+        dense={dense}
+    >
+        {children}
+    </ToggleGroup>
+)
 
 /**
  * @typedef {Object} PropTypes

--- a/src/CheckboxGroupField.js
+++ b/src/CheckboxGroupField.js
@@ -13,7 +13,40 @@ import { ToggleGroupField } from './ToggleGroupField.js'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/checkbox.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/checkboxgroupfield--default|Storybook}
  */
-const CheckboxGroupField = props => <ToggleGroupField {...props} />
+const CheckboxGroupField = ({
+    children,
+    onChange,
+    name,
+    value,
+    className,
+    disabled,
+    valid,
+    warning,
+    error,
+    dense,
+    label,
+    helpText,
+    validationText,
+    required,
+}) => (
+    <ToggleGroupField
+        onChange={onChange}
+        name={name}
+        value={value}
+        className={className}
+        disabled={disabled}
+        valid={valid}
+        warning={warning}
+        error={error}
+        dense={dense}
+        label={label}
+        helpText={helpText}
+        validationText={validationText}
+        required={required}
+    >
+        {children}
+    </ToggleGroupField>
+)
 
 /**
  * @typedef {Object} PropTypes

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -2,7 +2,6 @@ import propTypes from '@dhis2/prop-types'
 import React, { Component } from 'react'
 
 import { Button } from './Button.js'
-import { buttonVariantPropType, sizePropType } from './common-prop-types.js'
 import { DropMenu } from './DropMenu.js'
 import { ArrowDown, ArrowUp } from './icons/Arrow.js'
 
@@ -36,21 +35,52 @@ class DropdownButton extends Component {
 
     render() {
         const { open } = this.state
+        const {
+            component,
+            children,
+            className,
+            destructive,
+            disabled,
+            icon,
+            large,
+            primary,
+            secondary,
+            small,
+            name,
+            value,
+            tabIndex,
+            type,
+            initialFocus,
+        } = this.props
 
         const ArrowIcon = open ? <ArrowUp /> : <ArrowDown />
 
         return (
             <div ref={this.anchorRef}>
-                <Button {...this.props} onClick={this.onToggle}>
-                    {this.props.children}
-
+                <Button
+                    className={className}
+                    destructive={destructive}
+                    disabled={disabled}
+                    icon={icon}
+                    large={large}
+                    primary={primary}
+                    secondary={secondary}
+                    small={small}
+                    onClick={this.onToggle}
+                    name={name}
+                    value={value}
+                    tabIndex={tabIndex}
+                    type={type}
+                    initialFocus={initialFocus}
+                >
+                    {children}
                     {ArrowIcon}
                 </Button>
 
                 {open && (
                     <DropMenu
                         className="dropdown-button-dropmenu"
-                        component={this.props.component}
+                        component={component}
                         onClose={() => this.setState({ open: false })}
                         anchorEl={this.anchorRef.current}
                     />
@@ -74,12 +104,17 @@ class DropdownButton extends Component {
  * @static
  * @prop {Element} component
  *
- * @prop {string} [className]
- * @prop {string} [children]
- * @prop {Element} [icon]
+ * @prop {Node} [children] The children to render in the button
+ * @prop {function} [onClick] The click handler
  *
+ * @prop {string} [className]
+ * @prop {string} [name]
+ * @prop {string} [value]
+ * @prop {string} [tabIndex]
  * @prop {boolean} [small] - `small` and `large` are mutually exclusive
  * @prop {boolean} [large]
+ * @prop {string} [type] Type of button: `submit`, `reset`, or
+ * `button`
  *
  * @prop {boolean } [primary] - `primary`, `secondary`, and
  * `destructive` are mutually exclusive boolean props
@@ -87,22 +122,13 @@ class DropdownButton extends Component {
  * @prop {boolean } [destructive]
  *
  * @prop {boolean} [disabled] Disable the button
+ * @prop {Element} [icon]
+ *
+ * @prop {boolean} [initialFocus] Grants the button the initial focus
  */
 DropdownButton.propTypes = {
+    ...Button.propTypes,
     component: propTypes.element.isRequired,
-    children: propTypes.string,
-    className: propTypes.string,
-    destructive: buttonVariantPropType,
-
-    disabled: propTypes.bool,
-
-    icon: propTypes.element,
-    large: sizePropType,
-
-    primary: buttonVariantPropType,
-    secondary: buttonVariantPropType,
-    small: sizePropType,
-    onClick: propTypes.func,
 }
 
 export { DropdownButton }

--- a/src/MultiSelect/FilterableMenu.js
+++ b/src/MultiSelect/FilterableMenu.js
@@ -4,12 +4,34 @@ import { multiSelectedPropType } from '../common-prop-types.js'
 import { FilterableMenu as CommonFilterableMenu } from '../Select/FilterableMenu.js'
 import { Menu } from './Menu.js'
 
-const FilterableMenu = props => <CommonFilterableMenu {...props} Menu={Menu} />
+const FilterableMenu = ({
+    options,
+    onChange,
+    selected,
+    empty,
+    handleClose,
+    handleFocusInput,
+    placeholder,
+    noMatchText,
+}) => (
+    <CommonFilterableMenu
+        options={options}
+        onChange={onChange}
+        selected={selected}
+        empty={empty}
+        handleClose={handleClose}
+        handleFocusInput={handleFocusInput}
+        placeholder={placeholder}
+        noMatchText={noMatchText}
+        Menu={Menu}
+    />
+)
 
 FilterableMenu.propTypes = {
     noMatchText: propTypes.string.isRequired,
-    className: propTypes.string,
     empty: propTypes.node,
+    handleClose: propTypes.func,
+    handleFocusInput: propTypes.func,
     options: propTypes.node,
     placeholder: propTypes.string,
     selected: multiSelectedPropType,

--- a/src/RadioGroup.js
+++ b/src/RadioGroup.js
@@ -14,7 +14,32 @@ import { ToggleGroup } from './ToggleGroup.js'
  * @see Live demo: {@link /demo/?path=/story/radiogroup--default|Storybook}
  */
 
-const RadioGroup = props => <ToggleGroup {...props} />
+const RadioGroup = ({
+    children,
+    onChange,
+    name,
+    value,
+    className,
+    disabled,
+    valid,
+    warning,
+    error,
+    dense,
+}) => (
+    <ToggleGroup
+        onChange={onChange}
+        name={name}
+        value={value}
+        className={className}
+        disabled={disabled}
+        valid={valid}
+        warning={warning}
+        error={error}
+        dense={dense}
+    >
+        {children}
+    </ToggleGroup>
+)
 
 /**
  * @typedef {Object} PropTypes

--- a/src/RadioGroupField.js
+++ b/src/RadioGroupField.js
@@ -14,7 +14,40 @@ import { ToggleGroupField } from './ToggleGroupField.js'
  * @see Live demo: {@link /demo/?path=/story/radiogroupfield--default|Storybook}
  */
 
-const RadioGroupField = props => <ToggleGroupField {...props} />
+const RadioGroupField = ({
+    children,
+    onChange,
+    name,
+    value,
+    className,
+    disabled,
+    valid,
+    warning,
+    error,
+    dense,
+    label,
+    helpText,
+    validationText,
+    required,
+}) => (
+    <ToggleGroupField
+        onChange={onChange}
+        name={name}
+        value={value}
+        className={className}
+        disabled={disabled}
+        valid={valid}
+        warning={warning}
+        error={error}
+        dense={dense}
+        label={label}
+        helpText={helpText}
+        validationText={validationText}
+        required={required}
+    >
+        {children}
+    </ToggleGroupField>
+)
 
 /**
  * @typedef {Object} PropTypes

--- a/src/SingleSelect/FilterableMenu.js
+++ b/src/SingleSelect/FilterableMenu.js
@@ -4,11 +4,31 @@ import { singleSelectedPropType } from '../common-prop-types.js'
 import { FilterableMenu as CommonFilterableMenu } from '../Select/FilterableMenu.js'
 import { Menu } from './Menu.js'
 
-const FilterableMenu = props => <CommonFilterableMenu {...props} Menu={Menu} />
+const FilterableMenu = ({
+    options,
+    onChange,
+    selected,
+    empty,
+    handleClose,
+    handleFocusInput,
+    placeholder,
+    noMatchText,
+}) => (
+    <CommonFilterableMenu
+        options={options}
+        onChange={onChange}
+        selected={selected}
+        empty={empty}
+        handleClose={handleClose}
+        handleFocusInput={handleFocusInput}
+        placeholder={placeholder}
+        noMatchText={noMatchText}
+        Menu={Menu}
+    />
+)
 
 FilterableMenu.propTypes = {
     noMatchText: propTypes.string.isRequired,
-    className: propTypes.string,
     empty: propTypes.node,
     handleClose: propTypes.func,
     handleFocusInput: propTypes.func,

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -2,9 +2,6 @@ import cx from 'classnames'
 import propTypes from '@dhis2/prop-types'
 import React, { Component } from 'react'
 import css from 'styled-jsx/css'
-
-import { buttonVariantPropType } from './common-prop-types.js'
-
 import { Button } from './Button.js'
 import { DropMenu } from './DropMenu.js'
 import { ArrowDown, ArrowUp } from './icons/Arrow.js'
@@ -51,31 +48,67 @@ class SplitButton extends Component {
 
     render() {
         const { open } = this.state
+        const {
+            component,
+            children,
+            className,
+            name,
+            value,
+            icon,
+            small,
+            large,
+            primary,
+            secondary,
+            destructive,
+            disabled,
+            type,
+            tabIndex,
+        } = this.props
 
-        const icon = open ? <ArrowUp /> : <ArrowDown />
+        const arrow = open ? <ArrowUp /> : <ArrowDown />
 
         return (
             <div ref={this.anchorRef}>
                 <Button
-                    {...this.props}
+                    name={name}
+                    value={value}
+                    icon={icon}
+                    small={small}
+                    large={large}
+                    primary={primary}
+                    secondary={secondary}
+                    destructive={destructive}
+                    disabled={disabled}
                     onClick={this.onClick}
-                    className={cx(this.props.className)}
+                    type={type}
+                    tabIndex={tabIndex}
+                    className={cx(className)}
                 >
-                    {this.props.children}
+                    {children}
                 </Button>
 
                 <Button
-                    {...this.props}
+                    name={name}
+                    value={value}
+                    icon={icon}
+                    small={small}
+                    large={large}
+                    primary={primary}
+                    secondary={secondary}
+                    destructive={destructive}
+                    disabled={disabled}
                     onClick={this.onToggle}
-                    className={cx(this.props.className, rightButton.className)}
+                    type={type}
+                    tabIndex={tabIndex}
+                    className={cx(className, rightButton.className)}
                 >
-                    {icon}
+                    {arrow}
                 </Button>
 
                 {open && (
                     <DropMenu
                         className="split-button-dropmenu"
-                        component={this.props.component}
+                        component={component}
                         onClose={() => this.setState({ open: false })}
                         anchorEl={this.anchorRef.current}
                     />
@@ -114,35 +147,24 @@ class SplitButton extends Component {
  * @prop {string} [className]
  * @prop {string} [name]
  * @prop {string} [value]
+ * @prop {string} [tabIndex]
  * @prop {function} [onClick]
  * @prop {Element} [icon]
  * @prop {boolean} [small] - `small` and `large` are mutually exclusive
  * @prop {boolean} [large]
+ * @prop {string} [type] Type of button: `submit`, `reset`, or
+ * `button`
  * @prop {boolean } [primary] - `primary`, `secondary`, and
  * `destructive` are mutually exclusive boolean props
  * @prop {boolean } [secondary]
  * @prop {boolean } [destructive]
  * @prop {boolean } [disabled]
+ * @prop {boolean} [initialFocus] Grants the button the initial focus
  */
 SplitButton.propTypes = {
+    ...Button.propTypes,
     component: propTypes.element.isRequired,
     children: propTypes.string,
-
-    className: propTypes.string,
-
-    destructive: buttonVariantPropType,
-    disabled: propTypes.bool,
-    icon: propTypes.element,
-
-    large: propTypes.bool,
-
-    name: propTypes.string,
-    primary: buttonVariantPropType,
-
-    secondary: buttonVariantPropType,
-    small: propTypes.bool,
-    value: propTypes.string,
-    onClick: propTypes.func,
 }
 
 export { SplitButton }

--- a/src/SwitchField.js
+++ b/src/SwitchField.js
@@ -14,7 +14,48 @@ import { Switch } from './Switch.js'
  * @see Live demo: {@link /demo/?path=/story/switchfield--default|Storybook}
  */
 
-const SwitchField = props => <ToggleField {...props} toggleComponent={Switch} />
+const SwitchField = ({
+    value,
+    label,
+    name,
+    className,
+    tabIndex,
+    onChange,
+    onFocus,
+    onBlur,
+    checked,
+    disabled,
+    valid,
+    warning,
+    error,
+    dense,
+    initialFocus,
+    required,
+    helpText,
+    validationText,
+}) => (
+    <ToggleField
+        toggleComponent={Switch}
+        value={value}
+        label={label}
+        name={name}
+        className={className}
+        tabIndex={tabIndex}
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        checked={checked}
+        disabled={disabled}
+        valid={valid}
+        warning={warning}
+        error={error}
+        dense={dense}
+        initialFocus={initialFocus}
+        required={required}
+        helpText={helpText}
+        validationText={validationText}
+    />
+)
 
 /**
  * @typedef {Object} PropTypes

--- a/src/SwitchGroup.js
+++ b/src/SwitchGroup.js
@@ -14,7 +14,32 @@ import { ToggleGroup } from './ToggleGroup.js'
  * @see Live demo: {@link /demo/?path=/story/switchgroup--default|Storybook}
  */
 
-const SwitchGroup = props => <ToggleGroup {...props} />
+const SwitchGroup = ({
+    children,
+    onChange,
+    name,
+    value,
+    className,
+    disabled,
+    valid,
+    warning,
+    error,
+    dense,
+}) => (
+    <ToggleGroup
+        onChange={onChange}
+        name={name}
+        value={value}
+        className={className}
+        disabled={disabled}
+        valid={valid}
+        warning={warning}
+        error={error}
+        dense={dense}
+    >
+        {children}
+    </ToggleGroup>
+)
 
 /**
  * @typedef {Object} PropTypes

--- a/src/SwitchGroupField.js
+++ b/src/SwitchGroupField.js
@@ -14,7 +14,40 @@ import { ToggleGroupField } from './ToggleGroupField.js'
  * @see Live demo: {@link /demo/?path=/story/switchgroupfield--default|Storybook}
  */
 
-const SwitchGroupField = props => <ToggleGroupField {...props} />
+const SwitchGroupField = ({
+    children,
+    onChange,
+    name,
+    value,
+    className,
+    disabled,
+    valid,
+    warning,
+    error,
+    dense,
+    label,
+    helpText,
+    validationText,
+    required,
+}) => (
+    <ToggleGroupField
+        onChange={onChange}
+        name={name}
+        value={value}
+        className={className}
+        disabled={disabled}
+        valid={valid}
+        warning={warning}
+        error={error}
+        dense={dense}
+        label={label}
+        helpText={helpText}
+        validationText={validationText}
+        required={required}
+    >
+        {children}
+    </ToggleGroupField>
+)
 
 /**
  * @typedef {Object} PropTypes


### PR DESCRIPTION
- [x] Currently I've just looked at the jsdoc for inferring which props the component needs. I will need to verify that the jsdocs are also actually accurate (they weren't for the dropdownbutton for example)
- [x] Check nested components in src/ as well (which are public, if there are any)