### PR TITLE
fix(menu): style adjustments, dense divider, multiline items

### DIFF
--- a/src/Divider.js
+++ b/src/Divider.js
@@ -10,7 +10,7 @@ import { colors, spacers } from './theme.js'
  * @returns {React.Component}
  * @example import { Divider } from @dhis2/ui-core
  */
-const Divider = ({ margin, className, dataTest }) => (
+const Divider = ({ className, dataTest, dense, margin }) => (
     <div className={className} data-test={dataTest}>
         <style jsx>{`
             div {
@@ -22,27 +22,29 @@ const Divider = ({ margin, className, dataTest }) => (
         `}</style>
         <style jsx>{`
             div {
-                margin: ${margin};
+                margin: ${dense ? `${spacers.dp4} 0` : margin};
             }
         `}</style>
     </div>
 )
 
 Divider.defaultProps = {
-    margin: `${spacers.dp8} 0`,
     dataTest: 'dhis2-uicore-divider',
+    margin: `${spacers.dp8} 0`,
 }
 
 /**
  * @typedef {Object} PropTypes
  * @static
  * @prop {string} [className]
- * @prop {string} [margin="${spacers.dp8} 0"] - A CSS shorthand declaration for margin
  * @prop {string} [dataTest]
+ * @prop {bool} [dense]
+ * @prop {string} [margin="${spacers.dp8} 0"] - DEPRECATED: A CSS shorthand declaration for margin. If margin and dense are used at the same time, dense has precedence.
  */
 Divider.propTypes = {
     className: propTypes.string,
     dataTest: propTypes.string,
+    dense: propTypes.bool,
     margin: propTypes.string,
 }
 

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -16,7 +16,7 @@ import { spacers } from './theme.js'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/menu.md|Design system}
  * @see Live demo: {@link /demo/?path=/story/menu--default|Storybook}
  */
-const Menu = ({ children, className, dataTest }) => (
+const Menu = ({ children, className, dataTest, maxWidth }) => (
     <div className={className} data-test={dataTest}>
         <Card>
             <div className="menu-list-wrapper">
@@ -28,12 +28,22 @@ const Menu = ({ children, className, dataTest }) => (
             .menu-list-wrapper {
                 padding: ${spacers.dp4} 0;
             }
+            div {
+                display: inline-block;
+                min-width: 128px;
+            }
+        `}</style>
+        <style jsx>{`
+            div {
+                max-width: ${maxWidth};
+            }
         `}</style>
     </div>
 )
 
 Menu.defaultProps = {
     dataTest: 'dhis2-uicore-menu',
+    maxWidth: '380px',
 }
 
 /**
@@ -43,11 +53,13 @@ Menu.defaultProps = {
  * @prop {*} [children]
  * @prop {string} [className]
  * @prop {string} [dataTest]
+ * @prop {string} [maxWidth]
  */
 Menu.propTypes = {
     children: MenuList.propTypes.children,
     className: propTypes.string,
     dataTest: propTypes.string,
+    maxWidth: propTypes.string,
 }
 
 export { Menu }

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -64,6 +64,7 @@ const MenuItem = ({
     icon,
     children,
     active,
+    destructive,
     disabled,
     dense,
     onClick,
@@ -84,6 +85,7 @@ const MenuItem = ({
     return (
         <li
             className={cx(className, subMenu.className, {
+                destructive,
                 disabled,
                 dense,
                 active,
@@ -125,6 +127,7 @@ MenuItem.defaultProps = {
  * @prop {Element} [icon]
  * @prop {boolean} [dense]
  * @prop {boolean} [active]
+ * @prop {boolean} [destructive]
  * @prop {boolean} [disabled]
  * @prop {string} [dataTest]
  */
@@ -134,6 +137,7 @@ MenuItem.propTypes = {
     className: propTypes.string,
     dataTest: propTypes.string,
     dense: propTypes.bool,
+    destructive: propTypes.bool,
     disabled: propTypes.bool,
     href: propTypes.string,
     icon: propTypes.element,

--- a/src/MenuItem/styles.js
+++ b/src/MenuItem/styles.js
@@ -4,7 +4,6 @@ import { colors, spacers } from '../theme.js'
 export default css`
     li {
         position: relative;
-        height: 48px;
         padding: 0;
         cursor: pointer;
         list-style: none;
@@ -23,13 +22,13 @@ export default css`
         background-color: ${colors.grey400};
     }
 
-    .dense {
-        height: 32px;
-        padding: 0 ${spacers.dp24} 0 ${spacers.dp12};
+    .dense .link {
+        padding: ${spacers.dp8} ${spacers.dp12};
     }
 
     .dense .label {
         font-size: 14px;
+        line-height: 16px;
     }
 
     .dense .icon {
@@ -44,13 +43,29 @@ export default css`
 
     .disabled .icon,
     .disabled .label {
-        color: rgba(0, 0, 0, 0.3);
+        color: ${colors.grey500};
+    }
+
+    .destructive .label {
+        color: ${colors.red700};
+    }
+
+    .destructive .icon {
+        color: ${colors.red600};
+    }
+
+    li.destructive:hover {
+        background-color: ${colors.red050};
+    }
+
+    li.destructive:active {
+        background-color: ${colors.red100};
     }
 
     .link {
         display: block;
         height: 100%;
-        padding: 0 ${spacers.dp24};
+        padding: 15px ${spacers.dp24};
         text-decoration: none;
         display: flex;
         flex-direction: row;
@@ -60,13 +75,8 @@ export default css`
     .label {
         color: ${colors.grey900};
         font-size: 15px;
-
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-
+        line-height: 18px;
         user-select: none;
-        padding-right: ${spacers.dp12};
     }
 
     .icon {

--- a/src/__demo__/Menu.stories.js
+++ b/src/__demo__/Menu.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 
 import { Menu, MenuItem, Divider, Switch } from '../index.js'
 
-const Wrapper = fn => <div style={{ width: '358px' }}>{fn()}</div>
+const Wrapper = fn => <div style={{}}>{fn()}</div>
 
 storiesOf('Menu', module)
     .addDecorator(Wrapper)
@@ -51,7 +51,7 @@ storiesOf('Menu', module)
 
             <Divider />
             <MenuItem
-                label="Two"
+                label="This is a long menu item name, that should span onto multiple lines"
                 value="two"
                 onClick={val => {
                     alert(`this is ${val}`)
@@ -64,6 +64,15 @@ storiesOf('Menu', module)
                     alert(`this is ${val}`)
                 }}
             />
+        </Menu>
+    ))
+
+    .add('Short item labels', () => (
+        <Menu>
+            <MenuItem label="dog" />
+            <Divider />
+            <MenuItem label="cat" />
+            <MenuItem label="tree" />
         </Menu>
     ))
 

--- a/src/__demo__/Menu.stories.js
+++ b/src/__demo__/Menu.stories.js
@@ -91,7 +91,7 @@ storiesOf('Menu', module)
                     />
                 }
             />
-            <Divider />
+            <Divider dense />
             <MenuItem
                 dense
                 label="Three"
@@ -125,7 +125,7 @@ storiesOf('Menu', module)
                 </Menu>
             </MenuItem>
 
-            <Divider />
+            <Divider dense />
             <MenuItem
                 dense
                 label="Two"

--- a/src/__demo__/Menu.stories.js
+++ b/src/__demo__/Menu.stories.js
@@ -64,6 +64,22 @@ storiesOf('Menu', module)
                     alert(`this is ${val}`)
                 }}
             />
+            <MenuItem
+                disabled
+                label="Disabled menu item"
+                value="four"
+                onClick={val => {
+                    alert(`this is ${val}`)
+                }}
+            />
+            <MenuItem
+                destructive
+                label="Destructive menu item"
+                value="five"
+                onClick={val => {
+                    alert(`this is ${val}`)
+                }}
+            />
         </Menu>
     ))
 
@@ -138,6 +154,24 @@ storiesOf('Menu', module)
                 dense
                 label="Three"
                 value="three"
+                onClick={val => {
+                    alert(`this is ${val}`)
+                }}
+            />
+            <MenuItem
+                dense
+                disabled
+                label="Disabled menu item"
+                value="four"
+                onClick={val => {
+                    alert(`this is ${val}`)
+                }}
+            />
+            <MenuItem
+                dense
+                destructive
+                label="Destructive menu item"
+                value="five"
                 onClick={val => {
                     alert(`this is ${val}`)
                 }}


### PR DESCRIPTION
Fixes some of the issues from https://github.com/dhis2/ui-core/issues/500, I've not included things that could be considered features.

Fixed/Added to menu and/or menu-item
- min-width
- max-width, can be customised
- dense divider style
- destructive menu-item style
- disabled menu-item style
- allow multi-line menu items
- removed menu-item heights, now set via padding on content
- adjusted dense menu-item padding

I'm not sure if any of these would classify as being added as a `feat` instead, let me know if so.

Note: I've added and removed some props, I think I've done this in the correct way by documenting them with ` * @prop {boolean} [destructive]` etc. but an extra set of eyes here is much appreciated.