### PR TITLE
test: use clicks to focus components

### DIFF
--- a/cypress/integration/Checkbox/Can_be_focused/index.js
+++ b/cypress/integration/Checkbox/Can_be_focused/index.js
@@ -11,7 +11,7 @@ Given('a Checkbox with onFocus handler is rendered', () => {
 })
 
 When('the Checkbox is focused', () => {
-    cy.get('[data-test="dhis2-uicore-checkbox"] input').focus()
+    cy.get('[data-test="dhis2-uicore-checkbox"]').click()
 })
 
 Then('the onFocus handler is called', () => {

--- a/cypress/integration/Input/Can_be_focused/index.js
+++ b/cypress/integration/Input/Can_be_focused/index.js
@@ -11,7 +11,7 @@ Given('a Input with onFocus handler is rendered', () => {
 })
 
 When('the Input is focused', () => {
-    cy.get('[data-test="dhis2-uicore-input"] input').focus()
+    cy.get('[data-test="dhis2-uicore-input"]').click()
 })
 
 Then('the onFocus handler is called', () => {

--- a/cypress/integration/Radio/Can_be_focused/index.js
+++ b/cypress/integration/Radio/Can_be_focused/index.js
@@ -11,7 +11,7 @@ Given('a Radio with onFocus handler is rendered', () => {
 })
 
 When('the Radio is focused', () => {
-    cy.get('[data-test="dhis2-uicore-radio"] input').focus()
+    cy.get('[data-test="dhis2-uicore-radio"]').click()
 })
 
 Then('the onFocus handler is called', () => {

--- a/cypress/integration/Switch/Can_be_focused/index.js
+++ b/cypress/integration/Switch/Can_be_focused/index.js
@@ -11,7 +11,7 @@ Given('a Switch with onFocus handler is rendered', () => {
 })
 
 When('the Switch is focused', () => {
-    cy.get('[data-test="dhis2-uicore-switch"] input').focus()
+    cy.get('[data-test="dhis2-uicore-switch"]').click()
 })
 
 Then('the onFocus handler is called', () => {

--- a/cypress/integration/TextArea/Can_be_focused/index.js
+++ b/cypress/integration/TextArea/Can_be_focused/index.js
@@ -12,7 +12,7 @@ Given('a TextArea with onFocus handler is rendered', () => {
 })
 
 When('the TextArea is focused', () => {
-    cy.get('[data-test="dhis2-uicore-textarea"] textarea').focus()
+    cy.get('[data-test="dhis2-uicore-textarea"]').click()
 })
 
 Then('the onFocus handler is called', () => {


### PR DESCRIPTION
https://jira.dhis2.org/browse/TECH-280

Ideally we'd focus with a tab, since that won't trigger an action for elements like checkboxes, radios, etc. Maybe we should hold off on changing this until we can use tabs.