### PR TITLE
feat(select): append loading spinner to children instead of replacing

### DIFF
--- a/cypress/integration/MultiSelect/Accepts_loading.feature
+++ b/cypress/integration/MultiSelect/Accepts_loading.feature
@@ -4,11 +4,11 @@ Feature: Loading status
         Given a MultiSelect with options and a loading flag is rendered
         When the MultiSelect input is clicked
         Then the loading spinner is displayed
-        And the options are not displayed
+        And the options are displayed
 
     Scenario: The user opens a loading MultiSelect with a loading text
         Given a MultiSelect with options, a loading flag and a loading text is rendered
         When the MultiSelect input is clicked
         Then the loading spinner is displayed
         And the loading text is displayed
-        And the options are not displayed
+        And the options are displayed

--- a/cypress/integration/MultiSelect/Can_be_opened_and_closed/index.js
+++ b/cypress/integration/MultiSelect/Can_be_opened_and_closed/index.js
@@ -1,5 +1,5 @@
 import '../common'
-import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+import { Given, When } from 'cypress-cucumber-preprocessor/steps'
 
 Given('the MultiSelect is closed', () => {
     cy.contains('option one').should('not.exist')
@@ -25,10 +25,4 @@ When('the up arrowkey is pressed on the focused element', () => {
 
 When('the escape key is pressed on the focused element', () => {
     cy.focused().type('{esc}')
-})
-
-Then('the options are displayed', () => {
-    cy.contains('option one').should('be.visible')
-    cy.contains('option two').should('be.visible')
-    cy.contains('option three').should('be.visible')
 })

--- a/cypress/integration/MultiSelect/common/index.js
+++ b/cypress/integration/MultiSelect/common/index.js
@@ -34,6 +34,12 @@ Then('the options are not displayed', () => {
     cy.contains('option three').should('not.be.visible')
 })
 
+Then('the options are displayed', () => {
+    cy.contains('option one').should('be.visible')
+    cy.contains('option two').should('be.visible')
+    cy.contains('option three').should('be.visible')
+})
+
 Then('the MultiSelect has focus', () => {
     cy.focused()
         .parents('.select')

--- a/cypress/integration/SingleSelect/Accepts_loading.feature
+++ b/cypress/integration/SingleSelect/Accepts_loading.feature
@@ -4,11 +4,11 @@ Feature: Loading status
         Given a SingleSelect with options and a loading flag is rendered
         When the SingleSelect input is clicked
         Then the loading spinner is displayed
-        And the options are not displayed
+        And the options are displayed
 
     Scenario: The user opens a loading SingleSelect with a loading text
         Given a SingleSelect with options, a loading flag and a loading text is rendered
         When the SingleSelect input is clicked
         Then the loading spinner is displayed
         And the loading text is displayed
-        And the options are not displayed
+        And the options are displayed

--- a/cypress/integration/SingleSelect/Can_be_opened_and_closed/index.js
+++ b/cypress/integration/SingleSelect/Can_be_opened_and_closed/index.js
@@ -1,5 +1,5 @@
 import '../common'
-import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+import { Given, When } from 'cypress-cucumber-preprocessor/steps'
 
 Given('the SingleSelect is closed', () => {
     cy.contains('option one').should('not.exist')
@@ -25,10 +25,4 @@ When('the up arrowkey is pressed on the focused element', () => {
 
 When('the escape key is pressed on the focused element', () => {
     cy.focused().type('{esc}')
-})
-
-Then('the options are displayed', () => {
-    cy.contains('option one').should('be.visible')
-    cy.contains('option two').should('be.visible')
-    cy.contains('option three').should('be.visible')
 })

--- a/cypress/integration/SingleSelect/common/index.js
+++ b/cypress/integration/SingleSelect/common/index.js
@@ -34,6 +34,12 @@ Then('the options are not displayed', () => {
     cy.contains('option three').should('not.be.visible')
 })
 
+Then('the options are displayed', () => {
+    cy.contains('option one').should('be.visible')
+    cy.contains('option two').should('be.visible')
+    cy.contains('option three').should('be.visible')
+})
+
 Then('the SingleSelect has focus', () => {
     cy.focused()
         .parents('.select')

--- a/src/MultiSelect.js
+++ b/src/MultiSelect.js
@@ -87,7 +87,8 @@ const MultiSelect = ({
                     initialFocus={initialFocus}
                     dense={dense}
                 >
-                    {loading ? <Loading message={loadingText} /> : children}
+                    {children}
+                    {loading && <Loading message={loadingText} />}
                 </Select>
             </div>
             <StatusIcon error={error} valid={valid} warning={warning} />

--- a/src/MultiSelect/Menu.js
+++ b/src/MultiSelect/Menu.js
@@ -2,7 +2,12 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { multiSelectedPropType } from '../common-prop-types.js'
 import { Empty } from '../Select/Empty.js'
-import { removeOption, findOption } from '../Select/option-helpers.js'
+import {
+    filterIgnored,
+    checkIfValidOption,
+    removeOption,
+    findOption,
+} from '../Select/option-helpers.js'
 
 const onDisabledClick = (_, e) => {
     e.stopPropagation()
@@ -33,7 +38,9 @@ const createHandler = ({ isActive, onChange, selected, value, label }) => (
 }
 
 const Menu = ({ options, onChange, selected, empty }) => {
-    if (React.Children.count(options) === 0) {
+    const renderedOptions = filterIgnored(options)
+
+    if (React.Children.count(renderedOptions) === 0) {
         // If it's a string, supply it to our <Empty> component so it looks better
         if (typeof empty === 'string') {
             return <Empty message={empty} />
@@ -44,8 +51,7 @@ const Menu = ({ options, onChange, selected, empty }) => {
     }
 
     const children = React.Children.map(options, child => {
-        const isValidOption =
-            child.props && 'value' in child.props && 'label' in child.props
+        const isValidOption = checkIfValidOption(child)
 
         // Return early if the child isn't an option, to prevent attaching handlers etc.
         if (!isValidOption) {

--- a/src/MultiSelectOption.js
+++ b/src/MultiSelectOption.js
@@ -27,8 +27,14 @@ const MultiSelectOption = ({
     onClick,
     className,
     dataTest,
+    value,
 }) => (
-    <div className={cx(className, { disabled })} data-test={dataTest}>
+    <div
+        className={cx(className, { disabled })}
+        data-test={dataTest}
+        data-value={value}
+        data-label={label}
+    >
         <Checkbox
             name={label}
             className={checkboxClassname}
@@ -72,8 +78,6 @@ MultiSelectOption.defaultProps = {
  */
 MultiSelectOption.propTypes = {
     label: propTypes.string.isRequired,
-    // This prop is used by the Select, so still necessary
-    // eslint-disable-next-line react/no-unused-prop-types
     value: propTypes.string.isRequired,
     active: propTypes.bool,
     className: propTypes.string,

--- a/src/Select/FilterableMenu.js
+++ b/src/Select/FilterableMenu.js
@@ -6,6 +6,7 @@ import {
 } from '../common-prop-types.js'
 import { FilterInput } from '../Select/FilterInput.js'
 import { NoMatch } from '../Select/NoMatch.js'
+import { filterIgnored, checkIfValidOption } from '../Select/option-helpers.js'
 
 export class FilterableMenu extends Component {
     state = {
@@ -37,8 +38,10 @@ export class FilterableMenu extends Component {
             handleFocusInput,
         }
 
+        const renderedOptions = filterIgnored(options)
+
         // If there are no options or there's no filter, just pass everything through
-        if (React.Children.count(options) === 0 || !filter) {
+        if (React.Children.count(renderedOptions) === 0 || !filter) {
             return (
                 <React.Fragment>
                     <FilterInput
@@ -52,8 +55,7 @@ export class FilterableMenu extends Component {
         }
 
         const filtered = React.Children.map(options, child => {
-            const isValidOption =
-                child.props && 'value' in child.props && 'label' in child.props
+            const isValidOption = checkIfValidOption(child)
 
             // Filter it out if it's an invalid option
             if (!isValidOption) {

--- a/src/Select/MenuWrapper.js
+++ b/src/Select/MenuWrapper.js
@@ -25,7 +25,7 @@ const MenuWrapper = ({
     `
     return ReactDOM.createPortal(
         <Backdrop onClick={onClick} transparent zIndex={zIndex}>
-            <div className={className} ref={menuRef} dataTest={dataTest}>
+            <div className={className} ref={menuRef} data-test={dataTest}>
                 <Card className={cardClassName}>{children}</Card>
 
                 {styles}

--- a/src/Select/option-helpers.js
+++ b/src/Select/option-helpers.js
@@ -1,5 +1,18 @@
 import React from 'react'
 
+// Check whether an option is valid
+export const checkIfValidOption = option =>
+    option &&
+    'props' in option &&
+    'value' in option.props &&
+    'label' in option.props
+
+// Filters all children that won't be rendered from an array of react children
+export const filterIgnored = children =>
+    React.Children.toArray(children).filter(
+        child => child !== null && child !== false && child !== undefined
+    )
+
 // Find an option in an array of react children
 export const findOptionChild = (targetOption, optionChildren) =>
     React.Children.toArray(optionChildren).find(currentOption => {
@@ -22,7 +35,7 @@ export const findOption = (targetOption, optionArray) =>
         return matchesLabel && matchesValue
     })
 
-// Remove an option from an array of options
+// Remove a specific option from an array of options
 export const removeOption = (targetOption, optionArray) =>
     optionArray.filter(currentOption => {
         const matchesLabel = targetOption.label === currentOption.label

--- a/src/SingleSelect.js
+++ b/src/SingleSelect.js
@@ -87,7 +87,8 @@ const SingleSelect = ({
                     initialFocus={initialFocus}
                     dense={dense}
                 >
-                    {loading ? <Loading message={loadingText} /> : children}
+                    {children}
+                    {loading && <Loading message={loadingText} />}
                 </Select>
             </div>
             <StatusIcon error={error} valid={valid} warning={warning} />

--- a/src/SingleSelect/Menu.js
+++ b/src/SingleSelect/Menu.js
@@ -2,6 +2,7 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { singleSelectedPropType } from '../common-prop-types.js'
 import { Empty } from '../Select/Empty.js'
+import { filterIgnored, checkIfValidOption } from '../Select/option-helpers.js'
 
 const onIgnoredClick = (_, e) => {
     e.stopPropagation()
@@ -16,7 +17,9 @@ const Menu = ({
     handleFocusInput,
     handleClose,
 }) => {
-    if (React.Children.count(options) === 0) {
+    const renderedOptions = filterIgnored(options)
+
+    if (React.Children.count(renderedOptions) === 0) {
         // If it's a string, supply it to our <Empty> component so it looks better
         if (typeof empty === 'string') {
             return <Empty message={empty} />
@@ -27,8 +30,7 @@ const Menu = ({
     }
 
     const children = React.Children.map(options, child => {
-        const isValidOption =
-            child.props && 'value' in child.props && 'label' in child.props
+        const isValidOption = checkIfValidOption(child)
 
         // Return early if the child isn't an option, to prevent attaching handlers etc.
         if (!isValidOption) {

--- a/src/SingleSelect/Selection.js
+++ b/src/SingleSelect/Selection.js
@@ -6,10 +6,6 @@ import { spacers } from '../theme.js'
 import { findOptionChild } from '../Select/option-helpers.js'
 
 const Selection = ({ options, selected, className }) => {
-    if (React.Children.count(options) === 0) {
-        return null
-    }
-
     const selectedOption = findOptionChild(selected, options)
 
     if (!selectedOption) {

--- a/src/SingleSelectOption.js
+++ b/src/SingleSelectOption.js
@@ -21,6 +21,7 @@ const SingleSelectOption = ({
     onClick,
     className,
     dataTest,
+    value,
 }) => (
     <div
         className={cx(className, {
@@ -29,6 +30,8 @@ const SingleSelectOption = ({
         })}
         onClick={e => onClick({}, e)}
         data-test={dataTest}
+        data-value={value}
+        data-label={label}
     >
         {label}
 
@@ -83,8 +86,6 @@ SingleSelectOption.defaultProps = {
  */
 SingleSelectOption.propTypes = {
     label: propTypes.string.isRequired,
-    // This prop is used by the Select, so still necessary
-    // eslint-disable-next-line react/no-unused-prop-types
     value: propTypes.string.isRequired,
     active: propTypes.bool,
     className: propTypes.string,


### PR DESCRIPTION
This changes the behaviour of the loading spinner. When enabled, it'll be appended to the children, instead of replacing them. See this discussion: https://dhis2.slack.com/archives/CBM8LNEQM/p1577954451004500

It looks like this:

<img width="1042" alt="Screenshot 2020-01-06 at 14 14 02" src="https://user-images.githubusercontent.com/7355199/71820191-c661aa00-308e-11ea-8ccb-18c54c48f920.png">
<img width="1038" alt="Screenshot 2020-01-06 at 14 14 18" src="https://user-images.githubusercontent.com/7355199/71820192-c661aa00-308e-11ea-9fd6-e6c9037576d2.png">

Todo:

- [x] Check if there are other areas that could use the new helpers (input)
- [x] Check if Select can handle null, undefined, etc. properly (later on)
- [x] Check consequences of current changes for other areas of the select