### PR TITLE
feat(modal): allow modal without actions

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -19,7 +19,10 @@ import { ModalCard } from './Modal/ModalCard.js'
  * Use Model with the following Components:
  * ModelTitle (optional)
  * ModelContent (required)
- * ModelActions (required)
+ * ModelActions (optional)
+ * @module
+ * @param {Modal.PropTypes} props
+ * @returns {React.Component}
  *
  * @example import { Modal } from @dhis2/ui-core
  * @example
@@ -55,7 +58,6 @@ export const Modal = ({ children, onClose, small, large, className }) =>
  * @prop {bool} large
  */
 Modal.propTypes = {
-    // Can contain ModalTitle; Must contain ModalContent and ModalActions
     children: propTypes.oneOfType([
         propTypes.element,
         propTypes.arrayOf(propTypes.element),

--- a/src/ModalActions.js
+++ b/src/ModalActions.js
@@ -16,7 +16,7 @@ export const ModalActions = ({ children }) => (
 
         <style jsx>{`
             div {
-                padding: 0 ${spacers.dp24} ${spacers.dp24};
+                padding: 0 ${spacers.dp24} ${spacers.dp24} ${spacers.dp24};
                 display: flex;
                 justify-content: flex-end;
             }

--- a/src/ModalContent.js
+++ b/src/ModalContent.js
@@ -17,13 +17,9 @@ export const ModalContent = ({ children, className }) => (
         <style jsx>{`
             div {
                 flex-grow: 1;
-                margin-bottom: ${spacers.dp32};
-                overflow-y: auto;
+                margin: ${spacers.dp24} 0;
                 padding: 0 ${spacers.dp24};
-            }
-
-            div:first-child {
-                padding-top: ${spacers.dp24};
+                overflow-y: auto;
             }
         `}</style>
     </div>

--- a/src/ModalTitle.js
+++ b/src/ModalTitle.js
@@ -19,8 +19,8 @@ export const ModalTitle = ({ children }) => (
                 font-size: 20px;
                 font-weight: 500;
                 line-height: 24px;
-                padding: ${spacers.dp24} ${spacers.dp24} 0;
-                margin: 0 0 ${spacers.dp16};
+                margin: 0;
+                padding: ${spacers.dp24} ${spacers.dp24} 0 ${spacers.dp24};
             }
         `}</style>
     </h1>

--- a/stories/Modal.stories.js
+++ b/stories/Modal.stories.js
@@ -22,8 +22,24 @@ window.onClose = (payload, event) => {
 const onClose = (...args) => window.onClose(...args)
 
 storiesOf('Modal', module)
+    .add('Default: Content', () => (
+        <Modal onClose={onClose}>
+            <ModalContent>
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+                diam nonumy eirmod tempor invidunt ut labore et dolore magna
+                aliquyam erat, sed diam voluptua. At vero eos et accusam et
+                justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+                takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum
+                dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
+                eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+                sed diam voluptua. At vero eos et accusam et justo duo dolores
+                et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
+                est Lorem ipsum dolor sit amet.
+            </ModalContent>
+        </Modal>
+    ))
     .add('Small: Title, Content, Action', () => (
-        <Modal open small onClose={onClose}>
+        <Modal small onClose={onClose}>
             <ModalTitle>
                 This is a small modal with title, content and primary action
             </ModalTitle>
@@ -55,7 +71,7 @@ storiesOf('Modal', module)
         </Modal>
     ))
     .add('Medium: Title, Content, Action', () => (
-        <Modal open>
+        <Modal>
             <ModalTitle>
                 This is a medium modal with title, content and primary action
             </ModalTitle>
@@ -87,7 +103,7 @@ storiesOf('Modal', module)
         </Modal>
     ))
     .add('Large: Title, Content, Primary', () => (
-        <Modal open large>
+        <Modal large>
             <ModalTitle>
                 This is a large modal with title, content and primary action
             </ModalTitle>
@@ -119,7 +135,7 @@ storiesOf('Modal', module)
         </Modal>
     ))
     .add('Small: Content & Primary', () => (
-        <Modal open small>
+        <Modal small>
             <ModalContent>
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
                 diam nonumy eirmod tempor invidunt ut labore et dolore magna
@@ -147,7 +163,7 @@ storiesOf('Modal', module)
         </Modal>
     ))
     .add('Small: Destructive Primary', () => (
-        <Modal open small>
+        <Modal small>
             <ModalContent>
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
                 diam nonumy eirmod tempor invidunt ut labore et dolore magna
@@ -175,7 +191,7 @@ storiesOf('Modal', module)
         </Modal>
     ))
     .add('Small: Clickable screen cover', () => (
-        <Modal open small onClose={say('Clickable screen cover')}>
+        <Modal small onClose={say('Clickable screen cover')}>
             <ModalTitle>This is a modal with clickable screen cover</ModalTitle>
 
             <ModalContent>
@@ -198,7 +214,7 @@ storiesOf('Modal', module)
         </Modal>
     ))
     .add('Small: scrollable', () => (
-        <Modal open small onClose={say('Clickable screen cover')}>
+        <Modal small onClose={say('Clickable screen cover')}>
             <ModalTitle>This is a modal with scrollable content</ModalTitle>
 
             <ModalContent>
@@ -267,7 +283,7 @@ storiesOf('Modal', module)
         </Modal>
     ))
     .add('Small: Long title', () => (
-        <Modal open small>
+        <Modal small>
             <ModalTitle>
                 This headline should break into multiple lines because it&apos;s
                 way too long for one!
@@ -294,7 +310,7 @@ storiesOf('Modal', module)
         </Modal>
     ))
     .add('Large: with Select component', () => (
-        <Modal open large>
+        <Modal large>
             <ModalTitle>Select opens on top of the Modal</ModalTitle>
 
             <ModalContent>
@@ -326,7 +342,7 @@ storiesOf('Modal', module)
         </Modal>
     ))
     .add('Large: modal with more nested modals', () => (
-        <Modal open large>
+        <Modal large>
             <ModalTitle>Select opens on top of the Modal - Level 1</ModalTitle>
 
             <ModalContent>
@@ -342,7 +358,7 @@ storiesOf('Modal', module)
                     <SingleSelectOption key="9" value="3" label="nine" />
                     <SingleSelectOption key="10" value="3" label="ten" />
                 </SingleSelectField>
-                <Modal open large>
+                <Modal large>
                     <ModalTitle>
                         Select opens on top of the Modal - Level 2
                     </ModalTitle>
@@ -388,7 +404,7 @@ storiesOf('Modal', module)
                                 label="ten"
                             />
                         </SingleSelectField>
-                        <Modal open large>
+                        <Modal large>
                             <ModalTitle>
                                 Select opens on top of the Modal - Level 3
                             </ModalTitle>


### PR DESCRIPTION
To allow a Modal to be rendered with only content, we need to adjust the
margin/paddings on the components.

This also cleans up the dead prop `open` which was removed in v4.