### PR TITLE
refactor: use inline content for required indicator

### DIFF
--- a/cypress/integration/CheckboxField/Can_be_required.feature
+++ b/cypress/integration/CheckboxField/Can_be_required.feature
@@ -1,0 +1,5 @@
+Feature: Required status for the CheckboxField
+
+    Scenario: Rendering a CheckboxField that is required
+        Given a CheckboxField with label and a required flag is rendered
+        Then the required indicator is visible

--- a/cypress/integration/CheckboxField/Can_be_required/index.js
+++ b/cypress/integration/CheckboxField/Can_be_required/index.js
@@ -1,0 +1,11 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a CheckboxField with label and a required flag is rendered', () => {
+    cy.visitStory('CheckboxField', 'With label and required')
+})
+
+Then('the required indicator is visible', () => {
+    cy.get('[data-test="dhis2-uicore-checkboxfield-required"]').should(
+        'be.visible'
+    )
+})

--- a/cypress/integration/CheckboxGroupField/Can_be_required.feature
+++ b/cypress/integration/CheckboxGroupField/Can_be_required.feature
@@ -1,0 +1,5 @@
+Feature: Required status for the CheckboxGroupField
+
+    Scenario: Rendering a CheckboxGroupField that is required
+        Given a CheckboxGroupField with label and a required flag is rendered
+        Then the required indicator is visible

--- a/cypress/integration/CheckboxGroupField/Can_be_required/index.js
+++ b/cypress/integration/CheckboxGroupField/Can_be_required/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a CheckboxGroupField with label and a required flag is rendered', () => {
+    cy.visitStory('CheckboxGroupField', 'With label and required')
+})
+
+Then('the required indicator is visible', () => {
+    cy.get('[data-test="dhis2-uicore-legend-required"]').should('be.visible')
+})

--- a/cypress/integration/FileInputField/Can_be_required.feature
+++ b/cypress/integration/FileInputField/Can_be_required.feature
@@ -1,0 +1,5 @@
+Feature: Required status for the FileInputField
+
+    Scenario: Rendering a FileInputField that is required
+        Given a FileInputField with label and a required flag is rendered
+        Then the required indicator is visible

--- a/cypress/integration/FileInputField/Can_be_required/index.js
+++ b/cypress/integration/FileInputField/Can_be_required/index.js
@@ -1,7 +1,7 @@
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
-Given('a SingleSelectField with label and a required flag is rendered', () => {
-    cy.visitStory('SingleSelectField', 'With label and required status')
+Given('a FileInputField with label and a required flag is rendered', () => {
+    cy.visitStory('FileInputField', 'With label and required')
 })
 
 Then('the required indicator is visible', () => {

--- a/cypress/integration/InputField/Can_be_required.feature
+++ b/cypress/integration/InputField/Can_be_required.feature
@@ -1,0 +1,5 @@
+Feature: Required status for the InputField
+
+    Scenario: Rendering a InputField that is required
+        Given a InputField with label and a required flag is rendered
+        Then the required indicator is visible

--- a/cypress/integration/InputField/Can_be_required/index.js
+++ b/cypress/integration/InputField/Can_be_required/index.js
@@ -1,7 +1,7 @@
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
-Given('a SingleSelectField with label and a required flag is rendered', () => {
-    cy.visitStory('SingleSelectField', 'With label and required status')
+Given('a InputField with label and a required flag is rendered', () => {
+    cy.visitStory('InputField', 'With label and required')
 })
 
 Then('the required indicator is visible', () => {

--- a/cypress/integration/Legend/Can_be_required.feature
+++ b/cypress/integration/Legend/Can_be_required.feature
@@ -1,0 +1,5 @@
+Feature: Required status for the Legend
+
+    Scenario: Rendering a Legend that is required
+        Given a Legend with content and a required flag is rendered
+        Then the required indicator is visible

--- a/cypress/integration/Legend/Can_be_required/index.js
+++ b/cypress/integration/Legend/Can_be_required/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a Legend with content and a required flag is rendered', () => {
+    cy.visitStory('Legend', 'With content and required')
+})
+
+Then('the required indicator is visible', () => {
+    cy.get('[data-test="dhis2-uicore-legend-required"]').should('be.visible')
+})

--- a/cypress/integration/MultiSelectField/Can_be_required.feature
+++ b/cypress/integration/MultiSelectField/Can_be_required.feature
@@ -2,4 +2,4 @@ Feature: Required status for the MultiSelectField
 
     Scenario: Rendering a MultiSelectField that is required
         Given a MultiSelectField with label and a required flag is rendered
-        Then an asterisk is visible
+        Then the required indicator is visible

--- a/cypress/integration/MultiSelectField/Can_be_required/index.js
+++ b/cypress/integration/MultiSelectField/Can_be_required/index.js
@@ -4,6 +4,6 @@ Given('a MultiSelectField with label and a required flag is rendered', () => {
     cy.visitStory('MultiSelectField', 'With label and required status')
 })
 
-Then('an asterisk is visible', () => {
-    cy.get('label.required').should('exist')
+Then('the required indicator is visible', () => {
+    cy.get('[data-test="dhis2-uicore-label-required"]').should('be.visible')
 })

--- a/cypress/integration/RadioGroupField/Can_be_required.feature
+++ b/cypress/integration/RadioGroupField/Can_be_required.feature
@@ -1,0 +1,5 @@
+Feature: Required status for the RadioGroupField
+
+    Scenario: Rendering a RadioGroupField that is required
+        Given a RadioGroupField with label and a required flag is rendered
+        Then the required indicator is visible

--- a/cypress/integration/RadioGroupField/Can_be_required/index.js
+++ b/cypress/integration/RadioGroupField/Can_be_required/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a RadioGroupField with label and a required flag is rendered', () => {
+    cy.visitStory('RadioGroupField', 'With label and required')
+})
+
+Then('the required indicator is visible', () => {
+    cy.get('[data-test="dhis2-uicore-legend-required"]').should('be.visible')
+})

--- a/cypress/integration/SingleSelectField/Can_be_required.feature
+++ b/cypress/integration/SingleSelectField/Can_be_required.feature
@@ -2,4 +2,4 @@ Feature: Required status for the SingleSelectField
 
     Scenario: Rendering a SingleSelectField that is required
         Given a SingleSelectField with label and a required flag is rendered
-        Then an asterisk is visible
+        Then the required indicator is visible

--- a/cypress/integration/SwitchField/Can_be_required.feature
+++ b/cypress/integration/SwitchField/Can_be_required.feature
@@ -1,0 +1,5 @@
+Feature: Required status for the SwitchField
+
+    Scenario: Rendering a SwitchField that is required
+        Given a SwitchField with label and a required flag is rendered
+        Then the required indicator is visible

--- a/cypress/integration/SwitchField/Can_be_required/index.js
+++ b/cypress/integration/SwitchField/Can_be_required/index.js
@@ -1,0 +1,11 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a SwitchField with label and a required flag is rendered', () => {
+    cy.visitStory('SwitchField', 'With label and required')
+})
+
+Then('the required indicator is visible', () => {
+    cy.get('[data-test="dhis2-uicore-switchfield-required"]').should(
+        'be.visible'
+    )
+})

--- a/cypress/integration/SwitchGroupField/Can_be_required.feature
+++ b/cypress/integration/SwitchGroupField/Can_be_required.feature
@@ -1,0 +1,5 @@
+Feature: Required status for the SwitchGroupField
+
+    Scenario: Rendering a SwitchGroupField that is required
+        Given a SwitchGroupField with label and a required flag is rendered
+        Then the required indicator is visible

--- a/cypress/integration/SwitchGroupField/Can_be_required/index.js
+++ b/cypress/integration/SwitchGroupField/Can_be_required/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a SwitchGroupField with label and a required flag is rendered', () => {
+    cy.visitStory('SwitchGroupField', 'With label and required')
+})
+
+Then('the required indicator is visible', () => {
+    cy.get('[data-test="dhis2-uicore-legend-required"]').should('be.visible')
+})

--- a/cypress/integration/TextAreaField/Can_be_required.feature
+++ b/cypress/integration/TextAreaField/Can_be_required.feature
@@ -1,0 +1,5 @@
+Feature: Required status for the TextAreaField
+
+    Scenario: Rendering a TextAreaField that is required
+        Given a TextAreaField with label and a required flag is rendered
+        Then the required indicator is visible

--- a/cypress/integration/TextAreaField/Can_be_required/index.js
+++ b/cypress/integration/TextAreaField/Can_be_required/index.js
@@ -1,7 +1,7 @@
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
-Given('a SingleSelectField with label and a required flag is rendered', () => {
-    cy.visitStory('SingleSelectField', 'With label and required status')
+Given('a TextAreaField with label and a required flag is rendered', () => {
+    cy.visitStory('TextAreaField', 'With label and required')
 })
 
 Then('the required indicator is visible', () => {

--- a/src/Label.js
+++ b/src/Label.js
@@ -2,8 +2,7 @@ import React from 'react'
 import cx from 'classnames'
 import css from 'styled-jsx/css'
 import propTypes from '@dhis2/prop-types'
-
-import { spacers } from './theme.js'
+import { Required } from './Label/Required.js'
 
 const styles = css`
     label {
@@ -17,16 +16,10 @@ const styles = css`
     .disabled {
         cursor: not-allowed;
     }
-
-    .required span::after {
-        padding-left: ${spacers.dp4};
-        content: '*';
-    }
 `
 
-const constructClassName = ({ required, disabled, className }) =>
+const constructClassName = ({ disabled, className }) =>
     cx(className, {
-        required: required,
         disabled: disabled,
     })
 
@@ -47,10 +40,13 @@ export const Label = ({
 }) => (
     <label
         htmlFor={htmlFor}
-        className={constructClassName({ className, required, disabled })}
+        className={constructClassName({ className, disabled })}
         data-test={dataTest}
     >
         <span>{children}</span>
+
+        {required && <Required dataTest={`${dataTest}-required`} />}
+
         <style jsx>{styles}</style>
     </label>
 )

--- a/src/Label/Required.js
+++ b/src/Label/Required.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+import { spacers } from '../theme.js'
+
+export const Required = ({ dataTest }) => (
+    <span data-test={dataTest}>
+        *
+        <style jsx>{`
+            span {
+                padding-left: ${spacers.dp4};
+            }
+        `}</style>
+    </span>
+)
+
+Required.propTypes = {
+    dataTest: propTypes.string.isRequired,
+}

--- a/src/Legend.js
+++ b/src/Legend.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
-import cx from 'classnames'
 
-import { colors, spacers } from './theme.js'
+import { colors } from './theme.js'
+import { Required } from './Label/Required.js'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -15,17 +15,16 @@ import { colors, spacers } from './theme.js'
  * @see Live demo: {@link /demo/?path=/story/legend--default|Storybook}
  */
 const Legend = ({ className, children, required, dataTest }) => (
-    <legend className={cx(className, { required })} data-test={dataTest}>
+    <legend className={className} data-test={dataTest}>
         {children}
+
+        {required && <Required dataTest={`${dataTest}-required`} />}
+
         <style jsx>{`
             legend {
                 font-size: 14px;
                 line-height: 16px;
                 color: ${colors.grey900};
-            }
-            legend.required::after {
-                padding-left: ${spacers.dp4};
-                content: '*';
             }
         `}</style>
     </legend>

--- a/src/ToggleField.js
+++ b/src/ToggleField.js
@@ -1,19 +1,10 @@
-import cx from 'classnames'
-import { resolve } from 'styled-jsx/css'
 import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
 import { statusPropType } from './common-prop-types.js'
-import { spacers } from './theme.js'
 import { Field } from './Field.js'
 import { Help } from './Help.js'
-
-const labelStyles = resolve`
-    label.required::after {
-        padding-left: ${spacers.dp4};
-        content: '*';
-    }
-`
+import { AddRequired } from './ToggleField/AddRequired.js'
 
 const ToggleField = ({
     value,
@@ -40,9 +31,14 @@ const ToggleField = ({
     <Field className={className} dataTest={dataTest}>
         <ToggleComponent
             value={value}
-            label={label}
+            label={
+                <AddRequired
+                    label={label}
+                    required={required}
+                    dataTest={dataTest}
+                />
+            }
             name={name}
-            className={cx(labelStyles.className, { required })}
             tabIndex={tabIndex}
             onChange={onChange}
             onFocus={onFocus}
@@ -68,8 +64,6 @@ const ToggleField = ({
                 {validationText}
             </Help>
         )}
-
-        {labelStyles.styles}
     </Field>
 )
 

--- a/src/ToggleField/AddRequired.js
+++ b/src/ToggleField/AddRequired.js
@@ -1,0 +1,16 @@
+import propTypes from '@dhis2/prop-types'
+import React from 'react'
+import { Required } from '../Label/Required.js'
+
+export const AddRequired = ({ label, required, dataTest }) => (
+    <React.Fragment>
+        {label}
+        {required && <Required dataTest={`${dataTest}-required`} />}
+    </React.Fragment>
+)
+
+AddRequired.propTypes = {
+    label: propTypes.node.isRequired,
+    dataTest: propTypes.string,
+    required: propTypes.bool,
+}

--- a/src/__e2e__/CheckboxField.stories.js
+++ b/src/__e2e__/CheckboxField.stories.js
@@ -1,0 +1,7 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { CheckboxField } from '../index.js'
+
+storiesOf('CheckboxField', module).add('With label and required', () => (
+    <CheckboxField name="Ex" label="CheckboxField" required value="checked" />
+))

--- a/src/__e2e__/CheckboxGroupField.stories.js
+++ b/src/__e2e__/CheckboxGroupField.stories.js
@@ -1,0 +1,16 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { Checkbox, CheckboxGroupField } from '../index.js'
+
+storiesOf('CheckboxGroupField', module).add('With label and required', () => (
+    <CheckboxGroupField
+        label="I am a required label"
+        name="required"
+        value={['second', 'third']}
+        required
+    >
+        <Checkbox value="first" label="First" />
+        <Checkbox value="second" label="Second" />
+        <Checkbox value="third" label="Third" />
+    </CheckboxGroupField>
+))

--- a/src/__e2e__/FileInputField.stories.js
+++ b/src/__e2e__/FileInputField.stories.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { FileInputField } from '../index.js'
+
+storiesOf('FileInputField', module).add('With label and required', () => (
+    <FileInputField
+        name="upload"
+        label="upload something"
+        buttonLabel="Upload file"
+        required
+    />
+))

--- a/src/__e2e__/InputField.stories.js
+++ b/src/__e2e__/InputField.stories.js
@@ -1,0 +1,7 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { InputField } from '../index.js'
+
+storiesOf('InputField', module).add('With label and required', () => (
+    <InputField label="Default label" name="Default" required />
+))

--- a/src/__e2e__/Legend.stories.js
+++ b/src/__e2e__/Legend.stories.js
@@ -1,0 +1,7 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { Legend } from '../index.js'
+
+storiesOf('Legend', module).add('With content and required', () => (
+    <Legend required>I am wrapped in a legend which has some styling</Legend>
+))

--- a/src/__e2e__/RadioGroupField.stories.js
+++ b/src/__e2e__/RadioGroupField.stories.js
@@ -1,0 +1,16 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { Radio, RadioGroupField } from '../index.js'
+
+storiesOf('RadioGroupField', module).add('With label and required', () => (
+    <RadioGroupField
+        label="I am a required label"
+        name="required"
+        value="second"
+        required
+    >
+        <Radio value="first" label="First" />
+        <Radio value="second" label="Second" />
+        <Radio value="third" label="Third" />
+    </RadioGroupField>
+))

--- a/src/__e2e__/SwitchField.stories.js
+++ b/src/__e2e__/SwitchField.stories.js
@@ -1,0 +1,7 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { SwitchField } from '../index.js'
+
+storiesOf('SwitchField', module).add('With label and required', () => (
+    <SwitchField name="Ex" label="SwitchField" required value="checked" />
+))

--- a/src/__e2e__/SwitchGroupField.stories.js
+++ b/src/__e2e__/SwitchGroupField.stories.js
@@ -1,0 +1,16 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { Switch, SwitchGroupField } from '../index.js'
+
+storiesOf('SwitchGroupField', module).add('With label and required', () => (
+    <SwitchGroupField
+        label="I am a required label"
+        name="required"
+        value={['second', 'third']}
+        required
+    >
+        <Switch value="first" label="First" />
+        <Switch value="second" label="Second" />
+        <Switch value="third" label="Third" />
+    </SwitchGroupField>
+))

--- a/src/__e2e__/TextAreaField.stories.js
+++ b/src/__e2e__/TextAreaField.stories.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { TextAreaField } from '../index.js'
+
+storiesOf('TextAreaField', module).add('With label and required', () => (
+    <TextAreaField
+        name="textarea"
+        label="I am required and have an asterisk"
+        required
+    />
+))


### PR DESCRIPTION
Closes a task from: https://jira.dhis2.org/browse/TECH-280

This refactors our required indicator (an asterisk) from css generated content to an inline asterisk. That makes it easier to test for us (and others) if the indicator is present in integration tests, because now we can attach a data-test attribute to it.

I've decided to put the `Required` component under `src/Label`, since it's mostly used in labels, and not to pollute the `src` dir. It's also used in the `Legend` so maybe people prefer a different location. Let me know if you do.

Implementing this required the `Checkbox` and `Switch` to accept a `required` prop. Before this we were (mostly) targeting the `label` element in those components and generating a `*` after that. Adding the new prop could be seen as a downside, but I've tried multiple approaches and this way kept the changes the simplest and is more explicit in my opinion. Previously we assumed a label would be present in the Checkbox and Switch, whereas now we're relying on a prop. Plus, apparently it's necessary for our Checkboxes and Switches to be able to show a required status, so I felt it's fair to be explicit about it.

Let me know if anything is unclear.

Added integration tests for:
- [x] SingleSelectField
- [x] MultiSelectField
- [x] CheckboxField
- [x] CheckboxGroupField
- [x] FileInputField
- [x] InputField
- [x] Legend
- [x] RadioGroupField
- [x] SwitchField
- [x] SwitchGroupField
- [x] TextAreaField
