### PR TITLE
feat(input): enable additional types on input

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -231,6 +231,13 @@ Input.propTypes = {
         'email',
         'url',
         'tel',
+        'date',
+        'datetime',
+        'datetime-local',
+        'month',
+        'week',
+        'time',
+        'search',
     ]),
     valid: statusPropType,
 


### PR DESCRIPTION
E.g. date from UA:

![2019-12-12-192020_275x162_scrot](https://user-images.githubusercontent.com/185449/70738318-badfc500-1d14-11ea-80f0-ed981d8bff10.png)

This adds additional types of input controls:

- date
- datetime
- datetime-local
- month
- week
- time
- search