### PR TITLE
chore: allow multiple types per child prop-type

### DIFF
--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -219,4 +219,4 @@ Checkbox.propTypes = {
     onFocus: propTypes.func,
 }
 
-export { Checkbox }
+export { Checkbox, uniqueOnStatePropType }

--- a/src/CheckboxGroup.js
+++ b/src/CheckboxGroup.js
@@ -3,7 +3,7 @@ import propTypes from '@dhis2/prop-types'
 
 import { statusPropType } from './common-prop-types.js'
 import { ToggleGroup } from './ToggleGroup.js'
-import { Checkbox } from './Checkbox.js'
+import { uniqueOnStatePropType } from './Checkbox.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -77,8 +77,11 @@ const childWithPropTypes = propDefinition => (children, index) => {
     for (const key in propDefinition) {
         const prop = propDefinition[key]
         const childProp = childPropDefinition[key]
+        const isValid = Array.isArray(prop)
+            ? prop.some(p => p === childProp)
+            : prop === childProp
 
-        if (prop !== childProp) {
+        if (!isValid) {
             return new Error(
                 `Child does not implement the required props API for ${key}`
             )
@@ -91,10 +94,9 @@ const childWithPropTypes = propDefinition => (children, index) => {
 CheckboxGroup.propTypes = {
     children: propTypes.arrayOf(
         childWithPropTypes({
-            value: Checkbox.propTypes.value,
+            value: propTypes.string,
             onChange: propTypes.func,
-            // checked: Checkbox.propTypes.checked,
-            checked: propTypes.bool,
+            checked: [uniqueOnStatePropType, propTypes.bool],
         })
     ).isRequired,
 


### PR DESCRIPTION
### **IMPORTANT NOTICE**
**This isn't intended to ever get merged into ui-core. If we were to do something with this, it would have to be via `@dhis2/prop-types`.**

### Context
This is a continuation of https://github.com/dhis2/ui-core/pull/690, some things have improved:
- You can now assign arrays of propTypes to the properties of the `childWithPropTypes` payload object
- If this validator encounters them, it will check if the child propType matches any and if so, it will allow it.

So this at least fixes the actual problem I encountered and described in my previous draft PR.

But I wonder if this now makes this into a fully robust solution. Is this a bulletproof way to check if a child component has implemented the correct API or not?

I can imagine that if a developer were to implement a custom Checkbox, and that Checkbox were to have a custom prop-validator for its `checked` property, we'd still have a problem. Unless the developer were to override the `CheckboxGroup.propTypes.children` prop after importing it. (and that'd be pretty hacky). 

### Conclusions
Personally, I'm still not quite sure what to do with this.... I've got a feeling that I still haven't considered a lot of cases, like conditional rendering, mapping, etc. And I don't feel confident that this is something we will ever be able to completely "get right". We are still leaning on quite a few assumptions:
- That the child will have propTypes in the first place
- That the child uses the same (as in referential equality) prop-type functions as the parent

### Implications for past work
Suppose we cannot enforce a "contract between a parent and child" in this (or a different way)... Then we have some components with interdependencies that are not enforced in any way. And if this is true, then we have to accept that we are dependent on the developer doing the right thing...  And if we accept that, I think that doesn't justify the introduction of a wrapper `<div/>` around the `<label/>` in the `ToggleGroup`, because that only decouples the style. I see no point in doing so, if the more significant aspect of the loose coupling is still present, and completely brittle/unenforced.

So IMO that means we should have gone for this implementation https://github.com/dhis2/ui-core/pull/690/commits/e081e32131ed96cea72e66cc6f1fb5567978748b and NOT this one https://github.com/dhis2/ui-core/pull/690/commits/66ebc9d14d81e607ce20ef597e328d7212eefcf1

