### PR TITLE
docs(api): add workaround for jsdoc bug

### DIFF
--- a/src/AlertBar.js
+++ b/src/AlertBar.js
@@ -7,6 +7,7 @@ import { Dismiss } from './AlertBar/Dismiss.js'
 import { Icon, iconPropType } from './AlertBar/Icon.js'
 import { Message } from './AlertBar/Message.js'
 import styles, { ANIMATION_TIME } from './AlertBar/styles.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/AlertStack.js
+++ b/src/AlertStack.js
@@ -4,6 +4,7 @@ import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { layers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Backdrop.js
+++ b/src/Backdrop.js
@@ -3,6 +3,7 @@ import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { Layer } from './LayerContext.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/ButtonStrip.js
+++ b/src/ButtonStrip.js
@@ -3,6 +3,7 @@ import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Card.js
+++ b/src/Card.js
@@ -3,6 +3,7 @@ import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { colors } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -5,6 +5,7 @@ import React, { Component, createRef } from 'react'
 import { statusPropType } from './common-prop-types.js'
 import { Regular, Dense } from './icons/Checkbox.js'
 import { colors, theme } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/CheckboxField.js
+++ b/src/CheckboxField.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { ToggleField, toggleFieldPropTypes } from './ToggleField.js'
 import { Checkbox } from './Checkbox.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/CheckboxGroup.js
+++ b/src/CheckboxGroup.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroup } from './ToggleGroup.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/CheckboxGroupField.js
+++ b/src/CheckboxGroupField.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroupField } from './ToggleGroupField.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Chip.js
+++ b/src/Chip.js
@@ -6,6 +6,7 @@ import { colors, theme, spacers } from './theme.js'
 import { Content } from './Chip/Content.js'
 import { Icon } from './Chip/Icon.js'
 import { Remove } from './Chip/Remove.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/CircularLoader.js
+++ b/src/CircularLoader.js
@@ -4,6 +4,7 @@ import React from 'react'
 
 import { sizePropType } from './common-prop-types.js'
 import { theme, spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/ComponentCover.js
+++ b/src/ComponentCover.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { layers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/CssReset.js
+++ b/src/CssReset.js
@@ -1,15 +1,13 @@
 import React from 'react'
 
 import { theme } from './theme.js'
-
-/*
- * Normalize CSS
- * - https://github.com/necolas/normalize.css
- * - https://www.paulirish.com/2012/box-sizing-border-box-ftw/
- */
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module
+ * @desc Normalize CSS
+ * - https://github.com/necolas/normalize.css
+ * - https://www.paulirish.com/2012/box-sizing-border-box-ftw/
  * @returns {React.Component}
  * @example import { CssReset } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/cssreset--default|Storybook}

--- a/src/Divider.js
+++ b/src/Divider.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { colors, spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/DropMenu.js
+++ b/src/DropMenu.js
@@ -4,6 +4,7 @@ import propTypes from '@dhis2/prop-types'
 
 import { layers } from './theme.js'
 import { Layer } from './LayerContext.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { Button } from './Button.js'
 import { DropMenu } from './DropMenu.js'
 import { ArrowDown, ArrowUp } from './icons/Arrow.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Field.js
+++ b/src/Field.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -7,6 +7,7 @@ import { Button } from './Button.js'
 import { spacers } from './theme.js'
 import { Upload } from './icons/Upload.js'
 import { StatusIcon } from './icons/Status.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/FileInputField.js
+++ b/src/FileInputField.js
@@ -7,6 +7,7 @@ import { FileListPlaceholder } from './FileListPlaceholder.js'
 import { Field } from './Field.js'
 import { Label } from './Label.js'
 import { Help } from './Help.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/FileListItem.js
+++ b/src/FileListItem.js
@@ -5,6 +5,7 @@ import cx from 'classnames'
 import { colors, spacers } from './theme.js'
 import { AttachFile } from './icons/AttachFile.js'
 import { Loading } from './icons/Status.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/FileListPlaceholder.js
+++ b/src/FileListPlaceholder.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { colors, spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Help.js
+++ b/src/Help.js
@@ -4,6 +4,7 @@ import React from 'react'
 
 import { statusPropType } from './common-prop-types.js'
 import { spacers, theme } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/InputField.js
+++ b/src/InputField.js
@@ -8,6 +8,7 @@ import { Label } from './Label.js'
 import { Input } from './Input.js'
 import { Help } from './Help.js'
 import { Constrictor } from './Constrictor.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Legend.js
+++ b/src/Legend.js
@@ -3,6 +3,7 @@ import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { colors, spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Logo.js
+++ b/src/Logo.js
@@ -3,6 +3,7 @@ import propTypes from '@dhis2/prop-types'
 
 import { LogoSvg } from './Logo/LogoSvg'
 import { LogoIconSvg } from './Logo/LogoIconSvg'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /*
  * This should likely not live in ui-core, but in ui-widgets

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -4,6 +4,7 @@ import propTypes from '@dhis2/prop-types'
 import { Card } from './Card.js'
 import { MenuList } from './MenuList.js'
 import { spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -6,18 +6,20 @@ import { sizePropType } from './common-prop-types.js'
 import { ScreenCover } from './ScreenCover.js'
 
 import { ModalCard } from './Modal/ModalCard.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
- * Modal provides a UI to prompt the user to respond to a question
+ * @module
+ * @param {Modal.PropTypes} props
+ * @returns {React.Component}
+ *
+ * @desc Modal provides a UI to prompt the user to respond to a question
  * or a note to the user.
  *
  * Use Model with the following Components:
  * ModelTitle (optional)
  * ModelContent (required)
  * ModelActions (required)
- * @module
- * @param {Modal.PropTypes} props
- * @returns {React.Component}
  *
  * @example import { Modal } from @dhis2/ui-core
  * @example

--- a/src/ModalActions.js
+++ b/src/ModalActions.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/ModalContent.js
+++ b/src/ModalContent.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/ModalTitle.js
+++ b/src/ModalTitle.js
@@ -3,6 +3,7 @@ import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 import { spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/MultiSelect.js
+++ b/src/MultiSelect.js
@@ -8,6 +8,7 @@ import { FilterableMenu } from './MultiSelect/FilterableMenu.js'
 import { Loading } from './Select/Loading.js'
 import { StatusIcon } from './icons/Status.js'
 import { spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/MultiSelectField.js
+++ b/src/MultiSelectField.js
@@ -8,6 +8,7 @@ import { Label } from './Label.js'
 import { Help } from './Help.js'
 import { MultiSelect } from './MultiSelect.js'
 import { Constrictor } from './Constrictor.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -5,6 +5,7 @@ import React, { Component, createRef } from 'react'
 import { statusPropType } from './common-prop-types.js'
 import { Regular, Dense } from './icons/Radio.js'
 import { colors, theme } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/RadioGroup.js
+++ b/src/RadioGroup.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroup } from './ToggleGroup.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/RadioGroupField.js
+++ b/src/RadioGroupField.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroupField } from './ToggleGroupField.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/SingleSelect.js
+++ b/src/SingleSelect.js
@@ -8,6 +8,7 @@ import { FilterableMenu } from './SingleSelect/FilterableMenu.js'
 import { Loading } from './Select/Loading.js'
 import { StatusIcon } from './icons/Status.js'
 import { spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/SingleSelectField.js
+++ b/src/SingleSelectField.js
@@ -8,6 +8,7 @@ import { Label } from './Label.js'
 import { Help } from './Help.js'
 import { SingleSelect } from './SingleSelect.js'
 import { Constrictor } from './Constrictor.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/SingleSelectOption.js
+++ b/src/SingleSelectOption.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 import { colors, spacers } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -5,6 +5,7 @@ import React, { Component, createRef } from 'react'
 import { statusPropType } from './common-prop-types.js'
 import { Regular } from './icons/Switch.js'
 import { colors, theme } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/SwitchField.js
+++ b/src/SwitchField.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { ToggleField, toggleFieldPropTypes } from './ToggleField.js'
 import { Switch } from './Switch.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/SwitchGroup.js
+++ b/src/SwitchGroup.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroup } from './ToggleGroup.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/SwitchGroupField.js
+++ b/src/SwitchGroupField.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroupField } from './ToggleGroupField.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 import { colors, theme } from './theme.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 
 import { colors } from './theme.js'
 import { ScrollBar } from './TabBar/ScrollBar.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/TabBar/ScrollBar.js
+++ b/src/TabBar/ScrollBar.js
@@ -5,6 +5,7 @@ import { ChevronLeft, ChevronRight } from '../icons/Chevron'
 import { colors } from '../theme'
 import { detectHorizontalScrollbarHeight } from './detectHorizontalScrollbarHeight'
 import { animatedSideScroll } from './animatedSideScroll'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/TableRowHead.js
+++ b/src/TableRowHead.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { TableRow } from './TableRow.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -6,7 +6,15 @@ import { statusPropType } from './common-prop-types.js'
 import { StatusIcon } from './icons/Status.js'
 
 import { styles } from './TextArea/styles.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
+/**
+ * @module
+ * @param {TextArea.PropTypes} props
+ * @returns {React.Component}
+ *
+ * @example import { TextArea } from '@dhis2/ui-core'
+ */
 export class TextArea extends Component {
     textareaRef = React.createRef()
     state = {
@@ -206,7 +214,6 @@ TextArea.defaultProps = {
  * @prop {number} [rows=4]
  * @prop {string} [width]
  */
-
 TextArea.propTypes = {
     autoGrow: propTypes.bool,
 

--- a/src/TextAreaField.js
+++ b/src/TextAreaField.js
@@ -8,6 +8,7 @@ import { Label } from './Label.js'
 import { TextArea } from './TextArea.js'
 import { Help } from './Help.js'
 import { Constrictor } from './Constrictor.js'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
  * @module


### PR DESCRIPTION
JSDoc has a bug where if a named import is the last statement before the
doc comment, then it fails to pick up the doc comment.

Any valid statement between the named import and the doc comment works
around the problem, such as `;` or `''`. Our code style rewrites a `''`
statement as `;('')`, and that is the shortest non-functional workaround
I have found to work around the problem.

Refs https://github.com/jsdoc/jsdoc/issues/1718
Refs https://github.com/jsdoc/jsdoc/issues/1706

Compare the result (broken on the left, correct on the right):

![2019-12-13-165002_2019x1791_scrot](https://user-images.githubusercontent.com/185449/70812828-aa892200-1dc8-11ea-9e44-f1e05500397c.png)

It also had the result that most of the modules were dropped, and the PropTypes rendered without their owner:

![2019-12-13-165110_2427x2094_scrot](https://user-images.githubusercontent.com/185449/70812921-db695700-1dc8-11ea-99bd-8fa856fe6d54.png)
