### PR TITLE
refactor: set prop-types explicitly instead of spreading

### DIFF
--- a/src/CheckboxField.js
+++ b/src/CheckboxField.js
@@ -1,6 +1,8 @@
 import React from 'react'
+import propTypes from '@dhis2/prop-types'
 
-import { ToggleField, toggleFieldPropTypes } from './ToggleField.js'
+import { statusPropType } from './common-prop-types.js'
+import { ToggleField } from './ToggleField.js'
 import { Checkbox } from './Checkbox.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
@@ -86,6 +88,25 @@ const CheckboxField = ({
  * @prop {string} [helpText]
  * @prop {string} [validationText]
  */
-CheckboxField.propTypes = toggleFieldPropTypes
+CheckboxField.propTypes = {
+    label: propTypes.node.isRequired,
+    checked: propTypes.bool,
+    className: propTypes.string,
+    dense: propTypes.bool,
+    disabled: propTypes.bool,
+    error: statusPropType,
+    helpText: propTypes.string,
+    initialFocus: propTypes.bool,
+    name: propTypes.string,
+    required: propTypes.bool,
+    tabIndex: propTypes.string,
+    valid: statusPropType,
+    validationText: propTypes.string,
+    value: propTypes.string,
+    warning: statusPropType,
+    onBlur: propTypes.func,
+    onChange: propTypes.func,
+    onFocus: propTypes.func,
+}
 
 export { CheckboxField }

--- a/src/CheckboxGroup.js
+++ b/src/CheckboxGroup.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
+import { statusPropType } from './common-prop-types.js'
 import { ToggleGroup } from './ToggleGroup.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
@@ -61,9 +62,16 @@ const CheckboxGroup = ({
  * @prop {boolean} [dense]
  */
 CheckboxGroup.propTypes = {
-    ...ToggleGroup.propTypes,
     children: propTypes.arrayOf(propTypes.element).isRequired,
+    className: propTypes.string,
+    dense: propTypes.bool,
+    disabled: propTypes.bool,
+    error: statusPropType,
+    name: propTypes.string,
+    valid: statusPropType,
     value: propTypes.arrayOf(propTypes.string),
+    warning: statusPropType,
+    onChange: propTypes.func,
 }
 
 export { CheckboxGroup }

--- a/src/CheckboxGroupField.js
+++ b/src/CheckboxGroupField.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroupField } from './ToggleGroupField.js'
+import { statusPropType } from './common-prop-types.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -72,9 +73,20 @@ const CheckboxGroupField = ({
  * @prop {boolean} [required]
  */
 CheckboxGroupField.propTypes = {
-    ...ToggleGroupField.propTypes,
     children: propTypes.arrayOf(propTypes.element).isRequired,
+    className: propTypes.string,
+    dense: propTypes.bool,
+    disabled: propTypes.bool,
+    error: statusPropType,
+    helpText: propTypes.string,
+    label: propTypes.string,
+    name: propTypes.string,
+    required: propTypes.bool,
+    valid: statusPropType,
+    validationText: propTypes.string,
     value: propTypes.arrayOf(propTypes.string),
+    warning: statusPropType,
+    onChange: propTypes.func,
 }
 
 export { CheckboxGroupField }

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -2,6 +2,7 @@ import propTypes from '@dhis2/prop-types'
 import React, { Component } from 'react'
 
 import { Button } from './Button.js'
+import { buttonVariantPropType, sizePropType } from './common-prop-types.js'
 import { DropMenu } from './DropMenu.js'
 import { ArrowDown, ArrowUp } from './icons/Arrow.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
@@ -128,8 +129,22 @@ class DropdownButton extends Component {
  * @prop {boolean} [initialFocus] Grants the button the initial focus
  */
 DropdownButton.propTypes = {
-    ...Button.propTypes,
     component: propTypes.element.isRequired,
+    children: propTypes.node,
+    className: propTypes.string,
+    destructive: buttonVariantPropType,
+    disabled: propTypes.bool,
+    icon: propTypes.element,
+    initialFocus: propTypes.bool,
+    large: sizePropType,
+    name: propTypes.string,
+    primary: buttonVariantPropType,
+    secondary: buttonVariantPropType,
+    small: sizePropType,
+    tabIndex: propTypes.string,
+    type: propTypes.oneOf(['submit', 'reset', 'button']),
+    value: propTypes.string,
+    onClick: propTypes.func,
 }
 
 export { DropdownButton }

--- a/src/FileInputField.js
+++ b/src/FileInputField.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
+import { statusPropType, sizePropType } from './common-prop-types.js'
 import { FileInput } from './FileInput.js'
 import { FileList } from './FileList.js'
 import { FileListPlaceholder } from './FileListPlaceholder.js'
@@ -111,13 +112,25 @@ const FileInputField = ({
  * @prop {boolean} [multiple] - the `multiple` attribute of the native file input https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#multiple
  */
 FileInputField.propTypes = {
-    ...FileInput.propTypes,
+    accept: propTypes.string,
+    buttonLabel: propTypes.string,
     children: propTypes.node,
+    className: propTypes.string,
+    disabled: propTypes.bool,
+    error: statusPropType,
     helpText: propTypes.string,
     label: propTypes.string,
+    large: sizePropType,
+    multiple: propTypes.bool,
+    name: propTypes.string,
     placeholder: propTypes.string,
     required: propTypes.bool,
+    small: sizePropType,
+    tabIndex: propTypes.string,
+    valid: statusPropType,
     validationText: propTypes.string,
+    warning: statusPropType,
+    onChange: propTypes.func,
 }
 
 FileInputField.defaultProps = {

--- a/src/RadioGroup.js
+++ b/src/RadioGroup.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroup } from './ToggleGroup.js'
+import { statusPropType } from './common-prop-types.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -61,9 +62,16 @@ const RadioGroup = ({
  * @prop {boolean} [dense]
  */
 RadioGroup.propTypes = {
-    ...ToggleGroup.propTypes,
     children: propTypes.arrayOf(propTypes.element).isRequired,
+    className: propTypes.string,
+    dense: propTypes.bool,
+    disabled: propTypes.bool,
+    error: statusPropType,
+    name: propTypes.string,
+    valid: statusPropType,
     value: propTypes.string,
+    warning: statusPropType,
+    onChange: propTypes.func,
 }
 
 export { RadioGroup }

--- a/src/RadioGroupField.js
+++ b/src/RadioGroupField.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroupField } from './ToggleGroupField.js'
+import { statusPropType } from './common-prop-types.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -73,9 +74,20 @@ const RadioGroupField = ({
  * @prop {boolean} [required]
  */
 RadioGroupField.propTypes = {
-    ...ToggleGroupField.propTypes,
     children: propTypes.arrayOf(propTypes.element).isRequired,
+    className: propTypes.string,
+    dense: propTypes.bool,
+    disabled: propTypes.bool,
+    error: statusPropType,
+    helpText: propTypes.string,
+    label: propTypes.string,
+    name: propTypes.string,
+    required: propTypes.bool,
+    valid: statusPropType,
+    validationText: propTypes.string,
     value: propTypes.string,
+    warning: statusPropType,
+    onChange: propTypes.func,
 }
 
 export { RadioGroupField }

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -7,6 +7,7 @@ import { DropMenu } from './DropMenu.js'
 import { ArrowDown, ArrowUp } from './icons/Arrow.js'
 
 import { spacers } from './theme.js'
+import { buttonVariantPropType, sizePropType } from './common-prop-types.js'
 
 const rightButton = css.resolve`
     button {
@@ -164,9 +165,22 @@ class SplitButton extends Component {
  * @prop {boolean} [initialFocus] Grants the button the initial focus
  */
 SplitButton.propTypes = {
-    ...Button.propTypes,
     component: propTypes.element.isRequired,
     children: propTypes.string,
+    className: propTypes.string,
+    destructive: buttonVariantPropType,
+    disabled: propTypes.bool,
+    icon: propTypes.element,
+    initialFocus: propTypes.bool,
+    large: sizePropType,
+    name: propTypes.string,
+    primary: buttonVariantPropType,
+    secondary: buttonVariantPropType,
+    small: sizePropType,
+    tabIndex: propTypes.string,
+    type: propTypes.oneOf(['submit', 'reset', 'button']),
+    value: propTypes.string,
+    onClick: propTypes.func,
 }
 
 export { SplitButton }

--- a/src/SwitchField.js
+++ b/src/SwitchField.js
@@ -1,6 +1,8 @@
 import React from 'react'
+import propTypes from '@dhis2/prop-types'
 
-import { ToggleField, toggleFieldPropTypes } from './ToggleField.js'
+import { statusPropType } from './common-prop-types.js'
+import { ToggleField } from './ToggleField.js'
 import { Switch } from './Switch.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
@@ -86,6 +88,25 @@ const SwitchField = ({
  * @prop {string} [helpText]
  * @prop {string} [validationText]
  */
-SwitchField.propTypes = toggleFieldPropTypes
+SwitchField.propTypes = {
+    label: propTypes.node.isRequired,
+    checked: propTypes.bool,
+    className: propTypes.string,
+    dense: propTypes.bool,
+    disabled: propTypes.bool,
+    error: statusPropType,
+    helpText: propTypes.string,
+    initialFocus: propTypes.bool,
+    name: propTypes.string,
+    required: propTypes.bool,
+    tabIndex: propTypes.string,
+    valid: statusPropType,
+    validationText: propTypes.string,
+    value: propTypes.string,
+    warning: statusPropType,
+    onBlur: propTypes.func,
+    onChange: propTypes.func,
+    onFocus: propTypes.func,
+}
 
 export { SwitchField }

--- a/src/SwitchGroup.js
+++ b/src/SwitchGroup.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroup } from './ToggleGroup.js'
+import { statusPropType } from './common-prop-types.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -61,9 +62,16 @@ const SwitchGroup = ({
  * @prop {boolean} [dense]
  */
 SwitchGroup.propTypes = {
-    ...ToggleGroup.propTypes,
     children: propTypes.arrayOf(propTypes.element).isRequired,
+    className: propTypes.string,
+    dense: propTypes.bool,
+    disabled: propTypes.bool,
+    error: statusPropType,
+    name: propTypes.string,
+    valid: statusPropType,
     value: propTypes.arrayOf(propTypes.string),
+    warning: statusPropType,
+    onChange: propTypes.func,
 }
 
 export { SwitchGroup }

--- a/src/SwitchGroupField.js
+++ b/src/SwitchGroupField.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { ToggleGroupField } from './ToggleGroupField.js'
+import { statusPropType } from './common-prop-types.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -73,9 +74,20 @@ const SwitchGroupField = ({
  * @prop {boolean} [required]
  */
 SwitchGroupField.propTypes = {
-    ...ToggleGroupField.propTypes,
     children: propTypes.arrayOf(propTypes.element).isRequired,
+    className: propTypes.string,
+    dense: propTypes.bool,
+    disabled: propTypes.bool,
+    error: statusPropType,
+    helpText: propTypes.string,
+    label: propTypes.string,
+    name: propTypes.string,
+    required: propTypes.bool,
+    valid: statusPropType,
+    validationText: propTypes.string,
     value: propTypes.arrayOf(propTypes.string),
+    warning: statusPropType,
+    onChange: propTypes.func,
 }
 
 export { SwitchGroupField }

--- a/src/ToggleField.js
+++ b/src/ToggleField.js
@@ -93,33 +93,26 @@ const ToggleField = ({
  * @prop {string} [validationText]
  * @prop {function} toggleComponent
  */
-const toggleFieldPropTypes = {
-    value: propTypes.string,
+ToggleField.propTypes = {
     label: propTypes.node.isRequired,
-
-    name: propTypes.string,
+    toggleComponent: propTypes.func.isRequired,
+    checked: propTypes.bool,
     className: propTypes.string,
+    dense: propTypes.bool,
+    disabled: propTypes.bool,
+    error: statusPropType,
+    helpText: propTypes.string,
+    initialFocus: propTypes.bool,
+    name: propTypes.string,
+    required: propTypes.bool,
     tabIndex: propTypes.string,
-
+    valid: statusPropType,
+    validationText: propTypes.string,
+    value: propTypes.string,
+    warning: statusPropType,
+    onBlur: propTypes.func,
     onChange: propTypes.func,
     onFocus: propTypes.func,
-    onBlur: propTypes.func,
-
-    checked: propTypes.bool,
-    disabled: propTypes.bool,
-    valid: statusPropType,
-    warning: statusPropType,
-    error: statusPropType,
-
-    dense: propTypes.bool,
-    initialFocus: propTypes.bool,
-    required: propTypes.bool,
-    helpText: propTypes.string,
-    validationText: propTypes.string,
-}
-ToggleField.propTypes = {
-    ...toggleFieldPropTypes,
-    toggleComponent: propTypes.func.isRequired,
 }
 
-export { ToggleField, toggleFieldPropTypes }
+export { ToggleField }

--- a/src/ToggleGroupField.js
+++ b/src/ToggleGroupField.js
@@ -6,6 +6,7 @@ import { Field } from './Field.js'
 import { FieldSet } from './FieldSet.js'
 import { Legend } from './Legend.js'
 import { Help } from './Help.js'
+import { statusPropType } from './common-prop-types.js'
 
 const ToggleGroupField = ({
     children,
@@ -74,11 +75,23 @@ const ToggleGroupField = ({
  * @prop {boolean} [required]
  */
 ToggleGroupField.propTypes = {
-    ...ToggleGroup.propTypes,
+    children: propTypes.node.isRequired,
+    className: propTypes.string,
+    dense: propTypes.bool,
+    disabled: propTypes.bool,
+    error: statusPropType,
     helpText: propTypes.string,
     label: propTypes.string,
+    name: propTypes.string,
     required: propTypes.bool,
+    valid: statusPropType,
     validationText: propTypes.string,
+    value: propTypes.oneOfType([
+        propTypes.string,
+        propTypes.arrayOf(propTypes.string),
+    ]),
+    warning: statusPropType,
+    onChange: propTypes.func,
 }
 
 export { ToggleGroupField }


### PR DESCRIPTION
Extracted the changes regarding the spreading of prop-types from https://github.com/dhis2/ui-core/pull/641, to clean that PR up.