### PR TITLE
docs: changed repository link in package.json to https

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
     "main": "build/cjs/lib.js",
     "module": "build/es/lib.js",
     "sideEffects": false,
-    "repository": "git@github.com:dhis2/ui.git",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/dhis2/ui-core.git"
+    },
     "author": "Viktor Varland <viktor@dhis2.org>",
     "license": "BSD-3-Clause",
     "private": false,


### PR DESCRIPTION
Fixed the issue where all "edit on github" links are broken. 