### PR TITLE
docs(specs): data-table feature specs

### DIFF
--- a/cypress/integration/DataTable/Clickable_header.feature
+++ b/cypress/integration/DataTable/Clickable_header.feature
@@ -1,0 +1,17 @@
+Feature: Clicking a sortable column header cell toggles sorting
+
+    Background:
+        Given a table with three or more rows is rendered
+        And all column headers have sorting enbaled
+
+    Scenario: User clicks a header cell that is not currently sorting the table
+        When a header cell is clicked
+        And the clicked header cell is not currently sorting the table
+        Then the table rows are sorted low to high by the content of that column
+        And the clicked header cell changes background color during the click
+
+    Scenario: User clicks a header cell that is currently sorting the table
+        When a header cell is clicked
+        And the clicked header cell is currently sorting the table
+        Then the table rows are sorted in the opposite direction by the content of that column
+        And the clicked header cell changes background color during the click

--- a/cypress/integration/DataTable/Draggable_rows.feature
+++ b/cypress/integration/DataTable/Draggable_rows.feature
@@ -1,0 +1,16 @@
+Feature: Drag and drop to reorder table rows
+
+    Background:
+        Given a table with three or more rows is rendered
+        And the table has 'drag to reorder' enabled
+
+    Scenario: The user clicks and drags a table row within the table body
+        When a table row is clicked and dragged
+        And the mouse cursor is inside the table body when the click is released
+        Then the table row is removed from its original position
+        And the table row is displayed in the table in the position closest to the mouse cursor
+
+    Scenario: The user clicks and drags a table row outside of the table body
+        When a table row is clicked and dragged
+        And the mouse cursor is outside the table body when the click is released
+        Then the table row is displayed in its original position

--- a/cypress/integration/DataTable/Editable_cell.feature
+++ b/cypress/integration/DataTable/Editable_cell.feature
@@ -1,0 +1,8 @@
+Feature: Editable table cells
+
+    Scenario: User clicks an editable table cell
+        Given a table with data
+        And one or more cell has 'editable' enabled
+        When the editable cell is clicked
+        Then a popover is opened
+        # note: the popover is empty, the editing controls are handled by the app

--- a/cypress/integration/DataTable/Expandable_rows.feature
+++ b/cypress/integration/DataTable/Expandable_rows.feature
@@ -1,0 +1,8 @@
+Feature: Expandable table rows
+
+    Scenario: User clicks an expandable table row
+        Given a table with one or more rows is rendered
+        And all the table rows have 'expandable' enabled
+        When the cell containing the expand-arrow icon in the table row is clicked
+        Then the expandable content of the table cell visibility is toggled
+        And the arrow icon is vertically flipped

--- a/cypress/integration/DataTable/Overflow_actions.feature
+++ b/cypress/integration/DataTable/Overflow_actions.feature
@@ -1,0 +1,7 @@
+Feature: Display overflow actions in a menu when clicked
+
+    Scenario: User clicks the overflow actions icon
+        Given a table with one or more rows is rendered
+        And the rows contain a overflow actions
+        When the overflow actions icon is clicked
+        Then a menu containing the row actions is rendered

--- a/cypress/integration/DataTable/Row_interaction.feature
+++ b/cypress/integration/DataTable/Row_interaction.feature
@@ -1,0 +1,11 @@
+Feature: Interaction with a table row
+
+    Scenario: The user clicks on a table row
+        Given a table with at least one row is rendered
+        When a table row is clicked
+        Then the background color of the clicked table row changes during the click
+
+    Scenario: The user hovers a table row
+        Given a table with at least one row is rendered
+        When a table row is hovered
+        Then the background color of the hovered table row changes

--- a/cypress/integration/DataTable/Row_sorting.feature
+++ b/cypress/integration/DataTable/Row_sorting.feature
@@ -1,0 +1,19 @@
+Feature: Sorting table rows
+
+    Scenario: Low to high sorting of alphanumerical data
+        Given a table with at least three rows of alphanumerical data is rendered
+        When a column is sorted low to high
+        And that column contains textual data
+        Then the rows are ordered alphanumerically by the content in that column
+
+    Scenario: High to low sorting of alphanumerical data
+        Given a table with at least three rows of alphanumerical data is rendered
+        When a column is sorted high to low
+        And that column contains textual data
+        Then the rows are ordered reverse alphanumerically by the content in that column
+        
+    # I'm not sure about this one? Trying to test for some kind of default ordering, so that rows are never displayed in a random order
+    Scenario: Default sorting display
+        Given a table with at least three rows of alphanumerical data is rendered
+        When no columns are used for sorting
+        Then the rows are ordered in the order the data was supplied

--- a/cypress/integration/DataTable/Selectable_rows.feature
+++ b/cypress/integration/DataTable/Selectable_rows.feature
@@ -1,0 +1,22 @@
+ Feature: Selectable table rows
+
+    Background:
+        Given a table with three or more table rows is rendered
+        And all table rows have 'selectable' enabled
+
+    Feature: User clicks a table row checkbox
+        When the checkbox inside a table row is clicked
+        Then the selected state of the table row is toggled
+        And the background color of the table row changes
+
+    Feature: User clicks the header row checkbox with some rows unselected
+        Given there are rows in the table that are unselected
+        When the checkbox inside the header row is clicked
+        Then all of the table rows are selected
+        And the checkbox in the header row is displayed selected
+
+    Feature: User clicks the header row checkbox with all rows selected
+        Given all rows in the table are selected
+        When the checkbox inside the header row is clicked
+        Then all of the table rows are deselected
+        And the checkbox in the header row is displayed unselected


### PR DESCRIPTION
Feature files for the data table. 

Reference: [HTML & CSS mockup of all data table styles/functions](https://codesandbox.io/s/table-styles-bvf5r)

These .feature files cover the behaviour of the data table and it's varied functions. I have not included what I consider to be 'options', because I didn't think they were classified as behaviour. For example, the .feature files do not cover:
- displaying a header or a footer
- displaying table actions (the app defines table actions, so there would be no inherent behaviour except for 'display a button'. Perhaps that counts? `Given there are actions passed to the table, Then a button for each action is displayed in the header` for example.)
- bordered cells
- status badges
- empty states

The main functionality that I did not cover that I think *should* be covered is filtering. However, I think a proper discussion is warranted as to the level of filtering functionality that will be provided with this component (none, perhaps).

Feedback much appreciated on the .feature files and the points above.

(I also created a `feat` branch for this to be merged into. I figured all data-table related stuff can live there).