### PR TITLE
refactor(togglegroup): wrap children to allow for datatest attribute

### DIFF
--- a/src/ToggleGroup.js
+++ b/src/ToggleGroup.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 import { Children, cloneElement } from 'react'
@@ -16,23 +17,25 @@ const ToggleGroup = ({
     dense,
     className,
     dataTest,
-}) =>
-    Children.map(children, child =>
-        cloneElement(child, {
-            name,
-            onChange: child.props.onChange || onChange,
-            checked: Array.isArray(value)
-                ? value.indexOf(child.props.value) !== -1
-                : child.props.value === value,
-            disabled: child.props.disabled || disabled,
-            valid: child.props.valid || valid,
-            warning: child.props.warning || warning,
-            error: child.props.error || error,
-            dense: child.props.dense || dense,
-            className: cx(child.props.className, className, 'grouped'),
-            dataTest,
-        })
-    )
+}) => (
+    <div data-test={dataTest}>
+        {Children.map(children, child =>
+            cloneElement(child, {
+                name,
+                onChange: child.props.onChange || onChange,
+                checked: Array.isArray(value)
+                    ? value.indexOf(child.props.value) !== -1
+                    : child.props.value === value,
+                disabled: child.props.disabled || disabled,
+                valid: child.props.valid || valid,
+                warning: child.props.warning || warning,
+                error: child.props.error || error,
+                dense: child.props.dense || dense,
+                className: cx(child.props.className, className, 'grouped'),
+            })
+        )}
+    </div>
+)
 
 ToggleGroup.defaultProps = {
     dataTest: 'dhis2-uicore-togglegroup',


### PR DESCRIPTION
This is a small refactor, to allow the data-test prop to be set correctly for the CheckboxGroup, RadioGroup and SwitchGroup. Without this fix, we can only set a data-test attribute on the children (as that's the only thing that ToggleGroup returns). With this fix, we can set it on the wrapper, which will look like this:

<img width="710" alt="Screenshot 2019-12-12 at 13 46 54" src="https://user-images.githubusercontent.com/7355199/70713215-ca93e500-1ce5-11ea-8a72-1cd5192aab1f.png">
