### PR TITLE
fix: input and select styling

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -21,16 +21,14 @@ const styles = css`
         user-select: text;
 
         color: ${colors.grey900};
-        background-color: transparent;
+        background-color: white;
 
         padding: 12px 11px 10px;
 
         outline: 0;
         border: 1px solid ${colors.grey500};
         border-radius: 3px;
-        box-shadow: inset 0 0 0 1px rgba(102, 113, 123, 0.15),
-            inset 0 1px 2px 0 rgba(102, 113, 123, 0.1);
-
+        box-shadow: inset 0 1px 2px 0 rgba(48, 54, 60, 0.1);
         text-overflow: ellipsis;
     }
 

--- a/src/Select/InputWrapper.js
+++ b/src/Select/InputWrapper.js
@@ -40,14 +40,14 @@ const InputWrapper = ({
             <style jsx>{`
                 .root {
                     align-items: center;
+                    background-color: white;
                     border-radius: 3px;
                     border: 1px solid ${colors.grey500};
                     box-sizing: border-box;
                     display: flex;
-                    min-height: 34px;
+                    min-height: 40px;
                     padding: 6px 12px;
-                    box-shadow: inset 0 0 0 1px rgba(102, 113, 123, 0.15),
-                        inset 0 1px 2px 0 rgba(102, 113, 123, 0.1);
+                    box-shadow: inset 0 1px 2px 0 rgba(48, 54, 60, 0.1);
                 }
 
                 .root:focus,
@@ -77,6 +77,7 @@ const InputWrapper = ({
 
                 .root.dense {
                     padding: 4px 8px;
+                    min-height: 32px;
                 }
 
                 .root-children {


### PR DESCRIPTION
Some minor style changes to the `input` and `select` components.

I am changing the `min-height` defined for the `select`. I remember that this was discussed before and the current solution was the simplest. Right now there is a lack of consistency when using these types of user input side by side: 
![Screenshot 20191216142928](https://user-images.githubusercontent.com/33054985/70912838-15c73400-2015-11ea-8b25-1307b36a0207.png)

With the changes in this PR, default sized select and input have the same height:
![Screenshot 20191216142903](https://user-images.githubusercontent.com/33054985/70912882-2bd4f480-2015-11ea-9547-87a65875e1f9.png)

Are there any issues with these changes? [There was a slack discussion about this](https://dhis2.slack.com/archives/CBM8LNEQM/p1572261046057200), it looks like @Mohammer5 and @ismay had a call to discuss.

Ps. Are we merging straight into `master` now? I see there is no `next`. Please confirm before I merge 😉 