### PR TITLE
test(select): add specific data-test props

### DIFF
--- a/cypress/integration/MultiSelect/Accepts_loading/index.js
+++ b/cypress/integration/MultiSelect/Accepts_loading/index.js
@@ -17,5 +17,7 @@ Then('the loading spinner is displayed', () => {
 })
 
 Then('the loading text is displayed', () => {
-    cy.contains('Loading options').should('be.visible')
+    cy.get('[data-test="dhis2-uicore-multiselect-loading"]')
+        .contains('Loading options')
+        .should('be.visible')
 })

--- a/cypress/integration/MultiSelect/Accepts_placeholder/index.js
+++ b/cypress/integration/MultiSelect/Accepts_placeholder/index.js
@@ -10,11 +10,15 @@ Given('a MultiSelect with a placeholder and a selection is rendered', () => {
 })
 
 Then('the placeholder is shown', () => {
-    cy.contains('Placeholder text').should('be.visible')
+    cy.get('[data-test="dhis2-uicore-multiselect-placeholder"]')
+        .contains('Placeholder text')
+        .should('be.visible')
 })
 
 Then('the placeholder is not shown', () => {
-    cy.contains('Placeholder text').should('not.be.visible')
+    cy.get('[data-test="dhis2-uicore-multiselect-placeholder"]').should(
+        'not.be.visible'
+    )
 })
 
 Then('the selection is displayed', () => {

--- a/cypress/integration/MultiSelect/Accepts_prefix/index.js
+++ b/cypress/integration/MultiSelect/Accepts_prefix/index.js
@@ -10,7 +10,9 @@ Given('a MultiSelect with a prefix and a selection is rendered', () => {
 })
 
 Then('the prefix is shown', () => {
-    cy.contains('Prefix text').should('be.visible')
+    cy.get('[data-test="dhis2-uicore-multiselect-prefix"]')
+        .contains('Prefix text')
+        .should('be.visible')
 })
 
 Then('the selection is shown', () => {

--- a/cypress/integration/MultiSelect/Allows_invalid_options/index.js
+++ b/cypress/integration/MultiSelect/Allows_invalid_options/index.js
@@ -10,7 +10,10 @@ Given('a MultiSelect with invalid filterable options is rendered', () => {
 })
 
 When('the user enters a filter string', () => {
-    cy.focused().type('invalid')
+    cy.get('[data-test="dhis2-uicore-multiselect-filterinput"]')
+        .click()
+        .focused()
+        .type('invalid')
 })
 
 Then('the invalid options are displayed', () => {

--- a/cypress/integration/MultiSelect/Can_be_cleared/index.js
+++ b/cypress/integration/MultiSelect/Can_be_cleared/index.js
@@ -18,7 +18,7 @@ Given(
 )
 
 When('the clear button is clicked', () => {
-    cy.contains('Clear').click()
+    cy.get('[data-test="dhis2-uicore-multiselect-clear"]').click()
 })
 
 Then('the MultiSelect is cleared', () => {

--- a/cypress/integration/MultiSelect/Can_be_disabled/index.js
+++ b/cypress/integration/MultiSelect/Can_be_disabled/index.js
@@ -16,11 +16,12 @@ Given('the MultiSelect is closed', () => {
 })
 
 Given('the MultiSelect is focused', () => {
-    cy.get('[data-test="dhis2-uicore-select"] [tabIndex="0"]').focus()
+    cy.get('[data-test="dhis2-uicore-select-input"]').focus()
+    cy.focused().should('have.attr', 'data-test', 'dhis2-uicore-select-input')
 })
 
 When('the MultiSelect input is clicked', () => {
-    cy.get('[data-test="dhis2-uicore-select"] [tabIndex="0"]').click()
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
 })
 
 When('the down arrowkey is pressed on the focused element', () => {

--- a/cypress/integration/MultiSelect/Can_be_empty/index.js
+++ b/cypress/integration/MultiSelect/Can_be_empty/index.js
@@ -18,7 +18,9 @@ Then('an empty menu is displayed', () => {
 })
 
 Then('the custom empty text is displayed', () => {
-    cy.contains('Custom empty text').should('be.visible')
+    cy.get('[data-test="dhis2-uicore-multiselect-empty"]')
+        .contains('Custom empty text')
+        .should('be.visible')
 })
 
 Then('the custom empty component is displayed', () => {

--- a/cypress/integration/MultiSelect/Can_be_opened_and_closed/index.js
+++ b/cypress/integration/MultiSelect/Can_be_opened_and_closed/index.js
@@ -12,7 +12,8 @@ Given('the MultiSelect is closed', () => {
 })
 
 Given('the MultiSelect is focused', () => {
-    cy.get('[data-test="dhis2-uicore-select"] [tabIndex="0"]').focus()
+    cy.get('[data-test="dhis2-uicore-select-input"]').focus()
+    cy.focused().should('have.attr', 'data-test', 'dhis2-uicore-select-input')
 })
 
 When('the down arrowkey is pressed on the focused element', () => {

--- a/cypress/integration/MultiSelect/common/index.js
+++ b/cypress/integration/MultiSelect/common/index.js
@@ -24,7 +24,7 @@ Given(
 )
 
 Given('the MultiSelect is open', () => {
-    cy.get('[data-test="dhis2-uicore-select"] [tabIndex="0"]').click()
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
 
     cy.contains('option one').should('be.visible')
     cy.contains('option two').should('be.visible')
@@ -32,7 +32,7 @@ Given('the MultiSelect is open', () => {
 })
 
 When('the MultiSelect input is clicked', () => {
-    cy.get('[data-test="dhis2-uicore-select"] [tabIndex="0"]').click()
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
 })
 
 When('the user clicks the backdrop', () => {
@@ -52,7 +52,5 @@ Then('the options are displayed', () => {
 })
 
 Then('the MultiSelect has focus', () => {
-    cy.focused()
-        .parents('[data-test="dhis2-uicore-select"]')
-        .should('exist')
+    cy.focused().should('have.attr', 'data-test', 'dhis2-uicore-select-input')
 })

--- a/cypress/integration/SingleSelect/Accepts_loading/index.js
+++ b/cypress/integration/SingleSelect/Accepts_loading/index.js
@@ -17,5 +17,7 @@ Then('the loading spinner is displayed', () => {
 })
 
 Then('the loading text is displayed', () => {
-    cy.contains('Loading options').should('be.visible')
+    cy.get('[data-test="dhis2-uicore-singleselect-loading"]')
+        .contains('Loading options')
+        .should('be.visible')
 })

--- a/cypress/integration/SingleSelect/Accepts_placeholder/index.js
+++ b/cypress/integration/SingleSelect/Accepts_placeholder/index.js
@@ -10,11 +10,15 @@ Given('a SingleSelect with a placeholder and a selection is rendered', () => {
 })
 
 Then('the placeholder is shown', () => {
-    cy.contains('Placeholder text').should('be.visible')
+    cy.get('[data-test="dhis2-uicore-singleselect-placeholder"]')
+        .contains('Placeholder text')
+        .should('be.visible')
 })
 
 Then('the placeholder is not shown', () => {
-    cy.contains('Placeholder text').should('not.be.visible')
+    cy.get('[data-test="dhis2-uicore-singleselect-placeholder"]').should(
+        'not.be.visible'
+    )
 })
 
 Then('the selection is displayed', () => {

--- a/cypress/integration/SingleSelect/Accepts_prefix/index.js
+++ b/cypress/integration/SingleSelect/Accepts_prefix/index.js
@@ -10,7 +10,9 @@ Given('a SingleSelect with a prefix and a selection is rendered', () => {
 })
 
 Then('the prefix is shown', () => {
-    cy.contains('Prefix text').should('be.visible')
+    cy.get('[data-test="dhis2-uicore-singleselect-prefix"]')
+        .contains('Prefix text')
+        .should('be.visible')
 })
 
 Then('the selection is shown', () => {

--- a/cypress/integration/SingleSelect/Allows_invalid_options/index.js
+++ b/cypress/integration/SingleSelect/Allows_invalid_options/index.js
@@ -10,7 +10,10 @@ Given('a SingleSelect with invalid filterable options is rendered', () => {
 })
 
 When('the user enters a filter string', () => {
-    cy.focused().type('invalid')
+    cy.get('[data-test="dhis2-uicore-singleselect-filterinput"]')
+        .click()
+        .focused()
+        .type('invalid')
 })
 
 Then('the invalid options are displayed', () => {

--- a/cypress/integration/SingleSelect/Can_be_cleared/index.js
+++ b/cypress/integration/SingleSelect/Can_be_cleared/index.js
@@ -18,7 +18,7 @@ Given(
 )
 
 When('the clear button is clicked', () => {
-    cy.contains('Clear').click()
+    cy.get('[data-test="dhis2-uicore-singleselect-clear"]').click()
 })
 
 Then('the SingleSelect is cleared', () => {

--- a/cypress/integration/SingleSelect/Can_be_disabled/index.js
+++ b/cypress/integration/SingleSelect/Can_be_disabled/index.js
@@ -19,11 +19,8 @@ Given('the SingleSelect is closed', () => {
 })
 
 Given('the SingleSelect is focused', () => {
-    cy.get('[data-test="dhis2-uicore-select"] [tabIndex="0"]').focus()
-})
-
-When('the SingleSelect input is clicked', () => {
-    cy.get('[data-test="dhis2-uicore-select"] [tabIndex="0"]').click()
+    cy.get('[data-test="dhis2-uicore-select-input"]').focus()
+    cy.focused().should('have.attr', 'data-test', 'dhis2-uicore-select-input')
 })
 
 When('the down arrowkey is pressed on the focused element', () => {

--- a/cypress/integration/SingleSelect/Can_be_empty/index.js
+++ b/cypress/integration/SingleSelect/Can_be_empty/index.js
@@ -18,7 +18,9 @@ Then('an empty menu is displayed', () => {
 })
 
 Then('the custom empty text is displayed', () => {
-    cy.contains('Custom empty text').should('be.visible')
+    cy.get('[data-test="dhis2-uicore-singleselect-empty"]')
+        .contains('Custom empty text')
+        .should('be.visible')
 })
 
 Then('the custom empty component is displayed', () => {

--- a/cypress/integration/SingleSelect/Can_be_opened_and_closed/index.js
+++ b/cypress/integration/SingleSelect/Can_be_opened_and_closed/index.js
@@ -12,7 +12,8 @@ Given('the SingleSelect is closed', () => {
 })
 
 Given('the SingleSelect is focused', () => {
-    cy.get('[data-test="dhis2-uicore-select"] [tabIndex="0"]').focus()
+    cy.get('[data-test="dhis2-uicore-select-input"]').focus()
+    cy.focused().should('have.attr', 'data-test', 'dhis2-uicore-select-input')
 })
 
 When('the down arrowkey is pressed on the focused element', () => {

--- a/cypress/integration/SingleSelect/common/index.js
+++ b/cypress/integration/SingleSelect/common/index.js
@@ -28,7 +28,7 @@ Given('an onChange handler is attached', () => {
 })
 
 Given('the SingleSelect is open', () => {
-    cy.get('[data-test="dhis2-uicore-select"] [tabIndex="0"]').click()
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
 
     cy.contains('option one').should('exist')
     cy.contains('option two').should('exist')
@@ -36,7 +36,7 @@ Given('the SingleSelect is open', () => {
 })
 
 When('the SingleSelect input is clicked', () => {
-    cy.get('[data-test="dhis2-uicore-select"] [tabIndex="0"]').click()
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
 })
 
 When('the user clicks the backdrop', () => {
@@ -56,7 +56,5 @@ Then('the options are displayed', () => {
 })
 
 Then('the SingleSelect has focus', () => {
-    cy.focused()
-        .parents('[data-test="dhis2-uicore-select"]')
-        .should('exist')
+    cy.focused().should('have.attr', 'data-test', 'dhis2-uicore-select-input')
 })

--- a/src/MultiSelect.js
+++ b/src/MultiSelect.js
@@ -51,12 +51,13 @@ const MultiSelect = ({
     // If the select is filterable, use a filterable menu
     const menu = filterable ? (
         <FilterableMenu
+            dataTest={dataTest}
             empty={empty}
             noMatchText={noMatchText}
             placeholder={filterPlaceholder}
         />
     ) : (
-        <Menu empty={empty} />
+        <Menu empty={empty} dataTest={dataTest} />
     )
 
     return (
@@ -69,6 +70,7 @@ const MultiSelect = ({
                         <Input
                             clearable={clearable}
                             clearText={clearText}
+                            dataTest={dataTest}
                             placeholder={placeholder}
                             prefix={prefix}
                             inputMaxHeight={inputMaxHeight}
@@ -88,7 +90,12 @@ const MultiSelect = ({
                     dense={dense}
                 >
                     {children}
-                    {loading && <Loading message={loadingText} />}
+                    {loading && (
+                        <Loading
+                            message={loadingText}
+                            dataTest={`${dataTest}-loading`}
+                        />
+                    )}
                 </Select>
             </div>
             <StatusIcon error={error} valid={valid} warning={warning} />

--- a/src/MultiSelect/FilterableMenu.js
+++ b/src/MultiSelect/FilterableMenu.js
@@ -5,6 +5,7 @@ import { FilterableMenu as CommonFilterableMenu } from '../Select/FilterableMenu
 import { Menu } from './Menu.js'
 
 const FilterableMenu = ({
+    dataTest,
     options,
     onChange,
     selected,
@@ -15,6 +16,7 @@ const FilterableMenu = ({
     noMatchText,
 }) => (
     <CommonFilterableMenu
+        dataTest={dataTest}
         options={options}
         onChange={onChange}
         selected={selected}
@@ -28,6 +30,7 @@ const FilterableMenu = ({
 )
 
 FilterableMenu.propTypes = {
+    dataTest: propTypes.string.isRequired,
     noMatchText: propTypes.string.isRequired,
     empty: propTypes.node,
     handleClose: propTypes.func,

--- a/src/MultiSelect/Input.js
+++ b/src/MultiSelect/Input.js
@@ -14,6 +14,7 @@ const Input = ({
     clearable,
     clearText,
     placeholder,
+    dataTest,
     prefix,
     options,
     className,
@@ -30,9 +31,12 @@ const Input = ({
 
     return (
         <div className={cx('root', className)}>
-            <InputPrefix prefix={prefix} />
+            <InputPrefix prefix={prefix} dataTest={`${dataTest}-prefix`} />
             {!hasSelection && !prefix && (
-                <InputPlaceholder placeholder={placeholder} />
+                <InputPlaceholder
+                    placeholder={placeholder}
+                    dataTest={`${dataTest}-placeholder`}
+                />
             )}
             {hasSelection && (
                 <div className="root-input">
@@ -47,7 +51,11 @@ const Input = ({
             )}
             {hasSelection && clearable && !disabled && (
                 <div className="root-right">
-                    <InputClearButton onClear={onClear} clearText={clearText} />
+                    <InputClearButton
+                        onClear={onClear}
+                        clearText={clearText}
+                        dataTest={`${dataTest}-clear`}
+                    />
                 </div>
             )}
 
@@ -85,6 +93,7 @@ Input.defaultProps = {
 }
 
 Input.propTypes = {
+    dataTest: propTypes.string.isRequired,
     className: propTypes.string,
     clearText: propTypes.requiredIf(props => props.clearable, propTypes.string),
     clearable: propTypes.bool,

--- a/src/MultiSelect/Menu.js
+++ b/src/MultiSelect/Menu.js
@@ -37,13 +37,13 @@ const createHandler = ({ isActive, onChange, selected, value, label }) => (
     return onChange(data, e)
 }
 
-const Menu = ({ options, onChange, selected, empty }) => {
+const Menu = ({ options, onChange, selected, empty, dataTest }) => {
     const renderedOptions = filterIgnored(options)
 
     if (React.Children.count(renderedOptions) === 0) {
         // If it's a string, supply it to our <Empty> component so it looks better
         if (typeof empty === 'string') {
-            return <Empty message={empty} />
+            return <Empty message={empty} dataTest={`${dataTest}-empty`} />
         }
 
         // Otherwise just render the supplied markup
@@ -89,6 +89,7 @@ Menu.defaultProps = {
 }
 
 Menu.propTypes = {
+    dataTest: propTypes.string.isRequired,
     empty: propTypes.node,
     options: propTypes.node,
     selected: multiSelectedPropType,

--- a/src/Select.js
+++ b/src/Select.js
@@ -215,6 +215,7 @@ export class Select extends Component {
                     valid={valid}
                     disabled={disabled}
                     dense={dense}
+                    dataTest={`${dataTest}-input`}
                 >
                     {input}
                 </InputWrapper>

--- a/src/Select/Empty.js
+++ b/src/Select/Empty.js
@@ -2,8 +2,8 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { colors, spacers, theme } from '../theme.js'
 
-const Empty = ({ message, className }) => (
-    <div className={className}>
+const Empty = ({ message, className, dataTest }) => (
+    <div className={className} data-test={dataTest}>
         {message}
         <style jsx>{`
             div {
@@ -19,6 +19,7 @@ const Empty = ({ message, className }) => (
 )
 
 Empty.propTypes = {
+    dataTest: propTypes.string.isRequired,
     message: propTypes.string.isRequired,
     className: propTypes.string,
 }

--- a/src/Select/FilterInput.js
+++ b/src/Select/FilterInput.js
@@ -3,10 +3,11 @@ import propTypes from '@dhis2/prop-types'
 import { Input } from '../Input.js'
 import { spacers, colors } from '../theme.js'
 
-const FilterInput = ({ value, onChange, placeholder, className }) => (
+const FilterInput = ({ value, onChange, placeholder, className, dataTest }) => (
     <div className={className}>
         <Input
             dense
+            dataTest={dataTest}
             value={value}
             onChange={onChange}
             type="text"
@@ -28,6 +29,7 @@ const FilterInput = ({ value, onChange, placeholder, className }) => (
 )
 
 FilterInput.propTypes = {
+    dataTest: propTypes.string.isRequired,
     value: propTypes.string.isRequired,
     className: propTypes.string,
     placeholder: propTypes.string,

--- a/src/Select/FilterableMenu.js
+++ b/src/Select/FilterableMenu.js
@@ -19,6 +19,7 @@ export class FilterableMenu extends Component {
 
     render() {
         const {
+            dataTest,
             options,
             onChange,
             selected,
@@ -36,6 +37,7 @@ export class FilterableMenu extends Component {
             empty,
             handleClose,
             handleFocusInput,
+            dataTest,
         }
 
         const renderedOptions = filterIgnored(options)
@@ -45,6 +47,7 @@ export class FilterableMenu extends Component {
             return (
                 <React.Fragment>
                     <FilterInput
+                        dataTest={`${dataTest}-filterinput`}
                         placeholder={placeholder}
                         value={filter}
                         onChange={this.onFilterChange}
@@ -75,6 +78,7 @@ export class FilterableMenu extends Component {
         return (
             <React.Fragment>
                 <FilterInput
+                    dataTest={`${dataTest}-filterinput`}
                     placeholder={placeholder}
                     value={filter}
                     onChange={this.onFilterChange}
@@ -91,6 +95,7 @@ export class FilterableMenu extends Component {
 
 FilterableMenu.propTypes = {
     Menu: propTypes.elementType.isRequired,
+    dataTest: propTypes.string.isRequired,
     noMatchText: propTypes.string.isRequired,
     selected: propTypes.oneOfType([
         singleSelectedPropType,

--- a/src/Select/InputClearButton.js
+++ b/src/Select/InputClearButton.js
@@ -2,10 +2,11 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { Button } from '../Button.js'
 
-const InputClearButton = ({ onClear, clearText, className }) => (
+const InputClearButton = ({ onClear, clearText, className, dataTest }) => (
     <Button
         small
         secondary
+        dataTest={dataTest}
         onClick={onClear}
         type="button"
         className={className}
@@ -16,6 +17,7 @@ const InputClearButton = ({ onClear, clearText, className }) => (
 
 InputClearButton.propTypes = {
     clearText: propTypes.string.isRequired,
+    dataTest: propTypes.string.isRequired,
     onClear: propTypes.func.isRequired,
     className: propTypes.string,
 }

--- a/src/Select/InputPlaceholder.js
+++ b/src/Select/InputPlaceholder.js
@@ -2,13 +2,13 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { colors } from '../theme.js'
 
-const InputPlaceholder = ({ placeholder, className }) => {
+const InputPlaceholder = ({ placeholder, className, dataTest }) => {
     if (!placeholder) {
         return null
     }
 
     return (
-        <div className={className}>
+        <div className={className} data-test={dataTest}>
             {placeholder}
 
             <style jsx>{`
@@ -22,6 +22,7 @@ const InputPlaceholder = ({ placeholder, className }) => {
 }
 
 InputPlaceholder.propTypes = {
+    dataTest: propTypes.string.isRequired,
     className: propTypes.string,
     placeholder: propTypes.string,
 }

--- a/src/Select/InputPrefix.js
+++ b/src/Select/InputPrefix.js
@@ -2,13 +2,13 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { colors, spacers } from '../theme.js'
 
-const InputPrefix = ({ prefix, className }) => {
+const InputPrefix = ({ prefix, className, dataTest }) => {
     if (!prefix) {
         return null
     }
 
     return (
-        <div className={className}>
+        <div className={className} data-test={dataTest}>
             {prefix}
 
             <style jsx>{`
@@ -24,6 +24,7 @@ const InputPrefix = ({ prefix, className }) => {
 }
 
 InputPrefix.propTypes = {
+    dataTest: propTypes.string.isRequired,
     className: propTypes.string,
     prefix: propTypes.string,
 }

--- a/src/Select/InputWrapper.js
+++ b/src/Select/InputWrapper.js
@@ -6,6 +6,7 @@ import { ArrowDown } from './ArrowDown.js'
 import { colors, theme } from '../theme.js'
 
 const InputWrapper = ({
+    dataTest,
     onToggle,
     children,
     tabIndex,
@@ -31,6 +32,7 @@ const InputWrapper = ({
             onClick={onToggle}
             tabIndex={tabIndex}
             ref={inputRef}
+            data-test={dataTest}
         >
             <div className="root-children">{children}</div>
             <div className="root-right">
@@ -97,11 +99,10 @@ InputWrapper.defaultProps = {
 }
 
 InputWrapper.propTypes = {
+    dataTest: propTypes.string.isRequired,
     inputRef: propTypes.object.isRequired,
     tabIndex: propTypes.string.isRequired,
-
     onToggle: propTypes.func.isRequired,
-
     children: propTypes.element,
     className: propTypes.string,
     dense: propTypes.bool,

--- a/src/Select/Loading.js
+++ b/src/Select/Loading.js
@@ -3,8 +3,8 @@ import propTypes from '@dhis2/prop-types'
 import { colors, spacers, theme } from '../theme.js'
 import { CircularLoader } from '../CircularLoader.js'
 
-const Loading = ({ message, className }) => (
-    <div className={className}>
+const Loading = ({ message, className, dataTest }) => (
+    <div className={className} data-test={dataTest}>
         <CircularLoader small />
         {message}
         <style jsx>{`
@@ -22,6 +22,7 @@ const Loading = ({ message, className }) => (
 )
 
 Loading.propTypes = {
+    dataTest: propTypes.string.isRequired,
     className: propTypes.string,
     message: propTypes.string,
 }

--- a/src/SingleSelect.js
+++ b/src/SingleSelect.js
@@ -51,12 +51,13 @@ const SingleSelect = ({
     // If the select is filterable, use a filterable menu
     const menu = filterable ? (
         <FilterableMenu
+            dataTest={dataTest}
             empty={empty}
             noMatchText={noMatchText}
             placeholder={filterPlaceholder}
         />
     ) : (
-        <Menu empty={empty} />
+        <Menu empty={empty} dataTest={dataTest} />
     )
 
     return (
@@ -69,6 +70,7 @@ const SingleSelect = ({
                         <Input
                             clearable={clearable}
                             clearText={clearText}
+                            dataTest={dataTest}
                             placeholder={placeholder}
                             prefix={prefix}
                             inputMaxHeight={inputMaxHeight}
@@ -88,7 +90,12 @@ const SingleSelect = ({
                     dense={dense}
                 >
                     {children}
-                    {loading && <Loading message={loadingText} />}
+                    {loading && (
+                        <Loading
+                            message={loadingText}
+                            dataTest={`${dataTest}-loading`}
+                        />
+                    )}
                 </Select>
             </div>
             <StatusIcon error={error} valid={valid} warning={warning} />

--- a/src/SingleSelect/FilterableMenu.js
+++ b/src/SingleSelect/FilterableMenu.js
@@ -5,6 +5,7 @@ import { FilterableMenu as CommonFilterableMenu } from '../Select/FilterableMenu
 import { Menu } from './Menu.js'
 
 const FilterableMenu = ({
+    dataTest,
     options,
     onChange,
     selected,
@@ -15,6 +16,7 @@ const FilterableMenu = ({
     noMatchText,
 }) => (
     <CommonFilterableMenu
+        dataTest={dataTest}
         options={options}
         onChange={onChange}
         selected={selected}
@@ -28,6 +30,7 @@ const FilterableMenu = ({
 )
 
 FilterableMenu.propTypes = {
+    dataTest: propTypes.string.isRequired,
     noMatchText: propTypes.string.isRequired,
     empty: propTypes.node,
     handleClose: propTypes.func,

--- a/src/SingleSelect/Input.js
+++ b/src/SingleSelect/Input.js
@@ -14,6 +14,7 @@ const Input = ({
     clearable,
     clearText,
     placeholder,
+    dataTest,
     prefix,
     options,
     className,
@@ -30,9 +31,12 @@ const Input = ({
 
     return (
         <div className={cx('root', className)}>
-            <InputPrefix prefix={prefix} />
+            <InputPrefix prefix={prefix} dataTest={`${dataTest}-prefix`} />
             {!hasSelection && !prefix && (
-                <InputPlaceholder placeholder={placeholder} />
+                <InputPlaceholder
+                    placeholder={placeholder}
+                    dataTest={`${dataTest}-placeholder`}
+                />
             )}
             {hasSelection && (
                 <div className="root-input">
@@ -42,7 +46,11 @@ const Input = ({
             )}
             {hasSelection && clearable && !disabled && (
                 <div className="root-right">
-                    <InputClearButton onClear={onClear} clearText={clearText} />
+                    <InputClearButton
+                        onClear={onClear}
+                        clearText={clearText}
+                        dataTest={`${dataTest}-clear`}
+                    />
                 </div>
             )}
 
@@ -80,6 +88,7 @@ Input.defaultProps = {
 }
 
 Input.propTypes = {
+    dataTest: propTypes.string.isRequired,
     className: propTypes.string,
     clearText: propTypes.requiredIf(props => props.clearable, propTypes.string),
     clearable: propTypes.bool,

--- a/src/SingleSelect/Menu.js
+++ b/src/SingleSelect/Menu.js
@@ -16,13 +16,14 @@ const Menu = ({
     empty,
     handleFocusInput,
     handleClose,
+    dataTest,
 }) => {
     const renderedOptions = filterIgnored(options)
 
     if (React.Children.count(renderedOptions) === 0) {
         // If it's a string, supply it to our <Empty> component so it looks better
         if (typeof empty === 'string') {
-            return <Empty message={empty} />
+            return <Empty message={empty} dataTest={`${dataTest}-empty`} />
         }
 
         // Otherwise just render the supplied markup
@@ -68,6 +69,7 @@ Menu.defaultProps = {
 }
 
 Menu.propTypes = {
+    dataTest: propTypes.string.isRequired,
     empty: propTypes.node,
     handleClose: propTypes.func,
     handleFocusInput: propTypes.func,


### PR DESCRIPTION
Adding remaining specific data-test props for the select, so users can easier assert whether an element is present or not. Will squash this to `test(select): add specific data-test props` before rebasing on master, once approved.

See https://jira.dhis2.org/browse/TECH-280