### PR TITLE
chore: create stubs inside stories to not manipulate tested environment from the outside

### DIFF
--- a/cypress/integration/AlertBar/Accepts_hidden_cb/index.js
+++ b/cypress/integration/AlertBar/Accepts_hidden_cb/index.js
@@ -3,12 +3,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('an Alertbar with onHidden handler is rendered', () => {
     cy.visitStory('Alertbar', 'With onHidden')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onHidden = () => {}
-        cy.stub(win, 'onHidden')
-    })
 })
 
 When('the Alertbar is hidden', () => {

--- a/cypress/integration/Backdrop/Is_clickable/index.js
+++ b/cypress/integration/Backdrop/Is_clickable/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Backdrop with onClick handler is rendered', () => {
     cy.visitStory('Backdrop', 'With onClick')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 When('the user clicks on the Backdrop', () => {

--- a/cypress/integration/Button/Can_be_blurred/index.js
+++ b/cypress/integration/Button/Can_be_blurred/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('an Button with initialFocus and onBlur handler is rendered', () => {
     cy.visitStory('Button', 'With initialFocus and onBlur')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onBlur = () => {}
-        cy.stub(win, 'onBlur')
-    })
 })
 
 When('the Button is blurred', () => {

--- a/cypress/integration/Button/Can_be_clicked/index.js
+++ b/cypress/integration/Button/Can_be_clicked/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Button with onClick handler is rendered', () => {
     cy.visitStory('Button', 'With onClick')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 When('the Button is clicked', () => {

--- a/cypress/integration/Button/Can_be_focused/index.js
+++ b/cypress/integration/Button/Can_be_focused/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Button with onFocus handler is rendered', () => {
     cy.visitStory('Button', 'With onFocus')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onFocus = () => {}
-        cy.stub(win, 'onFocus')
-    })
 })
 
 When('the Button is focused', () => {

--- a/cypress/integration/Checkbox/Can_be_blurred/index.js
+++ b/cypress/integration/Checkbox/Can_be_blurred/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Checkbox with initialFocus and onBlur handler is rendered', () => {
     cy.visitStory('Checkbox', 'With initialFocus and onBlur')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onBlur = () => {}
-        cy.stub(win, 'onBlur')
-    })
 })
 
 When('the Checkbox is blurred', () => {

--- a/cypress/integration/Checkbox/Can_be_changed/index.js
+++ b/cypress/integration/Checkbox/Can_be_changed/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Checkbox with onChange handler is rendered', () => {
     cy.visitStory('Checkbox', 'With onChange')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onChange = () => {}
-        cy.stub(win, 'onChange')
-    })
 })
 
 When('the Checkbox is clicked', () => {

--- a/cypress/integration/Checkbox/Can_be_disabled/index.js
+++ b/cypress/integration/Checkbox/Can_be_disabled/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a disabled Checkbox with onClick handler is rendered', () => {
     cy.visitStory('Checkbox', 'Disabled with onClick')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 When('the Checkbox is clicked', () => {

--- a/cypress/integration/Checkbox/Can_be_focused/index.js
+++ b/cypress/integration/Checkbox/Can_be_focused/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Checkbox with onFocus handler is rendered', () => {
     cy.visitStory('Checkbox', 'With onFocus')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onFocus = () => {}
-        cy.stub(win, 'onFocus')
-    })
 })
 
 When('the Checkbox is focused', () => {

--- a/cypress/integration/Chip/Is_clickable/index.js
+++ b/cypress/integration/Chip/Is_clickable/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Chip with onClick handler is rendered', () => {
     cy.visitStory('Chip', 'With onClick')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 When('the Chip is clicked', () => {

--- a/cypress/integration/Chip/Is_removable/index.js
+++ b/cypress/integration/Chip/Is_removable/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Chip with onRemove handler is rendered', () => {
     cy.visitStory('Chip', 'With onRemove')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onRemove = () => {}
-        cy.stub(win, 'onRemove')
-    })
 })
 
 When('the remove icon is clicked', () => {

--- a/cypress/integration/DropdownButton/Button_is_clickable/index.js
+++ b/cypress/integration/DropdownButton/Button_is_clickable/index.js
@@ -3,12 +3,6 @@ import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a DropdownButton with onClick handler is rendered', () => {
     cy.visitStory('DropdownButton', 'With onClick')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 Then('the onClick handler is called', () => {

--- a/cypress/integration/DropdownButton/Can_be_disabled/index.js
+++ b/cypress/integration/DropdownButton/Can_be_disabled/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a disabled DropdownButton with onClick handler is rendered', () => {
     cy.visitStory('DropdownButton', 'Disabled with onClick')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 When('the DropdownButton is clicked', () => {

--- a/cypress/integration/FileInput/Accepts_multiple_files/index.js
+++ b/cypress/integration/FileInput/Accepts_multiple_files/index.js
@@ -3,12 +3,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a FileInput with multiple and onChange handler is rendered', () => {
     cy.visitStory('FileInput', 'With onChange and multiple')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onChange = () => {}
-        cy.stub(win, 'onChange')
-    })
 })
 
 When('the user selected multiple files', () => {

--- a/cypress/integration/FileInput/Can_be_blurred/index.js
+++ b/cypress/integration/FileInput/Can_be_blurred/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('an FileInput with initialFocus and onBlur handler is rendered', () => {
     cy.visitStory('FileInput', 'With initialFocus and onBlur')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onBlur = () => {}
-        cy.stub(win, 'onBlur')
-    })
 })
 
 When('the FileInput is blurred', () => {

--- a/cypress/integration/FileInput/Can_be_changed/index.js
+++ b/cypress/integration/FileInput/Can_be_changed/index.js
@@ -3,12 +3,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a FileInput with onChange handler is rendered', () => {
     cy.visitStory('FileInput', 'With onChange')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onChange = () => {}
-        cy.stub(win, 'onChange')
-    })
 })
 
 When('a file is selected', () => {

--- a/cypress/integration/FileInput/Can_be_focused/index.js
+++ b/cypress/integration/FileInput/Can_be_focused/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a FileInput with onFocus handler is rendered', () => {
     cy.visitStory('FileInput', 'With onFocus')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onFocus = () => {}
-        cy.stub(win, 'onFocus')
-    })
 })
 
 When('the FileInput is focused', () => {

--- a/cypress/integration/FileInputFieldWithList/common/index.js
+++ b/cypress/integration/FileInputFieldWithList/common/index.js
@@ -2,12 +2,6 @@ import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a FileInputFieldWithList with multiple files is rendered', () => {
     cy.visitStory('FileInputFieldWithList', 'Multiple files - with files')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onChange = () => {}
-        cy.stub(win, 'onChange')
-    })
 })
 
 Then('the onChange handler is called', () => {

--- a/cypress/integration/FileListItem/Can_be_removed/index.js
+++ b/cypress/integration/FileListItem/Can_be_removed/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a FileListItem with Onremove handler is rendered', () => {
     cy.visitStory('FileListItem', 'With onRemove')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onRemove = () => {}
-        cy.stub(win, 'onRemove')
-    })
 })
 
 When('the user clicks on the remove text', () => {

--- a/cypress/integration/FileListItem/Loading_can_be_cancelled/index.js
+++ b/cypress/integration/FileListItem/Loading_can_be_cancelled/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a loading FileListItem with onCancel handler is rendered', () => {
     cy.visitStory('FileListItem', 'Loading with onCancel')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onCancel = () => {}
-        cy.stub(win, 'onCancel')
-    })
 })
 
 When('the user clicks on the cancel text', () => {

--- a/cypress/integration/Input/Can_be_blurred/index.js
+++ b/cypress/integration/Input/Can_be_blurred/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('an Input with initialFocus and onBlur handler is rendered', () => {
     cy.visitStory('Input', 'With initialFocus and onBlur')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onBlur = () => {}
-        cy.stub(win, 'onBlur')
-    })
 })
 
 When('the Input is blurred', () => {

--- a/cypress/integration/Input/Can_be_changed/index.js
+++ b/cypress/integration/Input/Can_be_changed/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Input with onChange handler is rendered', () => {
     cy.visitStory('Input', 'With onChange')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onChange = () => {}
-        cy.stub(win, 'onChange')
-    })
 })
 
 When('the Input is filled with a character', () => {

--- a/cypress/integration/Input/Can_be_focused/index.js
+++ b/cypress/integration/Input/Can_be_focused/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Input with onFocus handler is rendered', () => {
     cy.visitStory('Input', 'With onFocus')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onFocus = () => {}
-        cy.stub(win, 'onFocus')
-    })
 })
 
 When('the Input is focused', () => {

--- a/cypress/integration/MenuItem/Is_clickable/index.js
+++ b/cypress/integration/MenuItem/Is_clickable/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a MenuItem with onClick handler and value is rendered', () => {
     cy.visitStory('MenuItem', 'With onClick and value')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 When('the MenuItem is clicked', () => {

--- a/cypress/integration/Modal/Can_be_closed/index.js
+++ b/cypress/integration/Modal/Can_be_closed/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Modal with onClose handler is rendered', () => {
     cy.visitStory('Modal', 'With onClose')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClose = () => {}
-        cy.stub(win, 'onClose')
-    })
 })
 
 When('the Screencover is clicked', () => {

--- a/cypress/integration/MultiSelect/Accepts_blur_cb/index.js
+++ b/cypress/integration/MultiSelect/Accepts_blur_cb/index.js
@@ -3,12 +3,6 @@ import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a MultiSelect with onBlur handler is rendered', () => {
     cy.visitStory('MultiSelect', 'With onBlur')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onBlur = () => {}
-        cy.stub(win, 'onBlur')
-    })
 })
 
 Then('the onBlur handler is called', () => {

--- a/cypress/integration/MultiSelect/Accepts_focus_cb/index.js
+++ b/cypress/integration/MultiSelect/Accepts_focus_cb/index.js
@@ -3,12 +3,6 @@ import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a MultiSelect with onFocus handler is rendered', () => {
     cy.visitStory('MultiSelect', 'With onFocus')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onFocus = () => {}
-        cy.stub(win, 'onFocus')
-    })
 })
 
 Then('the onFocus handler is called', () => {

--- a/cypress/integration/MultiSelect/Allows_selecting/index.js
+++ b/cypress/integration/MultiSelect/Allows_selecting/index.js
@@ -5,12 +5,6 @@ Given(
     'a MultiSelect with a disabled option and onChange handler is rendered',
     () => {
         cy.visitStory('MultiSelect', 'With disabled option and onChange')
-
-        cy.window().then(win => {
-            // The property has to be present to allow cy.stub
-            win.onChange = () => {}
-            cy.stub(win, 'onChange')
-        })
     }
 )
 
@@ -18,12 +12,6 @@ Given(
     'a MultiSelect with custom options and onChange handler is rendered',
     () => {
         cy.visitStory('MultiSelect', 'With custom options and onChange')
-
-        cy.window().then(win => {
-            // The property has to be present to allow cy.stub
-            win.onChange = () => {}
-            cy.stub(win, 'onChange')
-        })
     }
 )
 

--- a/cypress/integration/MultiSelect/Can_be_cleared/index.js
+++ b/cypress/integration/MultiSelect/Can_be_cleared/index.js
@@ -8,12 +8,6 @@ Given(
             'MultiSelect',
             'With clear button, selection and onChange'
         )
-
-        cy.window().then(win => {
-            // The property has to be present to allow cy.stub
-            win.onChange = () => {}
-            cy.stub(win, 'onChange')
-        })
     }
 )
 

--- a/cypress/integration/MultiSelect/common/index.js
+++ b/cypress/integration/MultiSelect/common/index.js
@@ -2,24 +2,12 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a MultiSelect with options and onChange handler is rendered', () => {
     cy.visitStory('MultiSelect', 'With options and onChange')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onChange = () => {}
-        cy.stub(win, 'onChange')
-    })
 })
 
 Given(
     'a MultiSelect with options, a selection and onChange handler is rendered',
     () => {
         cy.visitStory('MultiSelect', 'With options, a selection and onChange')
-
-        cy.window().then(win => {
-            // The property has to be present to allow cy.stub
-            win.onChange = () => {}
-            cy.stub(win, 'onChange')
-        })
     }
 )
 

--- a/cypress/integration/Node/Can_be_closed/index.js
+++ b/cypress/integration/Node/Can_be_closed/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('an open Node with an onClose handler is rendered', () => {
     cy.visitStory('Node', 'Open with onClose')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClose = () => {}
-        cy.stub(win, 'onClose')
-    })
 })
 
 When('the arrow is clicked', () => {

--- a/cypress/integration/Node/Can_be_opened/index.js
+++ b/cypress/integration/Node/Can_be_opened/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a closed Node with an onOpen handler is rendered', () => {
     cy.visitStory('Node', 'Closed with onOpen')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onOpen = () => {}
-        cy.stub(win, 'onOpen')
-    })
 })
 
 When('the arrow is clicked', () => {

--- a/cypress/integration/Radio/Can_be_blurred/index.js
+++ b/cypress/integration/Radio/Can_be_blurred/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Radio with initialFocus and onBlur handler is rendered', () => {
     cy.visitStory('Radio', 'With initialFocus and onBlur')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onBlur = () => {}
-        cy.stub(win, 'onBlur')
-    })
 })
 
 When('the Radio is blurred', () => {

--- a/cypress/integration/Radio/Can_be_changed/index.js
+++ b/cypress/integration/Radio/Can_be_changed/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Radio with onChange handler is rendered', () => {
     cy.visitStory('Radio', 'With onChange')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onChange = () => {}
-        cy.stub(win, 'onChange')
-    })
 })
 
 When('the Radio is checked', () => {

--- a/cypress/integration/Radio/Can_be_focused/index.js
+++ b/cypress/integration/Radio/Can_be_focused/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Radio with onFocus handler is rendered', () => {
     cy.visitStory('Radio', 'With onFocus')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onFocus = () => {}
-        cy.stub(win, 'onFocus')
-    })
 })
 
 When('the Radio is focused', () => {

--- a/cypress/integration/ScreenCover/Is_clickable/index.js
+++ b/cypress/integration/ScreenCover/Is_clickable/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Screencover with onClick handler is rendered', () => {
     cy.visitStory('Screencover', 'With onClick')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 When('the user clicks on the Screencover', () => {

--- a/cypress/integration/SingleSelect/Accepts_blur_cb/index.js
+++ b/cypress/integration/SingleSelect/Accepts_blur_cb/index.js
@@ -3,12 +3,6 @@ import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a SingleSelect with onBlur handler is rendered', () => {
     cy.visitStory('SingleSelect', 'With onBlur')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onBlur = () => {}
-        cy.stub(win, 'onBlur')
-    })
 })
 
 Then('the onBlur handler is called', () => {

--- a/cypress/integration/SingleSelect/Accepts_focus_cb/index.js
+++ b/cypress/integration/SingleSelect/Accepts_focus_cb/index.js
@@ -3,12 +3,6 @@ import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a SingleSelect with onFocus handler is rendered', () => {
     cy.visitStory('SingleSelect', 'With onFocus')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onFocus = () => {}
-        cy.stub(win, 'onFocus')
-    })
 })
 
 Then('the onFocus handler is called', () => {

--- a/cypress/integration/SingleSelect/Allows_selecting/index.js
+++ b/cypress/integration/SingleSelect/Allows_selecting/index.js
@@ -5,12 +5,6 @@ Given(
     'a SingleSelect with a disabled option and onChange handler is rendered',
     () => {
         cy.visitStory('SingleSelect', 'With disabled option and onChange')
-
-        cy.window().then(win => {
-            // The property has to be present to allow cy.stub
-            win.onChange = () => {}
-            cy.stub(win, 'onChange')
-        })
     }
 )
 
@@ -18,12 +12,6 @@ Given(
     'a SingleSelect with custom options and onChange handler is rendered',
     () => {
         cy.visitStory('SingleSelect', 'With custom options and onChange')
-
-        cy.window().then(win => {
-            // The property has to be present to allow cy.stub
-            win.onChange = () => {}
-            cy.stub(win, 'onChange')
-        })
     }
 )
 

--- a/cypress/integration/SingleSelect/Can_be_cleared/index.js
+++ b/cypress/integration/SingleSelect/Can_be_cleared/index.js
@@ -8,12 +8,6 @@ Given(
             'SingleSelect',
             'With clear button, selection and onChange'
         )
-
-        cy.window().then(win => {
-            // The property has to be present to allow cy.stub
-            win.onChange = () => {}
-            cy.stub(win, 'onChange')
-        })
     }
 )
 

--- a/cypress/integration/SingleSelect/common/index.js
+++ b/cypress/integration/SingleSelect/common/index.js
@@ -2,30 +2,14 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a SingleSelect with options and onChange handler is rendered', () => {
     cy.visitStory('SingleSelect', 'With options and onChange')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onChange = () => {}
-        cy.stub(win, 'onChange')
-    })
 })
 
 Given(
     'a SingleSelect with options, a selection and onChange handler is rendered',
     () => {
         cy.visitStory('SingleSelect', 'With options, a selection and onChange')
-
-        cy.window().then(win => {
-            // The property has to be present to allow cy.stub
-            win.onChange = () => {}
-            cy.stub(win, 'onChange')
-        })
     }
 )
-
-Given('an onChange handler is attached', () => {
-    cy.window().then(win => (win.onChange = cy.stub()))
-})
 
 Given('the SingleSelect is open', () => {
     cy.get('[data-test="dhis2-uicore-select-input"]').click()

--- a/cypress/integration/SplitButton/Button_is_clickable/index.js
+++ b/cypress/integration/SplitButton/Button_is_clickable/index.js
@@ -3,12 +3,6 @@ import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a SplitButton with onClick hander is rendered', () => {
     cy.visitStory('SplitButton', 'With onClick')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 Then('the onClick handler is called', () => {

--- a/cypress/integration/Switch/Can_be_blurred/index.js
+++ b/cypress/integration/Switch/Can_be_blurred/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Switch with initialFocus and onBlur handler is rendered', () => {
     cy.visitStory('Switch', 'With initialFocus and onBlur')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onBlur = () => {}
-        cy.stub(win, 'onBlur')
-    })
 })
 
 When('the Switch is blurred', () => {

--- a/cypress/integration/Switch/Can_be_changed/index.js
+++ b/cypress/integration/Switch/Can_be_changed/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Switch with onChange handler is rendered', () => {
     cy.visitStory('Switch', 'With onChange')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onChange = () => {}
-        cy.stub(win, 'onChange')
-    })
 })
 
 When('the Switch is clicked', () => {

--- a/cypress/integration/Switch/Can_be_focused/index.js
+++ b/cypress/integration/Switch/Can_be_focused/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Switch with onFocus handler is rendered', () => {
     cy.visitStory('Switch', 'With onFocus')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onFocus = () => {}
-        cy.stub(win, 'onFocus')
-    })
 })
 
 When('the Switch is focused', () => {

--- a/cypress/integration/Tab/Is_clickable/index.js
+++ b/cypress/integration/Tab/Is_clickable/index.js
@@ -2,22 +2,10 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a Tab with onClick handler is rendered', () => {
     cy.visitStory('Tab', 'With onClick')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 Given('a disabled Tab with onClick handler is rendered', () => {
     cy.visitStory('Tab', 'With onClick and disabled')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onClick = () => {}
-        cy.stub(win, 'onClick')
-    })
 })
 
 When('the Tab is clicked', () => {

--- a/cypress/integration/TextArea/Can_be_blurred/index.js
+++ b/cypress/integration/TextArea/Can_be_blurred/index.js
@@ -2,12 +2,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a TextArea with initialFocus and onBlur handler is rendered', () => {
     cy.visitStory('TextArea', 'With initialFocus and onBlur')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onBlur = () => {}
-        cy.stub(win, 'onBlur')
-    })
 })
 
 When('the TextArea is blurred', () => {

--- a/cypress/integration/TextArea/Can_be_changed/index.js
+++ b/cypress/integration/TextArea/Can_be_changed/index.js
@@ -3,12 +3,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a TextArea with onChange handler is rendered', () => {
     cy.visitStory('TextArea', 'With onChange')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onChange = () => {}
-        cy.stub(win, 'onChange')
-    })
 })
 
 When('the TextArea is filled with a character', () => {

--- a/cypress/integration/TextArea/Can_be_focused/index.js
+++ b/cypress/integration/TextArea/Can_be_focused/index.js
@@ -3,12 +3,6 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a TextArea with onFocus handler is rendered', () => {
     cy.visitStory('TextArea', 'With onFocus')
-
-    cy.window().then(win => {
-        // The property has to be present to allow cy.stub
-        win.onFocus = () => {}
-        cy.stub(win, 'onFocus')
-    })
 })
 
 When('the TextArea is focused', () => {

--- a/src/__e2e__/AlertBar.stories.js
+++ b/src/__e2e__/AlertBar.stories.js
@@ -26,8 +26,6 @@ storiesOf('AlertBar', module)
     ))
     .add('With message', () => <AlertBar>With a message</AlertBar>)
     .add('With onHidden', () => (
-        <AlertBar onHidden={(...args) => window.onHidden(...args)}>
-            Message
-        </AlertBar>
+        <AlertBar onHidden={window.onHidden}>Message</AlertBar>
     ))
     .add('Permanent', () => <AlertBar permanent>Message</AlertBar>)

--- a/src/__e2e__/AlertBar.stories.js
+++ b/src/__e2e__/AlertBar.stories.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { AlertBar } from '../index.js'
 
+window.onHidden = window.Cypress.cy.stub()
+
 storiesOf('AlertBar', module)
     .add('Default', () => <AlertBar>Default</AlertBar>)
     .add('Custom duration', () => (

--- a/src/__e2e__/Backdrop.stories.js
+++ b/src/__e2e__/Backdrop.stories.js
@@ -2,10 +2,10 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Backdrop } from '../Backdrop.js'
 
+window.onClick = window.Cypress.cy.stub()
+
 storiesOf('Backdrop', module)
-    .add('With onClick', () => (
-        <Backdrop onClick={(...args) => window.onClick(...args)} />
-    ))
+    .add('With onClick', () => <Backdrop onClick={window.onClick} />)
     .add('With children', () => (
         <Backdrop>
             <span>I am a child</span>

--- a/src/__e2e__/Button.stories.js
+++ b/src/__e2e__/Button.stories.js
@@ -8,11 +8,7 @@ window.onFocus = window.Cypress.cy.stub()
 
 storiesOf('Button', module)
     .add('With onClick', () => (
-        <Button
-            name="Button"
-            value="default"
-            onClick={(...args) => window.onClick(...args)}
-        >
+        <Button name="Button" value="default" onClick={window.onClick}>
             Label me!
         </Button>
     ))
@@ -21,17 +17,13 @@ storiesOf('Button', module)
             name="Button"
             value="default"
             initialFocus
-            onBlur={(...args) => window.onBlur(...args)}
+            onBlur={window.onBlur}
         >
             Label me!
         </Button>
     ))
     .add('With onFocus', () => (
-        <Button
-            name="Button"
-            value="default"
-            onFocus={(...args) => window.onFocus(...args)}
-        >
+        <Button name="Button" value="default" onFocus={window.onFocus}>
             Label me!
         </Button>
     ))

--- a/src/__e2e__/Button.stories.js
+++ b/src/__e2e__/Button.stories.js
@@ -2,6 +2,10 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Button } from '../index.js'
 
+window.onClick = window.Cypress.cy.stub()
+window.onBlur = window.Cypress.cy.stub()
+window.onFocus = window.Cypress.cy.stub()
+
 storiesOf('Button', module)
     .add('With onClick', () => (
         <Button

--- a/src/__e2e__/Checkbox.stories.js
+++ b/src/__e2e__/Checkbox.stories.js
@@ -13,7 +13,7 @@ storiesOf('Checkbox', module)
             name="Ex"
             label="Checkbox"
             value="default"
-            onChange={(...args) => window.onChange(...args)}
+            onChange={window.onChange}
         />
     ))
     .add('With initialFocus and onBlur', () => (
@@ -22,7 +22,7 @@ storiesOf('Checkbox', module)
             name="Ex"
             label="Checkbox"
             value="default"
-            onBlur={(...args) => window.onBlur(...args)}
+            onBlur={window.onBlur}
         />
     ))
     .add('With onFocus', () => (
@@ -30,7 +30,7 @@ storiesOf('Checkbox', module)
             name="Ex"
             label="Checkbox"
             value="default"
-            onFocus={(...args) => window.onFocus(...args)}
+            onFocus={window.onFocus}
         />
     ))
     .add('Disabled with onClick', () => (
@@ -39,7 +39,7 @@ storiesOf('Checkbox', module)
             label="Checkbox"
             value="default"
             disabled
-            onClick={(...args) => window.onClick(...args)}
+            onClick={window.onClick}
         />
     ))
     .add('With label', () => (

--- a/src/__e2e__/Checkbox.stories.js
+++ b/src/__e2e__/Checkbox.stories.js
@@ -2,6 +2,11 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { Checkbox } from '../index.js'
 
+window.onClick = window.Cypress.cy.stub()
+window.onChange = window.Cypress.cy.stub()
+window.onBlur = window.Cypress.cy.stub()
+window.onFocus = window.Cypress.cy.stub()
+
 storiesOf('Checkbox', module)
     .add('With onChange', () => (
         <Checkbox

--- a/src/__e2e__/Chip.stories.js
+++ b/src/__e2e__/Chip.stories.js
@@ -2,6 +2,9 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Chip } from '../index.js'
 
+window.onClick = window.Cypress.cy.stub()
+window.onRemove = window.Cypress.cy.stub()
+
 storiesOf('Chip', module)
     .add('Default', () => <Chip>Message</Chip>)
     .add('With onClick', () => (

--- a/src/__e2e__/Chip.stories.js
+++ b/src/__e2e__/Chip.stories.js
@@ -7,11 +7,9 @@ window.onRemove = window.Cypress.cy.stub()
 
 storiesOf('Chip', module)
     .add('Default', () => <Chip>Message</Chip>)
-    .add('With onClick', () => (
-        <Chip onClick={(...args) => window.onClick(...args)}>Chippy</Chip>
-    ))
+    .add('With onClick', () => <Chip onClick={window.onClick}>Chippy</Chip>)
     .add('With onRemove', () => (
-        <Chip onRemove={(...args) => window.onRemove(...args)}>Chipmunk</Chip>
+        <Chip onRemove={window.onRemove}>Chipmunk</Chip>
     ))
     .add('With children', () => <Chip>I am a child</Chip>)
     .add('With icon', () => <Chip icon={<div>Icon</div>}>Message</Chip>)

--- a/src/__e2e__/DropdownButton.stories.js
+++ b/src/__e2e__/DropdownButton.stories.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { DropdownButton } from '../index.js'
 
+window.onClick = window.Cypress.cy.stub()
+
 storiesOf('DropdownButton', module)
     .add('Default', () => (
         <DropdownButton

--- a/src/__e2e__/DropdownButton.stories.js
+++ b/src/__e2e__/DropdownButton.stories.js
@@ -18,7 +18,7 @@ storiesOf('DropdownButton', module)
         <DropdownButton
             name="Button"
             value="default"
-            onClick={(...args) => window.onClick(...args)}
+            onClick={window.onClick}
             component={<div>Content</div>}
         >
             Button
@@ -61,7 +61,7 @@ storiesOf('DropdownButton', module)
             name="Button"
             value="default"
             component={<div>Content</div>}
-            onClick={(...args) => window.onClick(...args)}
+            onClick={window.onClick}
             disabled
         />
     ))

--- a/src/__e2e__/FileInput.stories.js
+++ b/src/__e2e__/FileInput.stories.js
@@ -2,6 +2,9 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { FileInput } from '../index.js'
 
+window.onBlur = window.Cypress.cy.stub()
+window.onFocus = window.Cypress.cy.stub()
+
 const onChange = (payload, event) => {
     // NOTE: if files is not transformed into an array,
     // cypress will get an empty file list!

--- a/src/__e2e__/FileInput.stories.js
+++ b/src/__e2e__/FileInput.stories.js
@@ -38,13 +38,13 @@ storiesOf('FileInput', module)
             buttonLabel="Upload file"
             name="upload"
             initialFocus
-            onBlur={(...args) => window.onBlur(...args)}
+            onBlur={window.onBlur}
         />
     ))
     .add('With onFocus', () => (
         <FileInput
             buttonLabel="Upload file"
             name="upload"
-            onFocus={(...args) => window.onFocus(...args)}
+            onFocus={window.onFocus}
         />
     ))

--- a/src/__e2e__/FileInputFieldWithList.stories.js
+++ b/src/__e2e__/FileInputFieldWithList.stories.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-
 import { FileInputFieldWithList } from '../index.js'
+
+window.onChange = window.Cypress.cy.stub()
 
 const singleFileArray = [new File([], 'dummy.txt')]
 

--- a/src/__e2e__/FileListItem.stories.js
+++ b/src/__e2e__/FileListItem.stories.js
@@ -9,7 +9,7 @@ storiesOf('FileListItem', module)
     .add('With onRemove', () => (
         <FileListItem
             label="File list item"
-            onRemove={(...args) => window.onRemove(...args)}
+            onRemove={window.onRemove}
             removeText="Remove"
         />
     ))
@@ -18,7 +18,7 @@ storiesOf('FileListItem', module)
             loading
             label="File list item"
             removeText="Remove"
-            onCancel={(...args) => window.onCancel(...args)}
+            onCancel={window.onCancel}
             cancelText="Cancel"
         />
     ))

--- a/src/__e2e__/FileListItem.stories.js
+++ b/src/__e2e__/FileListItem.stories.js
@@ -2,6 +2,9 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { FileListItem } from '../index.js'
 
+window.onRemove = window.Cypress.cy.stub()
+window.onCancel = window.Cypress.cy.stub()
+
 storiesOf('FileListItem', module)
     .add('With onRemove', () => (
         <FileListItem

--- a/src/__e2e__/Input.stories.js
+++ b/src/__e2e__/Input.stories.js
@@ -12,7 +12,7 @@ storiesOf('Input', module)
             label="Default label"
             name="Default"
             value=""
-            onChange={(...args) => window.onChange(...args)}
+            onChange={window.onChange}
         />
     ))
     .add('With initialFocus and onBlur', () => (
@@ -21,7 +21,7 @@ storiesOf('Input', module)
             name="Default"
             value=""
             initialFocus
-            onBlur={(...args) => window.onBlur(...args)}
+            onBlur={window.onBlur}
         />
     ))
     .add('With onFocus', () => (
@@ -29,7 +29,7 @@ storiesOf('Input', module)
             label="Default label"
             name="Default"
             value=""
-            onFocus={(...args) => window.onFocus(...args)}
+            onFocus={window.onFocus}
         />
     ))
     .add('With initialFocus', () => (

--- a/src/__e2e__/Input.stories.js
+++ b/src/__e2e__/Input.stories.js
@@ -2,6 +2,10 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { Input } from '../index.js'
 
+window.onChange = window.Cypress.cy.stub()
+window.onBlur = window.Cypress.cy.stub()
+window.onFocus = window.Cypress.cy.stub()
+
 storiesOf('Input', module)
     .add('With onChange', () => (
         <Input

--- a/src/__e2e__/MenuItem.stories.js
+++ b/src/__e2e__/MenuItem.stories.js
@@ -2,6 +2,8 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { MenuItem } from '../index.js'
 
+window.onClick = window.Cypress.cy.stub()
+
 storiesOf('MenuItem', module)
     .add('With onClick and value', () => (
         <MenuItem

--- a/src/__e2e__/MenuItem.stories.js
+++ b/src/__e2e__/MenuItem.stories.js
@@ -6,11 +6,7 @@ window.onClick = window.Cypress.cy.stub()
 
 storiesOf('MenuItem', module)
     .add('With onClick and value', () => (
-        <MenuItem
-            label="Menu item"
-            value="Value"
-            onClick={(...args) => window.onClick(...args)}
-        />
+        <MenuItem label="Menu item" value="Value" onClick={window.onClick} />
     ))
     .add('With href', () => <MenuItem label="Menu item" href="url.test" />)
     .add('With icon', () => (

--- a/src/__e2e__/Modal.stories.js
+++ b/src/__e2e__/Modal.stories.js
@@ -13,7 +13,7 @@ window.onClose = window.Cypress.cy.stub()
 
 storiesOf('Modal', module)
     .add('With onClose', () => (
-        <Modal small onClose={(...args) => window.onClose(...args)}>
+        <Modal small onClose={window.onClose}>
             <ModalTitle>Title</ModalTitle>
             <ModalContent>Content</ModalContent>
             <ModalActions>

--- a/src/__e2e__/Modal.stories.js
+++ b/src/__e2e__/Modal.stories.js
@@ -9,6 +9,8 @@ import {
     ModalContent,
 } from '../index.js'
 
+window.onClose = window.Cypress.cy.stub()
+
 storiesOf('Modal', module)
     .add('With onClose', () => (
         <Modal small onClose={(...args) => window.onClose(...args)}>

--- a/src/__e2e__/MultiSelect.stories.js
+++ b/src/__e2e__/MultiSelect.stories.js
@@ -3,6 +3,10 @@ import propTypes from '@dhis2/prop-types'
 import { storiesOf } from '@storybook/react'
 import { MultiSelect, MultiSelectOption } from '../index.js'
 
+window.onChange = window.Cypress.cy.stub()
+window.onFocus = window.Cypress.cy.stub()
+window.onBlur = window.Cypress.cy.stub()
+
 const CustomMultiSelectOption = ({ label, onClick }) => (
     <div onClick={e => onClick({}, e)}>{label}</div>
 )

--- a/src/__e2e__/MultiSelect.stories.js
+++ b/src/__e2e__/MultiSelect.stories.js
@@ -25,40 +25,28 @@ storiesOf('MultiSelect', module)
         </MultiSelect>
     ))
     .add('With options and onChange', () => (
-        <MultiSelect
-            className="select"
-            onChange={(...args) => window.onChange(...args)}
-        >
+        <MultiSelect className="select" onChange={window.onChange}>
             <MultiSelectOption value="1" label="option one" />
             <MultiSelectOption value="2" label="option two" />
             <MultiSelectOption value="3" label="option three" />
         </MultiSelect>
     ))
     .add('With onFocus', () => (
-        <MultiSelect
-            className="select"
-            onFocus={(...args) => window.onFocus(...args)}
-        >
+        <MultiSelect className="select" onFocus={window.onFocus}>
             <MultiSelectOption value="1" label="option one" />
             <MultiSelectOption value="2" label="option two" />
             <MultiSelectOption value="3" label="option three" />
         </MultiSelect>
     ))
     .add('With onBlur', () => (
-        <MultiSelect
-            className="select"
-            onBlur={(...args) => window.onBlur(...args)}
-        >
+        <MultiSelect className="select" onBlur={window.onBlur}>
             <MultiSelectOption value="1" label="option one" />
             <MultiSelectOption value="2" label="option two" />
             <MultiSelectOption value="3" label="option three" />
         </MultiSelect>
     ))
     .add('With custom options and onChange', () => (
-        <MultiSelect
-            className="select"
-            onChange={(...args) => window.onChange(...args)}
-        >
+        <MultiSelect className="select" onChange={window.onChange}>
             <CustomMultiSelectOption value="1" label="option one" />
             <CustomMultiSelectOption value="2" label="option two" />
             <CustomMultiSelectOption value="3" label="option three" />
@@ -201,10 +189,7 @@ storiesOf('MultiSelect', module)
         </MultiSelect>
     ))
     .add('With disabled option and onChange', () => (
-        <MultiSelect
-            className="select"
-            onChange={(...args) => window.onChange(...args)}
-        >
+        <MultiSelect className="select" onChange={window.onChange}>
             <MultiSelectOption value="1" label="option one" />
             <MultiSelectOption value="2" label="option two" />
             <MultiSelectOption value="3" label="option three" />
@@ -225,7 +210,7 @@ storiesOf('MultiSelect', module)
         <MultiSelect
             className="select"
             selected={[{ value: '1', label: 'option one' }]}
-            onChange={(...args) => window.onChange(...args)}
+            onChange={window.onChange}
         >
             <MultiSelectOption value="1" label="option one" />
             <MultiSelectOption value="2" label="option two" />
@@ -251,7 +236,7 @@ storiesOf('MultiSelect', module)
             clearText="Clear"
             className="select"
             selected={[{ value: '1', label: 'option one' }]}
-            onChange={(...args) => window.onChange(...args)}
+            onChange={window.onChange}
         >
             <MultiSelectOption value="1" label="option one" />
             <MultiSelectOption value="2" label="option two" />

--- a/src/__e2e__/Node.stories.js
+++ b/src/__e2e__/Node.stories.js
@@ -2,6 +2,9 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Node } from '../index.js'
 
+window.onClose = window.Cypress.cy.stub()
+window.onOpen = window.Cypress.cy.stub()
+
 storiesOf('Node', module)
     .add('Open with onClose', () => (
         <Node

--- a/src/__e2e__/Node.stories.js
+++ b/src/__e2e__/Node.stories.js
@@ -7,19 +7,12 @@ window.onOpen = window.Cypress.cy.stub()
 
 storiesOf('Node', module)
     .add('Open with onClose', () => (
-        <Node
-            open
-            onClose={(...args) => window.onClose(...args)}
-            component={<div>Component</div>}
-        >
+        <Node open onClose={window.onClose} component={<div>Component</div>}>
             Children
         </Node>
     ))
     .add('Closed with onOpen', () => (
-        <Node
-            onOpen={(...args) => window.onOpen(...args)}
-            component={<div>Component</div>}
-        >
+        <Node onOpen={window.onOpen} component={<div>Component</div>}>
             Children
         </Node>
     ))

--- a/src/__e2e__/Radio.stories.js
+++ b/src/__e2e__/Radio.stories.js
@@ -2,6 +2,10 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { Radio } from '../index.js'
 
+window.onChange = window.Cypress.cy.stub()
+window.onBlur = window.Cypress.cy.stub()
+window.onFocus = window.Cypress.cy.stub()
+
 storiesOf('Radio', module)
     .add('With onChange', () => (
         <Radio

--- a/src/__e2e__/Radio.stories.js
+++ b/src/__e2e__/Radio.stories.js
@@ -12,7 +12,7 @@ storiesOf('Radio', module)
             name="Ex"
             label="Radio"
             value="default"
-            onChange={(...args) => window.onChange(...args)}
+            onChange={window.onChange}
         />
     ))
     .add('With initialFocus and onBlur', () => (
@@ -21,7 +21,7 @@ storiesOf('Radio', module)
             label="Radio"
             value="default"
             initialFocus
-            onBlur={(...args) => window.onBlur(...args)}
+            onBlur={window.onBlur}
         />
     ))
     .add('With onFocus', () => (
@@ -30,7 +30,7 @@ storiesOf('Radio', module)
             name="Ex"
             label="Radio"
             value="default"
-            onFocus={(...args) => window.onFocus(...args)}
+            onFocus={window.onFocus}
         />
     ))
     .add('With disabled', () => (

--- a/src/__e2e__/ScreenCover.stories.js
+++ b/src/__e2e__/ScreenCover.stories.js
@@ -5,7 +5,5 @@ import { ScreenCover } from '../index.js'
 window.onClick = window.Cypress.cy.stub()
 
 storiesOf('ScreenCover', module)
-    .add('With onClick', () => (
-        <ScreenCover onClick={(...args) => window.onClick(...args)} />
-    ))
+    .add('With onClick', () => <ScreenCover onClick={window.onClick} />)
     .add('With children', () => <ScreenCover>I am a child</ScreenCover>)

--- a/src/__e2e__/ScreenCover.stories.js
+++ b/src/__e2e__/ScreenCover.stories.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { ScreenCover } from '../index.js'
 
+window.onClick = window.Cypress.cy.stub()
+
 storiesOf('ScreenCover', module)
     .add('With onClick', () => (
         <ScreenCover onClick={(...args) => window.onClick(...args)} />

--- a/src/__e2e__/SingleSelect.stories.js
+++ b/src/__e2e__/SingleSelect.stories.js
@@ -3,6 +3,10 @@ import propTypes from '@dhis2/prop-types'
 import { storiesOf } from '@storybook/react'
 import { SingleSelect, SingleSelectOption } from '../index.js'
 
+window.onChange = window.Cypress.cy.stub()
+window.onFocus = window.Cypress.cy.stub()
+window.onBlur = window.Cypress.cy.stub()
+
 const CustomSingleSelectOption = ({ label, onClick }) => (
     <div onClick={e => onClick({}, e)}>{label}</div>
 )

--- a/src/__e2e__/SingleSelect.stories.js
+++ b/src/__e2e__/SingleSelect.stories.js
@@ -25,40 +25,28 @@ storiesOf('SingleSelect', module)
         </SingleSelect>
     ))
     .add('With options and onChange', () => (
-        <SingleSelect
-            className="select"
-            onChange={(...args) => window.onChange(...args)}
-        >
+        <SingleSelect className="select" onChange={window.onChange}>
             <SingleSelectOption value="1" label="option one" />
             <SingleSelectOption value="2" label="option two" />
             <SingleSelectOption value="3" label="option three" />
         </SingleSelect>
     ))
     .add('With onFocus', () => (
-        <SingleSelect
-            className="select"
-            onFocus={(...args) => window.onFocus(...args)}
-        >
+        <SingleSelect className="select" onFocus={window.onFocus}>
             <SingleSelectOption value="1" label="option one" />
             <SingleSelectOption value="2" label="option two" />
             <SingleSelectOption value="3" label="option three" />
         </SingleSelect>
     ))
     .add('With onBlur', () => (
-        <SingleSelect
-            className="select"
-            onBlur={(...args) => window.onBlur(...args)}
-        >
+        <SingleSelect className="select" onBlur={window.onBlur}>
             <SingleSelectOption value="1" label="option one" />
             <SingleSelectOption value="2" label="option two" />
             <SingleSelectOption value="3" label="option three" />
         </SingleSelect>
     ))
     .add('With custom options and onChange', () => (
-        <SingleSelect
-            className="select"
-            onChange={(...args) => window.onChange(...args)}
-        >
+        <SingleSelect className="select" onChange={window.onChange}>
             <CustomSingleSelectOption value="1" label="option one" />
             <CustomSingleSelectOption value="2" label="option two" />
             <CustomSingleSelectOption value="3" label="option three" />
@@ -201,10 +189,7 @@ storiesOf('SingleSelect', module)
         </SingleSelect>
     ))
     .add('With disabled option and onChange', () => (
-        <SingleSelect
-            className="select"
-            onChange={(...args) => window.onChange(...args)}
-        >
+        <SingleSelect className="select" onChange={window.onChange}>
             <SingleSelectOption value="1" label="option one" />
             <SingleSelectOption value="2" label="option two" />
             <SingleSelectOption value="3" label="option three" />
@@ -225,7 +210,7 @@ storiesOf('SingleSelect', module)
         <SingleSelect
             className="select"
             selected={{ value: '1', label: 'option one' }}
-            onChange={(...args) => window.onChange(...args)}
+            onChange={window.onChange}
         >
             <SingleSelectOption value="1" label="option one" />
             <SingleSelectOption value="2" label="option two" />
@@ -238,7 +223,7 @@ storiesOf('SingleSelect', module)
             clearText="Clear"
             className="select"
             selected={{ value: '1', label: 'option one' }}
-            onChange={(...args) => window.onChange(...args)}
+            onChange={window.onChange}
         >
             <SingleSelectOption value="1" label="option one" />
             <SingleSelectOption value="2" label="option two" />

--- a/src/__e2e__/SplitButton.stories.js
+++ b/src/__e2e__/SplitButton.stories.js
@@ -19,7 +19,7 @@ storiesOf('SplitButton', module)
             name="Button"
             value="default"
             component={<div>Component</div>}
-            onClick={(...args) => window.onClick(...args)}
+            onClick={window.onClick}
         >
             Label me!
         </SplitButton>

--- a/src/__e2e__/SplitButton.stories.js
+++ b/src/__e2e__/SplitButton.stories.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { SplitButton } from '../index.js'
 
+window.onClick = window.Cypress.cy.stub()
+
 storiesOf('SplitButton', module)
     .add('Default', () => (
         <SplitButton

--- a/src/__e2e__/Switch.stories.js
+++ b/src/__e2e__/Switch.stories.js
@@ -2,6 +2,10 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { Switch } from '../index.js'
 
+window.onChange = window.Cypress.cy.stub()
+window.onBlur = window.Cypress.cy.stub()
+window.onFocus = window.Cypress.cy.stub()
+
 storiesOf('Switch', module)
     .add('With onChange', () => (
         <Switch

--- a/src/__e2e__/Switch.stories.js
+++ b/src/__e2e__/Switch.stories.js
@@ -12,7 +12,7 @@ storiesOf('Switch', module)
             name="Ex"
             label="Switch"
             value="default"
-            onChange={(...args) => window.onChange(...args)}
+            onChange={window.onChange}
         />
     ))
     .add('With initialFocus and onBlur', () => (
@@ -21,7 +21,7 @@ storiesOf('Switch', module)
             name="Ex"
             label="Switch"
             value="default"
-            onBlur={(...args) => window.onBlur(...args)}
+            onBlur={window.onBlur}
         />
     ))
     .add('With onFocus', () => (
@@ -29,7 +29,7 @@ storiesOf('Switch', module)
             name="Ex"
             label="Switch"
             value="default"
-            onFocus={(...args) => window.onFocus(...args)}
+            onFocus={window.onFocus}
         />
     ))
     .add('With disabled', () => (

--- a/src/__e2e__/Tab.stories.js
+++ b/src/__e2e__/Tab.stories.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Tab } from '../index.js'
 
+window.onClick = window.Cypress.cy.stub()
+
 storiesOf('Tab', module)
     .add('With onClick', () => (
         <Tab onClick={(...args) => window.onClick(...args)}>Tab A</Tab>

--- a/src/__e2e__/Tab.stories.js
+++ b/src/__e2e__/Tab.stories.js
@@ -5,13 +5,11 @@ import { Tab } from '../index.js'
 window.onClick = window.Cypress.cy.stub()
 
 storiesOf('Tab', module)
-    .add('With onClick', () => (
-        <Tab onClick={(...args) => window.onClick(...args)}>Tab A</Tab>
-    ))
+    .add('With onClick', () => <Tab onClick={window.onClick}>Tab A</Tab>)
     .add('With children', () => <Tab>I am a child</Tab>)
     .add('With icon', () => <Tab icon={<div>Icon</div>}>Children</Tab>)
     .add('With onClick and disabled', () => (
-        <Tab onClick={(...args) => window.onClick(...args)} disabled>
+        <Tab onClick={window.onClick} disabled>
             Tab A
         </Tab>
     ))

--- a/src/__e2e__/TextArea.stories.js
+++ b/src/__e2e__/TextArea.stories.js
@@ -8,23 +8,13 @@ window.onFocus = window.Cypress.cy.stub()
 
 storiesOf('TextArea', module)
     .add('With onChange', () => (
-        <TextArea
-            onChange={(...args) => window.onChange(...args)}
-            name="textarea"
-        />
+        <TextArea onChange={window.onChange} name="textarea" />
     ))
     .add('With initialFocus and onBlur', () => (
-        <TextArea
-            initialFocus
-            name="textarea"
-            onBlur={(...args) => window.onBlur(...args)}
-        />
+        <TextArea initialFocus name="textarea" onBlur={window.onBlur} />
     ))
     .add('With onFocus', () => (
-        <TextArea
-            name="textarea"
-            onFocus={(...args) => window.onFocus(...args)}
-        />
+        <TextArea name="textarea" onFocus={window.onFocus} />
     ))
     .add('With initialFocus', () => <TextArea name="textarea" initialFocus />)
     .add('With disabled', () => <TextArea name="textarea" disabled />)

--- a/src/__e2e__/TextArea.stories.js
+++ b/src/__e2e__/TextArea.stories.js
@@ -2,6 +2,10 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { TextArea } from '../index.js'
 
+window.onChange = window.Cypress.cy.stub()
+window.onBlur = window.Cypress.cy.stub()
+window.onFocus = window.Cypress.cy.stub()
+
 storiesOf('TextArea', module)
     .add('With onChange', () => (
         <TextArea


### PR DESCRIPTION
# Status quo on master

So right now, in order to test whether the event handlers work, we create a stub in cypress and attach it to the `window` object of the testing story.  This approach works but manipulates the environment to be tested.

# What this PR changes

We have `window.Cypress.cy.stub` available in the stories, so we can make use of it,
so instead of creating the stub in the test, we create the stub in the story, attach it to the window object (so cypress has access to it) and then use it as the callback.
We also won't have to create anonymous functions anymore, we can pass in the stub directly because we're initializing it before the story is rendered.