### PR TITLE
refactor: move grouped styles to togglegroup component

### DIFF
--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -124,15 +124,6 @@ class Checkbox extends Component {
                         line-height: 20px;
                     }
 
-                    label.grouped,
-                    label.grouped.dense:first-of-type {
-                        padding-top: 4px;
-                    }
-
-                    label.grouped.dense {
-                        padding-top: 2px;
-                    }
-
                     label.dense {
                         font-size: 14px;
                         line-height: 16px;
@@ -142,6 +133,7 @@ class Checkbox extends Component {
                         cursor: not-allowed;
                         color: ${theme.disabled};
                     }
+
                     input {
                         opacity: 0;
                         pointer-events: none;

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -122,15 +122,6 @@ class Radio extends Component {
                         line-height: 20px;
                     }
 
-                    label.grouped,
-                    label.grouped.dense:first-of-type {
-                        padding-top: 4px;
-                    }
-
-                    label.grouped.dense {
-                        padding-top: 2px;
-                    }
-
                     label.dense {
                         font-size: 14px;
                         line-height: 16px;
@@ -140,6 +131,7 @@ class Radio extends Component {
                         cursor: not-allowed;
                         color: ${theme.disabled};
                     }
+
                     input {
                         opacity: 0;
                         pointer-events: none;

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -119,15 +119,6 @@ class Switch extends Component {
                         line-height: 20px;
                     }
 
-                    label.grouped,
-                    label.grouped.dense:first-of-type {
-                        padding-top: 4px;
-                    }
-
-                    label.grouped.dense {
-                        padding-top: 2px;
-                    }
-
                     label.dense {
                         font-size: 14px;
                         line-height: 16px;
@@ -137,6 +128,7 @@ class Switch extends Component {
                         cursor: not-allowed;
                         color: ${theme.disabled};
                     }
+
                     input {
                         opacity: 0;
                         pointer-events: none;

--- a/src/ToggleGroup.js
+++ b/src/ToggleGroup.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 import { Children, cloneElement } from 'react'
 
 import { statusPropType } from './common-prop-types.js'
+import { Spacer } from './ToggleGroup/Spacer.js'
 
 const ToggleGroup = ({
     children,
@@ -19,21 +20,23 @@ const ToggleGroup = ({
     dataTest,
 }) => (
     <div data-test={dataTest}>
-        {Children.map(children, child =>
-            cloneElement(child, {
-                name,
-                onChange: child.props.onChange || onChange,
-                checked: Array.isArray(value)
-                    ? value.indexOf(child.props.value) !== -1
-                    : child.props.value === value,
-                disabled: child.props.disabled || disabled,
-                valid: child.props.valid || valid,
-                warning: child.props.warning || warning,
-                error: child.props.error || error,
-                dense: child.props.dense || dense,
-                className: cx(child.props.className, className, 'grouped'),
-            })
-        )}
+        {Children.map(children, child => (
+            <Spacer dense={child.props.dense || dense}>
+                {cloneElement(child, {
+                    name,
+                    onChange: child.props.onChange || onChange,
+                    checked: Array.isArray(value)
+                        ? value.indexOf(child.props.value) !== -1
+                        : child.props.value === value,
+                    disabled: child.props.disabled || disabled,
+                    valid: child.props.valid || valid,
+                    warning: child.props.warning || warning,
+                    error: child.props.error || error,
+                    dense: child.props.dense || dense,
+                    className: cx(child.props.className, className),
+                })}
+            </Spacer>
+        ))}
     </div>
 )
 

--- a/src/ToggleGroup/Spacer.js
+++ b/src/ToggleGroup/Spacer.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+import cx from 'classnames'
+
+export const Spacer = ({ children, dense }) => (
+    <div className={cx({ dense })}>
+        {children}
+
+        <style jsx>{`
+            div,
+            div.dense:first-of-type {
+                padding-top: 4px;
+            }
+
+            div.dense {
+                padding-top: 2px;
+            }
+        `}</style>
+    </div>
+)
+
+Spacer.propTypes = {
+    children: propTypes.node.isRequired,
+    dense: propTypes.bool,
+}


### PR DESCRIPTION
https://jira.dhis2.org/browse/TECH-272

Closes #669

The first solution (first commit) relied on things that can't be enforced, and seemed slightly brittle (the dense class to detect dense child components, relying on there always being a label in the child).

The second solution (second commit, current state of the PR), is a little less easy to parse, but properly separates ToggleGroup from it's children. Everything it needs is clearly indicated with proptypes, I prefer that as a solution.