### PR TITLE
ci(cypress): run tests on push instead of pr

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,7 +3,7 @@
 
 name: 'DHIS2'
 
-on: pull_request
+on: push
 
 jobs:
     cypress-run:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -1,6 +1,6 @@
 name: 'DHIS2'
 
-on: [pull_request]
+on: [push]
 
 jobs:
     pr:


### PR DESCRIPTION
Running cypress and jest unit tests on push instead of pr, so that we run them on master as well.