### PR TITLE
feat(component-cover): introduce transparent mode and fix styles

### DIFF
--- a/src/ComponentCover.js
+++ b/src/ComponentCover.js
@@ -10,9 +10,17 @@ import { layers } from './theme.js'
  * @example import { ComponentCover } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/componentcover--circularloader|Storybook}
  */
-const ComponentCover = ({ children, className, dataTest }) => (
+const ComponentCover = ({ children, className, dataTest, transparent }) => (
     <div className={className} data-test={dataTest}>
         {children}
+        <style jsx>{`
+            div {
+                background: ${transparent
+                    ? 'transparent'
+                    : 'rgba(33, 43, 54, 0.4)'};
+                z-index: ${layers.applicationTop - 1};
+            }
+        `}</style>
         <style jsx>{`
             div {
                 display: flex;
@@ -20,12 +28,10 @@ const ComponentCover = ({ children, className, dataTest }) => (
                 justify-content: center;
 
                 position: absolute;
-
-                height: inherit;
-                width: inherit;
-
-                z-index: ${layers.applicationTop - 1};
-                background: rgba(33, 43, 54, 0.4);
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
             }
         `}</style>
     </div>
@@ -41,11 +47,13 @@ ComponentCover.defaultProps = {
  * @prop {string} [className]
  * @prop {Node} [children]
  * @prop {string} [dataTest]
+ * @prop {boolean} [transparent]
  */
 ComponentCover.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    transparent: propTypes.bool,
 }
 
 export { ComponentCover }

--- a/stories/ComponentCover.stories.js
+++ b/stories/ComponentCover.stories.js
@@ -4,7 +4,7 @@ import { CircularLoader, ComponentCover, Card } from '../src'
 
 storiesOf('ComponentCover', module)
     .add('CircularLoader', () => (
-        <div style={{ width: '400px', height: '400px' }}>
+        <div style={{ width: '400px', height: '400px', position: 'relative' }}>
             <ComponentCover>
                 <CircularLoader />
             </ComponentCover>
@@ -14,8 +14,30 @@ storiesOf('ComponentCover', module)
         </div>
     ))
 
+    .add('CircularLoader - transparent', () => (
+        <div
+            style={{
+                width: '400px',
+                height: '400px',
+                border: '1px solid grey',
+                position: 'relative',
+            }}
+        >
+            <ComponentCover transparent>
+                <CircularLoader />
+            </ComponentCover>
+        </div>
+    ))
+
     .add('Modal', () => (
-        <div style={{ width: '400px', height: '400px', background: 'purple' }}>
+        <div
+            style={{
+                width: '400px',
+                minHeight: '400px',
+                background: 'purple',
+                position: 'relative',
+            }}
+        >
             <ComponentCover>
                 <div style={{ width: '200px', height: '200px' }}>
                     <Card>Some text.</Card>


### PR DESCRIPTION
### `transparent` prop
As [discussed on slack](https://dhis2.slack.com/archives/CBM8LNEQM/p1579163079038000?thread_ts=1579105721.036000&cid=CBM8LNEQM), I've added a `transparent` prop that makes the background transparent. The prop-name is still up for debate, especially @ismay expressed a desire to change this, so hoping for suggestions here.

### Styles
I've discussed this with @varl on Slack. In a nutshell, the current solution is very brittle, and only works for parents with a fixed height/width. The solution implemented in this PR also comes with a prerequisite: the parent needs to have a non-static position. On balance, I think this is a prerequisite that is easier to fulfil than the fixed height/width one, so I would say this is an improvement.

----------------

Below is a summary of some things I tried (I've just copy-pasted this from my Slack discussion with Viktor):

The implementation of the `ComponentCover` in `master` breaks if, in the parent element in `/story/componentcover--modal` has the following changes (currently `height: '400px'`):
- `minHeight: '400px'` (breaks badly)
- `height: '50%'` (breaks a little bit)
- `display: flex` (breaks badly)

What does work is `height: '50vh'`. This is consistent with what I regard as a “fixed” height in CSS: percentages are relative to a given parent, so dynamic. `vh` is just a fraction of a fixed amount, so fixed.

Now, switching to the top/right/bottom/left=0 implementation on my branch, I find that the story in its current form is broken pretty badly. We need to fix this by adding `position: 'relative'` to the parent. I’ll list the same examples I tried for the current approach:
- fixed height (i.e. current example, 400px) works
- relative height (i.e. 50%): works
- minHeight: works
- flexbox layout (i.e. display: flex): works
**But these ALL requires `position: 'relative'` to be added to the parent** (any non-static form of positioning would work)

I think this summary covers the most important scenarios. I’ve only focussed on height related stuff, but the same would obviously apply to width related styles.

Having to add a non-static position to the parent, could possibly be problematic in some scenarios. I.e. we’ve seen some interference between sticky and relative positioning when building the Select…. So I won’t claim that this new solution is 100% perfect.

However, the current solution requires a static height/width on the parent, and that’s a prerequisite that can’t be fulfilled very often.

So, on balance the new implementation is an improvement over the current.
