### PR TITLE
chore: introduce child-prop-validator

### DIFF
--- a/src/CheckboxGroup.js
+++ b/src/CheckboxGroup.js
@@ -3,6 +3,7 @@ import propTypes from '@dhis2/prop-types'
 
 import { statusPropType } from './common-prop-types.js'
 import { ToggleGroup } from './ToggleGroup.js'
+import { Checkbox } from './Checkbox.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -68,8 +69,35 @@ CheckboxGroup.defaultProps = {
  * @prop {boolean} [dense]
  * @prop {string} [dataTest]
  */
+
+const childWithPropTypes = propDefinition => (children, index) => {
+    const child = children[index]
+    const childPropDefinition = child.type.propTypes
+
+    for (const key in propDefinition) {
+        const prop = propDefinition[key]
+        const childProp = childPropDefinition[key]
+
+        if (prop !== childProp) {
+            return new Error(
+                `Child does not implement the required props API for ${key}`
+            )
+        }
+    }
+
+    return undefined
+}
+
 CheckboxGroup.propTypes = {
-    children: propTypes.arrayOf(propTypes.element).isRequired,
+    children: propTypes.arrayOf(
+        childWithPropTypes({
+            value: Checkbox.propTypes.value,
+            onChange: propTypes.func,
+            // checked: Checkbox.propTypes.checked,
+            checked: propTypes.bool,
+        })
+    ).isRequired,
+
     className: propTypes.string,
     dataTest: propTypes.string,
     dense: propTypes.bool,

--- a/src/ToggleGroup.js
+++ b/src/ToggleGroup.js
@@ -4,7 +4,6 @@ import cx from 'classnames'
 import { Children, cloneElement } from 'react'
 
 import { statusPropType } from './common-prop-types.js'
-import { Spacer } from './ToggleGroup/Spacer.js'
 
 const ToggleGroup = ({
     children,
@@ -20,23 +19,32 @@ const ToggleGroup = ({
     dataTest,
 }) => (
     <div data-test={dataTest}>
-        {Children.map(children, child => (
-            <Spacer dense={child.props.dense || dense}>
-                {cloneElement(child, {
-                    name,
-                    onChange: child.props.onChange || onChange,
-                    checked: Array.isArray(value)
-                        ? value.indexOf(child.props.value) !== -1
-                        : child.props.value === value,
-                    disabled: child.props.disabled || disabled,
-                    valid: child.props.valid || valid,
-                    warning: child.props.warning || warning,
-                    error: child.props.error || error,
-                    dense: child.props.dense || dense,
-                    className: cx(child.props.className, className),
-                })}
-            </Spacer>
-        ))}
+        {Children.map(children, child =>
+            cloneElement(child, {
+                name,
+                onChange: child.props.onChange || onChange,
+                checked: Array.isArray(value)
+                    ? value.indexOf(child.props.value) !== -1
+                    : child.props.value === value,
+                disabled: child.props.disabled || disabled,
+                valid: child.props.valid || valid,
+                warning: child.props.warning || warning,
+                error: child.props.error || error,
+                dense: child.props.dense || dense,
+                className: cx(child.props.className, className),
+            })
+        )}
+
+        <style jsx>{`
+            div :global(label),
+            div :global(label.dense:first-of-type) {
+                padding-top: 4px;
+            }
+
+            div :global(label.dense) {
+                padding-top: 2px;
+            }
+        `}</style>
     </div>
 )
 

--- a/src/ToggleGroup.js
+++ b/src/ToggleGroup.js
@@ -21,7 +21,7 @@ const ToggleGroup = ({
 }) => (
     <div data-test={dataTest}>
         {Children.map(children, child => (
-            <Spacer dense={child.props.dense}>
+            <Spacer dense={child.props.dense || dense}>
                 {cloneElement(child, {
                     name,
                     onChange: child.props.onChange || onChange,

--- a/src/ToggleGroup.js
+++ b/src/ToggleGroup.js
@@ -4,6 +4,7 @@ import cx from 'classnames'
 import { Children, cloneElement } from 'react'
 
 import { statusPropType } from './common-prop-types.js'
+import { Spacer } from './ToggleGroup/Spacer.js'
 
 const ToggleGroup = ({
     children,
@@ -19,32 +20,23 @@ const ToggleGroup = ({
     dataTest,
 }) => (
     <div data-test={dataTest}>
-        {Children.map(children, child =>
-            cloneElement(child, {
-                name,
-                onChange: child.props.onChange || onChange,
-                checked: Array.isArray(value)
-                    ? value.indexOf(child.props.value) !== -1
-                    : child.props.value === value,
-                disabled: child.props.disabled || disabled,
-                valid: child.props.valid || valid,
-                warning: child.props.warning || warning,
-                error: child.props.error || error,
-                dense: child.props.dense || dense,
-                className: cx(child.props.className, className),
-            })
-        )}
-
-        <style jsx>{`
-            div :global(label),
-            div :global(label.dense:first-of-type) {
-                padding-top: 4px;
-            }
-
-            div :global(label.dense) {
-                padding-top: 2px;
-            }
-        `}</style>
+        {Children.map(children, child => (
+            <Spacer dense={child.props.dense}>
+                {cloneElement(child, {
+                    name,
+                    onChange: child.props.onChange || onChange,
+                    checked: Array.isArray(value)
+                        ? value.indexOf(child.props.value) !== -1
+                        : child.props.value === value,
+                    disabled: child.props.disabled || disabled,
+                    valid: child.props.valid || valid,
+                    warning: child.props.warning || warning,
+                    error: child.props.error || error,
+                    dense: child.props.dense || dense,
+                    className: cx(child.props.className, className),
+                })}
+            </Spacer>
+        ))}
     </div>
 )
 


### PR DESCRIPTION
### **IMPORTANT NOTICE**
**This isn't intended to ever get merged into ui-core. If we were to do something with this, it would have to be via `@dhis2/prop-types`.**

### Context
In #684 we discussed loose coupling between parent and child components when the parent calls `cloneElement` on the children. A possible way to enforce "a contract" between the two would be:
> We could implement runtime checks if the passed in components meet the props share criteria (we could also write a prop type that checks that a certain api has been implemented, so it's component independent)

_(I'm quoting @Mohammer5 here, but he and I both had the same idea)_

So in this PR I have explored the possibility to do so.

### Findings
Initially I was thinking I could verify the actual props on the child component. This was a not a good approach: we shouldn't be checking if the child _**has a value**_ for a given prop, we should be checking if the component _**could receive**_ a given prop.

There is no 100% accurate way to check this for components that haven't implemented propTypes, but for ones that have we can verify that the child component propType difinitions match the ones we have fed to the `childWithPropTypes` function. So in theory, this could be a viable approach from that perspective...

However, when I tried to get this to work for the `CheckboxGroup`, I soon hit a snag.... First I'll try to explain things step-by step:

This part is trying to express: "We want all children that are passed to this component to have at least the following props, otherwise the CheckboxGroup will break". Not sure if this is technically true, it's just an example...
```javascript
        childWithPropTypes({
            value: Checkbox.propTypes.value,
            onChange: propTypes.func,
            // checked: Checkbox.propTypes.checked,
            checked: propTypes.bool,
        })
```

So... all of this is working quite well for the `value` and the `onChange` property: you can either pick a prop from the propTypes of the child you are expecting, or you can just use a propType directly.

But the `checked` prop presents a challenge.... From the perspective of the `ToggleGroup` this can just be a boolean. However, from the perspective of the `Checkbox` it is relevant that this prop is mutuallyExclusive with the `indeterminate` prop, so it is defined like this:
```javascript
const uniqueOnStatePropType = propTypes.mutuallyExclusive(
    ['checked', 'indeterminate'],
    propTypes.bool
)

Checkbox.propTypes = {
    // ...
    checked: uniqueOnStatePropType,
    // ...
    indeterminate: uniqueOnStatePropType,
    // ...
}
```

Obviously `uniqueOnStatePropType !== propTypes.bool` so using `checked: propTypes.bool,` in the call to `childWithPropTypes` will result in a false positive: we'll get an error but actually this child component `Checkbox` can work wel within a `CheckboxGroup`/`ToggleGroup`...

To at least get the `Checkbox` to be a valid child for `CheckboxGroup`, we'd also have to switch to using the same validator as the Checkbox does for `checked`, so we'd get:
```javascript
checked: Checkbox.propTypes.checked
```
Effectively this would mean that if anyone ever wanted to make a custom `Checkbox` and put it into a `CheckboxGroup`, they'd have to import the ui-core `Checkbox` purely to use the propType...

### Conclusion
I feel this current implementation definitely is NOT a solution for anything...

I'm leaving the code here unchanged, but I do have a slightly improved version in another PR.... So read on in https://github.com/dhis2/ui-core/pull/691