### PR TITLE
chore(storybook jsx addon): add missing decorator to show jsx again

### DIFF
--- a/.storybook/decorators.js
+++ b/.storybook/decorators.js
@@ -1,7 +1,9 @@
 import React, { Fragment } from 'react'
 import { addDecorator } from '@storybook/react'
-
+import { jsxDecorator } from 'storybook-addon-jsx'
 import { CssReset } from '../src/index.js'
+
+addDecorator(jsxDecorator)
 
 addDecorator(fn => (
     <Fragment>


### PR DESCRIPTION
This will add the jsx-addon decorator which is missing since we upgraded to the newer setup-style.