### PR TITLE
refactor: positioning

### DIFF
--- a/cypress/drafts/Menu/position.feature
+++ b/cypress/drafts/Menu/position.feature
@@ -1,0 +1,51 @@
+Feature: Position of a menu component
+
+    # default max width: 380px; default max height: 380px
+    Background:
+        Given the menu component has a height and width of its default maximum
+
+    Scenario: Default rendering
+        Given there is enough space between the anchor's bottom and the body's bottom to fit the default maximum
+        When the menu is opened
+        Then the menu is below the anchor
+        And the left of the menu is aligned with the left of the anchor
+
+    Scenario: Flipped vertically
+        Given there is not enough space between the anchor's bottom and the body's bottom to fit the default maximum
+        And there is not enough space between the anchor's top and the body's top to fit the default maximum
+        When the menu is opened
+        Then the menu is above the anchor
+        And the left of the menu is aligned with the left of the anchor
+
+    Scenario: Less than 368px and more than 50px available space below and above anchor
+        Given there is not enough space between the anchor's bottom and the body's bottom to fit the default maximum
+        And there is not enough space between the anchor's top and the body's top to fit the default maximum
+        But there is more than 50px of available space between the anchor's bottom and the body's bottom
+        When the menu is opened
+        Then the menu is below the anchor
+        And the height of the menu is reduced to fit
+
+    # ¯\_(ツ)_/¯
+    # This will cause the menu always to be off screen, but that's the apps fault
+    Scenario: Less than 50px available space below and above anchor
+        Given there is not enough space between the anchor's top and the body's top to fit the default maximum
+        And there is not enough space between the anchor's bottom and the body's bottom to fit the default maximum
+        When the menu is opened
+        Then the menu is below the anchor
+        And the heght of the menu is not reduced below 50px
+
+    Scenario: Flipped horizontally
+        Given the space between the anchor's right and the body's right is less than the horizontal minimum space
+        And the space between the anchor's left and the body's left is at least the horizontal minimum space
+        When the menu is opened
+        Then the right of the menu is aligned with the right of the anchor
+        And the menu is below the anchor
+
+    # ¯\_(ツ)_/¯
+    # This will cause the menu always to be off screen, but that's the apps fault
+    Scenario: Forced body overflow
+        Given the space between the anchor's right and the body's right is less than the horizontal minimum space
+        And the space between the anchor's left and the body's left is less than the horizontal minimum space
+        When the menu is opened
+        Then the left of the menu is aligned with the left of the anchor
+        And the menu is rendered below the anchor

--- a/cypress/drafts/Popover/position.feature
+++ b/cypress/drafts/Popover/position.feature
@@ -1,0 +1,31 @@
+Feature: Popover positioning
+
+    Background:
+        Given the popover has a width of 360px and height of 200px
+
+    Scenario: Spacing between anchor and popover
+        When the anchor is clicked
+        Then there is some space between the anchor and the popover
+
+    Scenario: Default positioning
+        Given there is enough space between the anchor's top and the body's top to fit the Popover
+        When the anchor is clicked
+        Then the popover is rendered above the the anchor
+        And the horizontal center of the popover is aligned with the horizontal center of the anchor
+
+    Scenario: Flipped vertical
+        Given there is not enough space between the anchor's top and the body's top to fit the Popover
+        And there is enough space between the anchor's bottom and the body's bottom to fit the Popover
+        When the anchor is clicked
+        Then the popover is rendered below the anchor
+        And the horizontal center of the popover is aligned with the horizontal center of the anchor
+
+    Scenario: Adjusted width
+        Given there is not enough space between the anchor's top and the body's top to fit the Popover
+        And there is not enough space between the anchor's bottom and the body's bottom to fit the Popover
+        When the anchor is clicked
+        Then the popover is rendered above the anchor
+        And the horizontal center of the popover is aligned with the horizontal center of the anchor
+        And the popover width is reduced to fit in the available space
+
+        #!!Note: this is a exact copy of tooltip positioning

--- a/cypress/drafts/Select/position.feature
+++ b/cypress/drafts/Select/position.feature
@@ -1,0 +1,25 @@
+Feature: Position of select menu dropdown
+
+    Background:
+        Given the select menu dropdown has a height of 368px
+        And the select menu dropdown has a width of 280px
+
+    Scenario: Default rendering
+        Given there is enough space between the anchor's bottom and the body's bottom to fit the Select's menu
+        When the menu is opened
+        Then it is rendered below the select
+        And the left of the select is aligned with the left of the anchor
+
+    Scenario: Flipped rendering when insufficient space below
+        Given there is not enough space between the anchor's bottom and the body's bottom to fit the Select's menu
+        And there is enough space between the anchor's top and the body's top to fit the Select's menu
+        When the menu is opened
+        Then it is rendered above the select
+        And the left of the select is aligned with the left of the anchor
+
+    Scenario: A select with less than 368px available space below and above
+        Given there is not enough space between the anchor's bottom and the body's bottom to fit the Select's menu
+        And there is not enough space between the anchor's top and the body's top to fit the Select's menu
+        When the menu is opened
+        Then it is rendered below the select
+        And the height of the select dropdown menu is reduced to fit within the <body> element

--- a/cypress/drafts/Tooltip/position.feature
+++ b/cypress/drafts/Tooltip/position.feature
@@ -1,0 +1,38 @@
+Feature: Tooltip positioning
+
+    Background:
+        Given the tooltip has a width of 300px and height of 28px
+
+    Scenario: Spacing between anchor and tooltip
+        When the anchor is clicked
+        Then there is some space between the anchor and the tooltip
+
+    Scenario: Default positioning
+        Given there is enough space between the anchor's top and the body's top to fit the Tooltip
+        When the anchor is clicked
+        Then the tooltip is rendered above the the anchor
+        And the horizontal center of the tooltip is aligned with the horizontal center of the anchor
+
+    Scenario: Flipped vertical
+        Given there is not enough space between the anchor's top and the body's top to fit the Tooltip
+        And there is enough space between the anchor's bottom and the body's bottom to fit the Tooltip
+        When the anchor is clicked
+        Then the tooltip is rendered below the anchor
+        And the horizontal center of the tooltip is aligned with the horizontal center of the anchor
+
+    Scenario: Adjusted horiztonal position
+        Given there is enough space between the anchor's top and the body's top to fit the Tooltip
+        And there is enough space between the body's left and the body's right to fit the Tooltip
+        And the Tooltip doesn't use more than 50% of the space between the body's sides and the anchor's sides
+        When the anchor is clicked
+        Then the tooltip is rendered above the anchor
+        And the horizontal center of the tooltip is aligned with the horizontal center of the anchor
+
+    Scenario: Adjusted width
+        Given there is enough space between the anchor's top and the body's top to fit the Tooltip
+        And there is enough space between the body's left and the body's right to fit the Tooltip
+        And the Tooltip does use more than 50% of the space between the body's sides and the anchor's sides
+        When the anchor is clicked
+        Then the tooltip is rendered above the anchor
+        And the horizontal center of the tooltip is aligned with the horizontal center of the anchor
+        But the tooltip's width is reducesd to only take 50% of the space available next to the anchor

--- a/cypress/integration/Popper/Positions.feature
+++ b/cypress/integration/Popper/Positions.feature
@@ -1,0 +1,63 @@
+Feature: Generic position options
+
+    # the definition of adjacent below: having a common endpoint or border
+
+    Scenario: Top position
+        Given the Popper is rendered with placement top
+        Then the bottom of the popper is adjacent to the top of the reference element
+        And it is horizontally center aligned with the reference element
+
+    Scenario: Top-start position
+        Given the Popper is rendered with placement top-start
+        Then the bottom of the popper is adjacent to the top of the reference element
+        And it is horizontally left aligned with the reference element
+
+    Scenario: Top-end position
+        Given the Popper is rendered with placement top-end
+        Then the bottom of the popper is adjacent to the top of the reference element
+        And it is horizontally right aligned with the reference element
+
+    Scenario: Right position
+        Given the Popper is rendered with placement right
+        Then the left of the popper is adjacent to the right of the reference element
+        And it is vertically center aligned with the reference element
+
+    Scenario: Right-start position
+        Given the Popper is rendered with placement right-start
+        Then the left of the popper is adjacent to the right of the reference element
+        And it is vertically top aligned with the reference element
+
+    Scenario: Right-end position
+        Given the Popper is rendered with placement right-end
+        Then the left of the popper is adjacent to the right of the reference element
+        And it is vertically bottom aligned with the reference element
+
+    Scenario: Bottom position
+        Given the Popper is rendered with placement bottom
+        Then the top of the popper is adjacent to the bottom of the reference element
+        And it is horizontally center aligned with the reference element
+
+    Scenario: Bottom-start position
+        Given the Popper is rendered with placement bottom-start
+        Then the top of the popper is adjacent to the bottom of the reference element
+        And it is horizontally left aligned with the reference element
+
+    Scenario: Bottom-end position
+        Given the Popper is rendered with placement bottom-end
+        Then the top of the popper is adjacent to the bottom of the reference element
+        And it is horizontally right aligned with the reference element
+
+    Scenario: Left position
+        Given the Popper is rendered with placement left
+        Then the right of the popper is adjacent to the left of the reference element
+        And it is vertically center aligned with the reference element
+
+    Scenario: Left-start position
+        Given the Popper is rendered with placement left-start
+        Then the right of the popper is adjacent to the left of the reference element
+        And it is vertically top aligned with the reference element
+
+    Scenario: Left-end position
+        Given the Popper is rendered with placement left-end
+        Then the right of the popper is adjacent to the left of the reference element
+        And it is vertically bottom aligned with the reference element

--- a/cypress/integration/Popper/Positions/index.js
+++ b/cypress/integration/Popper/Positions/index.js
@@ -1,0 +1,131 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+// Visit stories with different placements
+Given('the Popper is rendered with placement top', () => {
+    cy.visitStory('Popper', 'top')
+})
+Given('the Popper is rendered with placement top-start', () => {
+    cy.visitStory('Popper', 'top-start')
+})
+Given('the Popper is rendered with placement top-end', () => {
+    cy.visitStory('Popper', 'top-end')
+})
+Given('the Popper is rendered with placement right', () => {
+    cy.visitStory('Popper', 'right')
+})
+Given('the Popper is rendered with placement right-start', () => {
+    cy.visitStory('Popper', 'right-start')
+})
+Given('the Popper is rendered with placement right-end', () => {
+    cy.visitStory('Popper', 'right-end')
+})
+Given('the Popper is rendered with placement bottom', () => {
+    cy.visitStory('Popper', 'bottom')
+})
+Given('the Popper is rendered with placement bottom-start', () => {
+    cy.visitStory('Popper', 'bottom-start')
+})
+Given('the Popper is rendered with placement bottom-end', () => {
+    cy.visitStory('Popper', 'bottom-end')
+})
+Given('the Popper is rendered with placement left', () => {
+    cy.visitStory('Popper', 'left')
+})
+Given('the Popper is rendered with placement left-start', () => {
+    cy.visitStory('Popper', 'left-start')
+})
+Given('the Popper is rendered with placement left-end', () => {
+    cy.visitStory('Popper', 'left-end')
+})
+
+// Directional assertions
+// top
+Then(
+    'the bottom of the popper is adjacent to the top of the reference element',
+    () => {
+        getRefAndPopperPositions().then(([refPos, popperPos]) => {
+            expect(refPos.top).to.equal(popperPos.bottom)
+        })
+    }
+)
+// right
+Then(
+    'the left of the popper is adjacent to the right of the reference element',
+    () => {
+        getRefAndPopperPositions().then(([refPos, popperPos]) => {
+            expect(refPos.right).to.equal(popperPos.left)
+        })
+    }
+)
+// bottom
+Then(
+    'the top of the popper is adjacent to the bottom of the reference element',
+    () => {
+        getRefAndPopperPositions().then(([refPos, popperPos]) => {
+            expect(refPos.bottom).to.equal(popperPos.top)
+        })
+    }
+)
+// left
+Then(
+    'the right of the popper is adjacent to the left of the reference element',
+    () => {
+        getRefAndPopperPositions().then(([refPos, popperPos]) => {
+            expect(refPos.left).to.equal(popperPos.right)
+        })
+    }
+)
+
+// Horizontal alignments
+// *-start
+Then('it is horizontally left aligned with the reference element', () => {
+    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+        expect(refPos.left).to.equal(popperPos.left)
+    })
+})
+// * (no suffix)
+Then('it is horizontally center aligned with the reference element', () => {
+    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+        const refCenterX = refPos.left + refPos.width / 2
+        const popperCenterX = popperPos.left + popperPos.width / 2
+
+        expect(refCenterX).to.equal(popperCenterX)
+    })
+})
+// *-end
+Then('it is horizontally right aligned with the reference element', () => {
+    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+        expect(refPos.right).to.equal(popperPos.right)
+    })
+})
+
+// Vertical alignments
+// *-start
+Then('it is vertically top aligned with the reference element', () => {
+    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+        expect(refPos.top).to.equal(popperPos.top)
+    })
+})
+// * (no suffix)
+Then('it is vertically center aligned with the reference element', () => {
+    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+        const refCenterY = refPos.top + refPos.height / 2
+        const popperCenterY = popperPos.top + popperPos.height / 2
+
+        expect(refCenterY).to.equal(popperCenterY)
+    })
+})
+// *-end
+Then('it is vertically bottom aligned with the reference element', () => {
+    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+        expect(refPos.bottom).to.equal(popperPos.bottom)
+    })
+})
+
+// helper
+function getRefAndPopperPositions() {
+    return cy.getPositionsBySelectors(
+        '.reference-element',
+        '[data-test="dhis2-uicore-popper"]'
+    )
+}

--- a/cypress/support/getPositionsBySelectors.js
+++ b/cypress/support/getPositionsBySelectors.js
@@ -1,0 +1,15 @@
+Cypress.Commands.add('getPositionsBySelectors', (...elements) => {
+    const promise = cy.wrap([], { log: false })
+
+    for (const element of elements) {
+        promise.then(arr =>
+            cy
+                .get(element)
+                .then(jQueryInstance =>
+                    cy.wrap([...arr, jQueryInstance[0].getBoundingClientRect()])
+                )
+        )
+    }
+
+    return promise
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,6 +1,7 @@
 import '@dhis2/cli-utils-cypress/support'
 
 // Add additional support functions here
+import './getPositionsBySelectors'
 import './uploadMultipleFiles'
 import './uploadSingleFile'
 import './visitStory'

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     },
     "dependencies": {
         "@dhis2/prop-types": "^1.5.0",
+        "@popperjs/core": "^2.0.0-rc.3",
         "classnames": "^2.2.6"
     },
     "files": [

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -1,0 +1,81 @@
+import React, { Component, createRef } from 'react'
+import propTypes from 'prop-types'
+
+import { createPopper } from './Popper/createPopper.js'
+import { elementRefPropType } from './common-prop-types.js'
+
+class Popper extends Component {
+    popperInstance = null
+    popperRef = createRef()
+
+    componentDidMount() {
+        const { reference, options } = this.props
+
+        this.popperInstance = createPopper(
+            reference.current,
+            this.popperRef.current,
+            options
+        )
+    }
+
+    componentWillUnmount() {
+        this.popperInstance.destroy()
+        this.popperInstance = null
+    }
+
+    render() {
+        const { children, dataTest, className } = this.props
+
+        return (
+            <div
+                className={className}
+                data-test={dataTest}
+                ref={this.popperRef}
+            >
+                {children}
+            </div>
+        )
+    }
+}
+
+Popper.defaultProps = {
+    dataTest: 'dhis2-uicore-popper',
+}
+
+// Prop names follow the names here: https://popper.js.org/docs/v2/constructors/
+Popper.propTypes = {
+    children: propTypes.node.isRequired,
+    reference: elementRefPropType.isRequired,
+    className: propTypes.string,
+    dataTest: propTypes.string,
+    options: propTypes.shape({
+        modifiers: propTypes.arrayOf(
+            propTypes.shape({
+                enabled: propTypes.bool,
+                name: propTypes.string,
+                options: propTypes.object,
+            })
+        ),
+        placement: propTypes.oneOf([
+            'auto',
+            'auto-start',
+            'auto-end',
+            'top',
+            'top-start',
+            'top-end',
+            'bottom', // will be used as default
+            'bottom-start',
+            'bottom-end',
+            'right',
+            'right-start',
+            'right-end',
+            'left',
+            'left-start',
+            'left-end',
+        ]),
+        strategy: propTypes.oneOf(['absolute', 'fixed']), // defaults to 'absolute'
+        onFirstUpdate: propTypes.func,
+    }),
+}
+
+export { Popper }

--- a/src/Popper/createPopper.js
+++ b/src/Popper/createPopper.js
@@ -1,0 +1,12 @@
+import {
+    popperGenerator,
+    defaultModifiers,
+} from '@popperjs/core/lib/popper-lite'
+import flip from '@popperjs/core/lib/modifiers/flip'
+import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow'
+
+const createPopper = popperGenerator({
+    defaultModifiers: [...defaultModifiers, flip, preventOverflow],
+})
+
+export { createPopper }

--- a/src/__e2e__/Popper.stories.js
+++ b/src/__e2e__/Popper.stories.js
@@ -1,0 +1,137 @@
+import React, { Component, createRef } from 'react'
+import propTypes from '@dhis2/prop-types'
+import { storiesOf } from '@storybook/react'
+import { Popper } from '../../src/Popper.js'
+
+const boxStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 400,
+    height: 400,
+    backgroundColor: 'aliceblue',
+}
+
+const referenceElementStyle = {
+    width: 100,
+    height: 50,
+    backgroundColor: 'cadetblue',
+    textAlign: 'center',
+    padding: 6,
+}
+
+const popperStyle = {
+    width: 80,
+    height: 30,
+    backgroundColor: 'lightblue',
+    textAlign: 'center',
+    padding: 6,
+}
+
+class BoxWithCenteredReferenceElement extends Component {
+    ref = createRef()
+
+    render() {
+        const { renderChildren } = this.props
+        return (
+            <div className="box" style={boxStyle}>
+                <div
+                    className="reference-element"
+                    style={referenceElementStyle}
+                    ref={this.ref}
+                >
+                    Reference element
+                </div>
+                {renderChildren({ referenceElement: this.ref })}
+            </div>
+        )
+    }
+}
+BoxWithCenteredReferenceElement.propTypes = {
+    renderChildren: propTypes.func,
+}
+
+const PopperWithPlacement = ({ referenceElement, placement }) => (
+    <Popper reference={referenceElement} options={{ placement }}>
+        <div style={popperStyle}>Popper</div>
+    </Popper>
+)
+PopperWithPlacement.propTypes = {
+    placement: propTypes.string,
+    referenceElement: propTypes.object,
+}
+
+storiesOf('Popper', module)
+    .addDecorator(fn => <BoxWithCenteredReferenceElement renderChildren={fn} />)
+    .add('Top', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="top"
+        />
+    ))
+    .add('Top-start', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="top-start"
+        />
+    ))
+    .add('Top-end', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="top-end"
+        />
+    ))
+    .add('Bottom', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="bottom"
+        />
+    ))
+    .add('Bottom-start', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="bottom-start"
+        />
+    ))
+    .add('Bottom-end', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="bottom-end"
+        />
+    ))
+    .add('Right', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="right"
+        />
+    ))
+    .add('Right-start', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="right-start"
+        />
+    ))
+    .add('Right-end', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="right-end"
+        />
+    ))
+    .add('Left', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="left"
+        />
+    ))
+    .add('Left-start', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="left-start"
+        />
+    ))
+    .add('Left-end', ({ referenceElement }) => (
+        <PopperWithPlacement
+            referenceElement={referenceElement}
+            placement="left-end"
+        />
+    ))

--- a/src/common-prop-types.js
+++ b/src/common-prop-types.js
@@ -27,3 +27,8 @@ export const insideAlignmentPropType = propTypes.oneOf([
     'middle',
     'bottom',
 ])
+
+export const elementRefPropType = propTypes.oneOfType([
+    propTypes.func,
+    propTypes.shape({ current: propTypes.instanceOf(Element) }),
+])

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,6 +1966,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@popperjs/core@^2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.0.0-rc.3.tgz#17b92f1aabd15ae426e51300ee1c9e38062e9a06"
+  integrity sha512-GqczvJIO6yh6OmPlJdEsVGDQ48twFV3iJUnj3JugVpoBnyM5fQE99E2fVCQZs6qS9AiQ4w/lEiW25m+GwbcCkA==
+
 "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"


### PR DESCRIPTION
This branch will be used to collect feature files, changes to our components and possibly a positioning engine (ours or third party)

ToDos (added by @HendrikThePendric 23-01-2020):
- [x] Implement **internal** Popper component, which is a react-binding to popper.js 
- [ ] Refactor `DropMenu` to use `Popper`
- [ ] Refactor `Menu` and `SubMenu` to use `Popper`, incl. flipping logic
- [ ] Refactor `Select` to use `Popper`
- [ ] Revise/refactor `Popper` API (establish a good design when refactoring the components), and expose `Popper` component