### PR TITLE
docs: remove required textarea story

### DIFF
--- a/src/__demo__/TextArea.stories.js
+++ b/src/__demo__/TextArea.stories.js
@@ -177,17 +177,6 @@ storiesOf('TextArea', module)
         />
     ))
 
-    .add('Required', () => (
-        <TextArea
-            onChange={onChange}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            name="textarea"
-            label="I am required and have an asterisk"
-            required
-        />
-    ))
-
     .add('Rows', () => (
         <TextArea
             onChange={onChange}


### PR DESCRIPTION
I assume this is not meant to be there, as the textarea has no required prop, but the textareafield does. Noticed this when I was checking the `required` stories.