### PR TITLE
refactor: improved layering system

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -1,0 +1,66 @@
+import cx from 'classnames'
+import React, { createContext, useState, useContext } from 'react'
+import { createPortal } from 'react-dom'
+import propTypes from '@dhis2/prop-types'
+import { oneOf } from 'prop-types'
+
+const LayerContext = createContext({
+    node: document.body,
+    level: 0,
+})
+
+const Layer = ({ children, className, level, position }) => {
+    const parentLayer = useContext(LayerContext)
+    const [layerEl, setLayerEl] = useState(null)
+    const nextLayer = {
+        node: layerEl,
+        level: Math.max(parentLayer.level, level),
+    }
+    const portalNode =
+        level > parentLayer.level ? document.body : parentLayer.node
+
+    return createPortal(
+        <div
+            ref={setLayerEl}
+            className={cx(className, position, `level-${level}`)}
+        >
+            {layerEl && (
+                <LayerContext.Provider value={nextLayer}>
+                    {children}
+                </LayerContext.Provider>
+            )}
+            <style jsx>{`
+                div {
+                    z-index: ${level};
+                    height: 100%;
+                    width: 100%;
+                }
+                div.fixed {
+                    position: fixed;
+                    height: 100vh;
+                    width: 100vw;
+                }
+                div.absolute {
+                    position: absolute;
+                }
+                div.relative {
+                    position: relative;
+                }
+            `}</style>
+        </div>,
+        portalNode
+    )
+}
+
+Layer.defaultProps = {
+    position: 'fixed',
+}
+
+Layer.propTypes = {
+    children: propTypes.node,
+    className: propTypes.string,
+    level: propTypes.number,
+    position: oneOf(['absolute', 'relative', 'fixed']),
+}
+
+export { Layer }

--- a/src/__demo__/Layer.stories.js
+++ b/src/__demo__/Layer.stories.js
@@ -1,0 +1,126 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import propTypes from '@dhis2/prop-types'
+import { Layer } from '../Layer.js'
+import { layers } from '../theme.js'
+
+const logger = event => {
+    event.stopPropagation()
+    console.log('I happened', event.currentTarget)
+}
+
+const DivInLayer = ({ stackLevel, className, children }) => (
+    <Layer level={stackLevel}>
+        <div className={className} onClick={logger}>
+            {children}
+        </div>
+        <style jsx>{`
+            div {
+                position: absolute;
+                width: 210px;
+                height: 140px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+            }
+            .layer-a-child {
+                top: 0;
+                left: 0;
+                background-color: magenta;
+            }
+            .layer-b-child {
+                top: 0;
+                left: 140px;
+                background-color: blue;
+            }
+            .layer-c-child {
+                top: 0;
+                left: 280px;
+                background-color: green;
+            }
+            .layer-d-child {
+                top: 90px;
+                left: 0;
+                background-color: orange;
+            }
+            .layer-e-child {
+                top: 90px;
+                left: 140px;
+                background-color: red;
+            }
+            .layer-f-child {
+                top: 90px;
+                left: 280px;
+                background-color: turquoise;
+            }
+        `}</style>
+    </Layer>
+)
+
+DivInLayer.propTypes = {
+    stackLevel: propTypes.number.isRequired,
+    children: propTypes.node,
+    className: propTypes.string,
+}
+
+storiesOf('Layer', module).add('Stacked layers (pure nesting)', () => (
+    <>
+        <DivInLayer stackLevel={layers.alert} className="layer-a-child">
+            A
+            <DivInLayer stackLevel={layers.blocking} className="layer-b-child">
+                B
+                <DivInLayer stackLevel={4561} className="layer-c-child">
+                    C
+                </DivInLayer>
+            </DivInLayer>
+        </DivInLayer>
+        <DivInLayer stackLevel={layers.blocking} className="layer-d-child">
+            D
+            <DivInLayer stackLevel={layers.blocking} className="layer-e-child">
+                E
+                <DivInLayer
+                    stackLevel={layers.applicationTop}
+                    className="layer-f-child"
+                >
+                    F
+                </DivInLayer>
+            </DivInLayer>
+        </DivInLayer>
+        <style jsx>{`
+            :global(#root) {
+                height: auto !important;
+            }
+        `}</style>
+    </>
+))
+
+storiesOf('Layer', module).add('Inverse nesting', () => (
+    <>
+        <DivInLayer stackLevel={layers.blocking} className="layer-a-child">
+            A
+            <DivInLayer stackLevel={layers.alert} className="layer-b-child">
+                B
+                <DivInLayer stackLevel={layers.alert} className="layer-c-child">
+                    C
+                </DivInLayer>
+            </DivInLayer>
+        </DivInLayer>
+        <DivInLayer stackLevel={layers.blocking} className="layer-d-child">
+            D
+            <DivInLayer
+                stackLevel={layers.applicationTop}
+                className="layer-e-child"
+            >
+                E
+                <DivInLayer stackLevel={layers.alert} className="layer-f-child">
+                    F
+                </DivInLayer>
+            </DivInLayer>
+        </DivInLayer>
+        <style jsx>{`
+            :global(#root) {
+                height: auto !important;
+            }
+        `}</style>
+    </>
+))


### PR DESCRIPTION
### TL;DR

- Start leveraging z-index stacking context
- Use `StackedLayer` to create a new stack/layer in the stacking context and append a portal to it
- Use `Layer` to append a portal to the current stacking context layer
- Use `BaseLayer` to append a portal to the document.body

---

I've been thinking about issue #596 and and have been experimenting with a possible solution for this. I think I have come up with the start of an approach that probably makes more sense than what we have now.

I think that at the core of the problem is the fact that our definition of how stacking should work in an app is an oversimplification of how things really work. Our [design specs](https://github.com/dhis2/design-system/blob/master/principles/spacing-alignment.md#stacking) only define 5 “layers” in an app, and don’t take into account how things may be stacked upon one another. This was also reflected in the first bug we found, a `Select` was rendered from within a `Modal` and the select-menu was rendered below the modal because the select-menu has a lower z-index than the modal.

Our current `LayerContext` solution for this attempts to hold on to the approach already in place (i.e. all portals are appended to the end of the `document.body`) but then tries to correct the zIndex value to make sure things overlap correctly. In previous conversations about this @ismay already suggested that leveraging the z-index stacking-context could simplify things a lot when rendering elements on top of each other. So effectively that would mean that we don’t always append elements to the end of the document body, but instead we would append to a closer ancestor that we need to stack upon.

Conceptually this makes a lot of sense, but I also had some reservations about this. The reason we were appending to the `document.body` in the first place, was because we needed a solid way to avoid potential z-index conflicts and overflow issues. Imo this is still a relevant consideration to take into account. As such, I would argue that we should strive to find a solution that meets these two criteria:
- Leverages the z-index stacking context instead of trying to correct/compute z-index values. This implies we are going to be nesting elements instead of rendering them as siblings.
- Prevent potential overflow and z-index issues. This implies we need to control the styles of the elements that are going to be nested.

### Leveraging the z-index stacking context
When we want to render an element on top of another element, we use `React.createPortal` instead of simply rendering the child from the parent. This is to avoid the aforementioned overflow and z-index problems, and we should definitely keep doing so. The second argument provided to `React.createPortal` is the `container` element, i.e. the element the child is appended to. If we had a `LayerContext` that would not keep track of a computed `zIndex`, but rather a `layerRootElement` we can control the nesting of the components via that. Each time we use `React.createPortal` we use the `layerRootElement` from the context as the `container` argument. Most often this will just be the `document.body`, but if we are rendering layers on top of each other, the `layerRootElement` will be the element provided to the closest ancestor's `LayerContext.Provider`.

### Prevent potential overflow and z-index issues
Given that each layer produces an actual element that can function as the container for the next portal, we can apply styling to that layer that avoids these issues:
- Overflow should not be hidden
- Perhaps rules should be applied to make sure the layer covers the whole screen/ document
- Perhaps we need `fixed` vs `relative` mode

Or perhaps we don’t need any of the above, perhaps just rendering everything in an element that doesn’t have any styling is enough. It might be the case that all we need is to prevent the `layerRootElement` to have certain styles that could cause problems. And if this is the case an unstyled element would do…

### Implementation
I’ve had a go at implementing the approach I’ve outlined in this draft PR. This is all very basic, but illustrates the main approach. Some notes:
- I’ve differentiated between three different scenarios:
	- Adding a new level to the stacking-context can be done by wrapping JSX in a `StackedLayer` (i.e. nesting the new portal in the root of the current portal and creating a new root in the LayerContext).
	- Appending a new portal to the current stacking-context can be done by wrapping JSX in a `Layer`
	- In some cases (I guess alerts) you might want to guarantee that an element is always on top of everything else. This can be guaranteed by appending to the end of the `document.body` and give the highest z-index in our design-system. So, in these cases you’d want to completely opt-out of the z-index stacking context and just append the portal to the document.body again. Do achieve this I have introduced the `BaseLayer` component.
- I’ve assumed that the root element doesn’t need any styling, as suggested above.
- I’ve also included a hook for getting the current layerRootElement, called `useLayerRootElement`, but I don’t actually see any use cases for this yet
- The stories attempt to demonstrate the element hierarchy that would be generated by the given JSX markup. This is also pretty minimal, but I hope it contains enough to illustrate the approach. Please focus on the DOM, because the UI doesn’t make complete sense, because none of these elements have any styling that resembles a Popover/Modal.
- In the `Layer` component I am currently using a constructor in which I set a class-name on the layer element. That’s simply there to clarify what is happening in the story. In a final implementation I’d probably just use a class property instead.

### Consequences for the design-system
I think introducing a layered system that leverages z-index stacking context makes sense. However, the design-system doesn’t include the notion of stacking things on top of each other, so if we chose to include it in the technical implementation we’ll have to also update the design specs to reflect that.
