### PR TITLE
refactor(tabbar): add wrapper to allow for data-test

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
-import cx from 'classnames'
 
-import { colors } from './theme.js'
 import { ScrollBar } from './TabBar/ScrollBar.js'
+import { Tabs } from './TabBar/Tabs.js'
 
 /**
  * @module
@@ -15,28 +14,30 @@ import { ScrollBar } from './TabBar/ScrollBar.js'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/tab.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/tabs--default-fluid|Storybook}
  */
-const TabBar = ({ fixed, children, className, scrollable }) => {
-    const Container = scrollable ? ScrollBar : React.Fragment
-    return (
-        <Container>
-            <div className={cx('tab-bar', className, { fixed })}>
-                {children}
-
-                <style jsx>{`
-                    div {
-                        display: flex;
-                        align-items: flex-start;
-                        position: relative;
-                        overflow: hidden;
-                        box-shadow: inset 0 -1px 0 0 ${colors.grey400};
-                        flex-wrap: nowrap;
-                        flex-grow: 1;
-                        background: ${colors.white};
-                    }
-                `}</style>
+const TabBar = ({ fixed, children, className, scrollable, dataTest }) => {
+    if (scrollable) {
+        return (
+            <div data-test={dataTest}>
+                <ScrollBar>
+                    <Tabs className={className} fixed={fixed}>
+                        {children}
+                    </Tabs>
+                </ScrollBar>
             </div>
-        </Container>
+        )
+    }
+
+    return (
+        <div data-test={dataTest}>
+            <Tabs className={className} fixed={fixed}>
+                {children}
+            </Tabs>
+        </div>
     )
+}
+
+TabBar.defaultProps = {
+    dataTest: 'dhis2-uicore-tabbar',
 }
 
 /**
@@ -53,6 +54,7 @@ TabBar.propTypes = {
         propTypes.arrayOf(propTypes.element),
     ]),
     className: propTypes.string,
+    dataTest: propTypes.string,
     fixed: propTypes.bool,
     scrollable: propTypes.bool,
 }

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -17,21 +17,17 @@ import { Tabs } from './TabBar/Tabs.js'
 const TabBar = ({ fixed, children, className, scrollable, dataTest }) => {
     if (scrollable) {
         return (
-            <div data-test={dataTest}>
+            <div className={className} data-test={dataTest}>
                 <ScrollBar>
-                    <Tabs className={className} fixed={fixed}>
-                        {children}
-                    </Tabs>
+                    <Tabs fixed={fixed}>{children}</Tabs>
                 </ScrollBar>
             </div>
         )
     }
 
     return (
-        <div data-test={dataTest}>
-            <Tabs className={className} fixed={fixed}>
-                {children}
-            </Tabs>
+        <div className={className} data-test={dataTest}>
+            <Tabs fixed={fixed}>{children}</Tabs>
         </div>
     )
 }
@@ -47,6 +43,7 @@ TabBar.defaultProps = {
  * @prop {string} [className]
  * @prop {boolean} [fixed]
  * @prop {boolean} [scrollable]
+ * @prop {string} [dataTest]
  */
 TabBar.propTypes = {
     children: propTypes.oneOfType([

--- a/src/TabBar/Tabs.js
+++ b/src/TabBar/Tabs.js
@@ -10,8 +10,8 @@ import { colors } from '../theme.js'
  * @param {Object} PropTypes
  * @returns {React.Component}
  */
-const Tabs = ({ children, className, fixed, dataTest }) => (
-    <div className={cx(className, { fixed })} data-test={dataTest}>
+const Tabs = ({ children, fixed, dataTest }) => (
+    <div className={cx({ fixed })} data-test={dataTest}>
         {children}
 
         <style jsx>{`
@@ -37,16 +37,14 @@ Tabs.defaultProps = {
  * @typedef {Object} PropTypes
  * @static
  * @prop {Tab|Array.<Tab>} children
- * @prop {string} [className]
  * @prop {boolean} [fixed]
- * @prop {boolean} [scrollable]
+ * @prop {string} [dataTest]
  */
 Tabs.propTypes = {
     children: propTypes.oneOfType([
         propTypes.element,
         propTypes.arrayOf(propTypes.element),
     ]),
-    className: propTypes.string,
     dataTest: propTypes.string,
     fixed: propTypes.bool,
 }

--- a/src/TabBar/Tabs.js
+++ b/src/TabBar/Tabs.js
@@ -11,7 +11,7 @@ import { colors } from '../theme.js'
  * @returns {React.Component}
  */
 const Tabs = ({ children, className, fixed, dataTest }) => (
-    <div className={cx('tab-bar', className, { fixed })} data-test={dataTest}>
+    <div className={cx(className, { fixed })} data-test={dataTest}>
         {children}
 
         <style jsx>{`

--- a/src/TabBar/Tabs.js
+++ b/src/TabBar/Tabs.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+import cx from 'classnames'
+
+import { colors } from '../theme.js'
+
+/**
+ * @module
+ * @private
+ * @param {Object} PropTypes
+ * @returns {React.Component}
+ */
+const Tabs = ({ children, className, fixed, dataTest }) => (
+    <div className={cx('tab-bar', className, { fixed })} data-test={dataTest}>
+        {children}
+
+        <style jsx>{`
+            div {
+                display: flex;
+                align-items: flex-start;
+                position: relative;
+                overflow: hidden;
+                box-shadow: inset 0 -1px 0 0 ${colors.grey400};
+                flex-wrap: nowrap;
+                flex-grow: 1;
+                background: ${colors.white};
+            }
+        `}</style>
+    </div>
+)
+
+Tabs.defaultProps = {
+    dataTest: 'dhis2-uicore-tabbar-tabs',
+}
+
+/**
+ * @typedef {Object} PropTypes
+ * @static
+ * @prop {Tab|Array.<Tab>} children
+ * @prop {string} [className]
+ * @prop {boolean} [fixed]
+ * @prop {boolean} [scrollable]
+ */
+Tabs.propTypes = {
+    children: propTypes.oneOfType([
+        propTypes.element,
+        propTypes.arrayOf(propTypes.element),
+    ]),
+    className: propTypes.string,
+    dataTest: propTypes.string,
+    fixed: propTypes.bool,
+}
+
+export { Tabs }


### PR DESCRIPTION
I've considered a couple different approaches to allow for a data-test attribute to be set on the TabBar. We've attached it to the root rendered node everywhere else, so that's my goal for the TabBar as well.

Initially I tried keeping the component as is. The existing markup is:

<img width="556" alt="Screenshot 2019-12-12 at 14 12 28" src="https://user-images.githubusercontent.com/7355199/70714890-62df9900-1ce9-11ea-81be-3796e5d28b92.png">

### Minimal approach, semantically confusing

Keeping this as-is, means attaching the data-test attr. to either the Scrollable component, or a div wrapper (which would replace the current Fragment), depending on the value of `scrollable`. That would keep the markup reasonably similar, but I thought it made for a more confusing data-test attr. Because now, depending on the value of `scrollable`, the attribute is either attached to the scrollable component, or the root div. Which are different components, and at different points in the eventually rendered markup, kind of defeating the purpose of using a data-test attribute in my opinion.

### More elaborate, semantically more correct

The fix in this PR is more elaborate and adds a div around the entire TabBar component, including the Scrollbar. The main thing I don't like about _this_ approach is that to not break existing className rules from users, we're passing className down, and not applying it to the root node. Which kind of goes against our conventions as well I think. Still, to me this seemed like the more correct approach, and later on we could move className up for a major version.

Let me know what you all think.