### PR TITLE
refactor(node): add spacer component

### DIFF
--- a/cypress/integration/Node/Can_be_closed/index.js
+++ b/cypress/integration/Node/Can_be_closed/index.js
@@ -11,7 +11,9 @@ Given('the Node is provided with an onClose handler', () => {
 })
 
 When('the arrow is clicked', () => {
-    cy.get('#root > .tree > .tree__arrow > span').click()
+    cy.get(
+        '#root > div:nth-child(1) > div:nth-child(1) > span:nth-child(1)'
+    ).click()
 })
 
 Then('the onClose handler is called', () => {

--- a/cypress/integration/Node/Can_be_opened/index.js
+++ b/cypress/integration/Node/Can_be_opened/index.js
@@ -11,7 +11,7 @@ Given('the Node is provided with an onOpen handler', () => {
 })
 
 When('the arrow is clicked', () => {
-    cy.get('#root > div > .tree:first-child > .tree__arrow > span').click()
+    cy.get('div:nth-child(1) > div:nth-child(1) > span:nth-child(1)').click()
 })
 
 Then('the onOpen handler is called', () => {

--- a/src/Node.js
+++ b/src/Node.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
-import cx from 'classnames'
 
 import { Arrow } from './Node/Arrow.js'
+import { Spacer } from './Node/Spacer.js'
 import { Content } from './Node/Content.js'
 
 /**
@@ -26,15 +26,12 @@ export const Node = ({
     const hasLeaves = !!React.Children.toArray(children).filter(i => i).length
 
     return (
-        <div
-            className={cx('tree', className, { open, 'has-leaves': hasLeaves })}
-        >
-            <Arrow
-                open={open}
-                hasLeaves={hasLeaves}
-                onOpen={onOpen}
-                onClose={onClose}
-            />
+        <div className={className}>
+            {hasLeaves ? (
+                <Arrow open={open} onOpen={onOpen} onClose={onClose} />
+            ) : (
+                <Spacer />
+            )}
 
             <Content open={open} label={component}>
                 {children}

--- a/src/Node/Arrow.js
+++ b/src/Node/Arrow.js
@@ -5,19 +5,13 @@ import cx from 'classnames'
 import { ArrowDown } from '../icons/Arrow.js'
 import { colors } from '../theme.js'
 
-export const Arrow = ({ hasLeaves, open, onOpen, onClose }) => {
-    const arrowIcon = hasLeaves ? <ArrowDown /> : <span />
+export const Arrow = ({ open, onOpen, onClose }) => {
     const onClick = open ? onClose : onOpen
 
     return (
-        <div
-            className={cx('tree__arrow', {
-                open,
-                'has-leaves': hasLeaves,
-            })}
-        >
+        <div className={cx({ open })}>
             <span onClick={event => onClick && onClick({ open: !open }, event)}>
-                {arrowIcon}
+                <ArrowDown />
             </span>
 
             <style jsx>{`
@@ -35,7 +29,7 @@ export const Arrow = ({ hasLeaves, open, onOpen, onClose }) => {
                     width: 1px;
                     z-index: 1;
                 }
-                .has-leaves.open:after {
+                .open:after {
                     content: '';
                 }
                 span {
@@ -57,7 +51,6 @@ export const Arrow = ({ hasLeaves, open, onOpen, onClose }) => {
 }
 
 Arrow.propTypes = {
-    hasLeaves: propTypes.bool,
     open: propTypes.bool,
     onClose: propTypes.func,
     onOpen: propTypes.func,

--- a/src/Node/Contents.js
+++ b/src/Node/Contents.js
@@ -3,7 +3,7 @@ import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
 export const Contents = ({ children, open }) => (
-    <div className={cx('tree__contents', { open })}>
+    <div className={cx({ open })}>
         {children}
 
         <style jsx>{`

--- a/src/Node/Spacer.js
+++ b/src/Node/Spacer.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export const Spacer = () => (
+    <div>
+        <style jsx>{`
+            div {
+                width: 24px;
+            }
+        `}</style>
+    </div>
+)


### PR DESCRIPTION
Follow-up of https://github.com/dhis2/ui-core/pull/676.

I've updated the rendering of the Arrow slightly, so that the intention of rendering either an Arrow or empty space is more obvious from the code. I've also updated classes, that seemed to be old style hooks, but seemed to be no longer used. Correct me if I'm wrong though.

The integration tests have to be updated, as they still target the classes. We could hold off on merging this until the data-test attrs. are in, rebase and then use them to fix the integration tests for this PR and merge this in.