### PR TITLE
feat: tooltip with support for renderprops

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -65,7 +65,7 @@ class Tooltip extends Component {
         const {
             children,
             className,
-            component: Component,
+            tag: Element,
             content,
             dataTest,
             maxWidth,
@@ -75,14 +75,22 @@ class Tooltip extends Component {
 
         return (
             <>
-                <Component
-                    onMouseOver={this.onMouseOver}
-                    onMouseOut={this.onMouseOut}
-                    ref={this.ref}
-                    data-test={`${dataTest}-reference`}
-                >
-                    {children}
-                </Component>
+                {typeof children === 'function' ? (
+                    children({
+                        onMouseOver: this.onMouseOver,
+                        onMouseOut: this.onMouseOut,
+                        ref: this.ref,
+                    })
+                ) : (
+                    <Element
+                        onMouseOver={this.onMouseOver}
+                        onMouseOut={this.onMouseOut}
+                        ref={this.ref}
+                        data-test={`${dataTest}-reference`}
+                    >
+                        {children}
+                    </Element>
+                )}
 
                 {open &&
                     createPortal(
@@ -122,9 +130,9 @@ class Tooltip extends Component {
 
 Tooltip.defaultProps = {
     dataTest: 'dhis2-uicore-tooltip',
-    component: 'span',
     maxWidth: 300,
     placement: 'top',
+    tag: 'span',
 }
 
 /**
@@ -132,41 +140,20 @@ Tooltip.defaultProps = {
  * @static
  * @prop {Node} [children]
  * @prop {string} [className]
- * @prop {string|function} [component] Use a custom component to wrap the Tooltip children or pass a string (i.e. 'p') to use a custom built-in component
- * @example
- * const Content = React.forwardRef(
- *     ({ children, onMouseOver, onMouseOut, dataTest }, ref) => (
- *         <em
- *             style={{ display: 'inline-block', color: 'red' }}
- *             ref={ref}
- *             onMouseOver={onMouseOver}
- *             onMouseOut={onMouseOut}
- *             dataTest={`${dataTest}-reference`}
- *         >
- *             {children}
- *         </em>
- *     )
- * )
- * Content.displayName = 'Content'
- * Content.propTypes = {
- *     children: propTypes.node,
- *     dataTest: propTypes.string,
- *     onMouseOut: propTypes.func,
- *     onMouseOver: propTypes.func,
- * }
  * @prop {Node} [content]
- * @prop {string} [dataTest]
- * @prop {number} [maxWidth]
+ * @prop {string} [dataTest=dhis2-uicore-tooltip]
+ * @prop {number} [maxWidth=300]
  * @prop {('top'|'bottom'|'right'|'left')} [placement=top]
+ * @prop {string} [tag=span] The HTML tag to render
  */
 Tooltip.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
-    component: propTypes.oneOfType([propTypes.string, propTypes.func]),
     content: propTypes.node,
     dataTest: propTypes.string,
     maxWidth: propTypes.number,
     placement: propTypes.oneOf(['top', 'right', 'bottom', 'left']),
+    tag: propTypes.string,
 }
 
 export { Tooltip, TOOLTIP_OFFSET }

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -65,7 +65,6 @@ class Tooltip extends Component {
         const {
             children,
             className,
-            tag: Element,
             content,
             dataTest,
             maxWidth,
@@ -82,14 +81,14 @@ class Tooltip extends Component {
                         ref: this.ref,
                     })
                 ) : (
-                    <Element
+                    <span
                         onMouseOver={this.onMouseOver}
                         onMouseOut={this.onMouseOut}
                         ref={this.ref}
                         data-test={`${dataTest}-reference`}
                     >
                         {children}
-                    </Element>
+                    </span>
                 )}
 
                 {open &&
@@ -144,7 +143,6 @@ Tooltip.defaultProps = {
  * @prop {string} [dataTest=dhis2-uicore-tooltip]
  * @prop {number} [maxWidth=300]
  * @prop {('top'|'bottom'|'right'|'left')} [placement=top]
- * @prop {string} [tag=span] The HTML tag to render
  */
 Tooltip.propTypes = {
     children: propTypes.node,
@@ -153,7 +151,6 @@ Tooltip.propTypes = {
     dataTest: propTypes.string,
     maxWidth: propTypes.number,
     placement: propTypes.oneOf(['top', 'right', 'bottom', 'left']),
-    tag: propTypes.string,
 }
 
 export { Tooltip, TOOLTIP_OFFSET }

--- a/src/__demo__/Tooltip.stories.js
+++ b/src/__demo__/Tooltip.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Tooltip } from '../Tooltip.js'
-import propTypes from '@dhis2/prop-types'
+import { Button } from '../Button.js'
 
 export default {
     title: 'Tooltip',
@@ -59,11 +59,11 @@ export const PlacementLeft = () => (
     </p>
 )
 
-export const CustomElement = () => {
+export const CustomElementViaTagProp = () => {
     return (
         <p>
             I am a{' '}
-            <Tooltip content="Some extra info" component="p">
+            <Tooltip content="Some extra info" tag="em">
                 paragraph
             </Tooltip>{' '}
             that contains a tooltip.
@@ -71,35 +71,53 @@ export const CustomElement = () => {
     )
 }
 
-const Content = React.forwardRef(
-    ({ children, onMouseOver, onMouseOut, ...rest }, ref) => (
-        <em
-            style={{ display: 'inline-block', color: 'red' }}
-            ref={ref}
-            onMouseOver={onMouseOver}
-            onMouseOut={onMouseOut}
-            {...rest}
-        >
-            {children}
-        </em>
+export const CustomBuiltInComponent = () => {
+    return (
+        <p>
+            I am a{' '}
+            <Tooltip content="Some extra info">
+                {({ ref, onMouseOver, onMouseOut }) => (
+                    <span
+                        ref={ref}
+                        onMouseOver={onMouseOver}
+                        onMouseOut={onMouseOut}
+                    >
+                        paragraph
+                        <style jsx>{`
+                            span {
+                                color: green;
+                                text-decoration: underline;
+                            }
+                        `}</style>
+                    </span>
+                )}
+            </Tooltip>{' '}
+            that contains a tooltip.
+        </p>
     )
-)
-Content.displayName = 'Content'
-Content.propTypes = {
-    children: propTypes.node,
-    dataTest: propTypes.string,
-    onMouseOut: propTypes.func,
-    onMouseOver: propTypes.func,
 }
 
 export const CustomComponent = () => {
     return (
         <p>
             I am a{' '}
-            <Tooltip content="Some extra info" component={Content}>
-                paragraph
+            <Tooltip content="Some extra info">
+                {({ ref, onMouseOver, onMouseOut }) => (
+                    <span
+                        ref={ref}
+                        onMouseOver={onMouseOver}
+                        onMouseOut={onMouseOut}
+                    >
+                        <Button>paragraph</Button>
+                        <style jsx>{`
+                            span {
+                                display: inline-flex;
+                            }
+                        `}</style>
+                    </span>
+                )}
             </Tooltip>{' '}
-            that contains a tooltip.
+            that contains a Button with a tooltip.
         </p>
     )
 }


### PR DESCRIPTION
The purpose of this PR is mainly to demonstrate a generic approach to dealing with components that need to be able to render any content, but do require this content to implement certain props. 

This is an example for the `Tooltip`, but we see the same/a very similar problem appear in  the `Menu`/`SubMenu` too.

The main idea is that we offer two methods of rendering:
- For default scenarios we accept children in the normal way (CONVENIENT)
- And if further customization is required we switch to the renderProps approach (FLEXIBLE)

So for the Tooltip this means:
- Normally children are simply wrapped in a `span` and the ref, OnMouseOver, onMouseOut props are attached to that in the Tooltip. If the app wants to use a different tag, this can be customised via the `tag` prop (see demo CustomElementViaTagProp)
- If further customisation is needed, the app can switch to renderProps (see CustomBuiltInComponent and CustomComponent)

An important note for that last example, CustomComponent: 
In the example you see that I am adding a wrapper around the Button. This is for two reasons:
1. The Button is currently not able to hold a ref. But we can see in @dhis2/ui that this is going to change...
2. The Tooltip anchor needs to implement not only a ref, but also a `onMouseOver` and `onMouseOut`, and our Button has not implemented those methods either.

There's nothing wrong with a wrapper element per se, but if we look into the future, i.e. `@dhis2/ui` , where the `*Base` components [can all hold a ref](https://github.com/dhis2/ui/blob/alpha/packages/core/src/ButtonBase/ButtonBase.js#L69) and [forward props](https://github.com/dhis2/ui/blob/alpha/packages/core/src/ButtonBase/ButtonBase.js#L29), we could also solve this in a different way, using the `ButtonBase`:

_quick and dirty:_
```jsx
<p>
    I am a{' '}
    <Tooltip content="Some extra info">
        {tooltipProps => <ButtonBase {...tooltipProps}>paragraph</ButtonBase>}
    </Tooltip>{' '}
    that contains a Button with a tooltip.
</p>
```

_dedicated component:_
```jsx
const TooltipButton = ({ children, content, placement, onClick }) => (
    <Tooltip content={content} placement={placement}>
        {tooltipRenderProps => (
            <ButtonBase {...tooltipRenderProps} onClick={onClick}>
                {children}
            </ButtonBase>
        )}
    </Tooltip>
)

<p>I am a paragrapg that contains a <TooltipButton content="Some extra info">tooltip button</TooltipButton>.</p>
```

**If I've understood the feedback I've received recently correctly, then one of the main problems that has been mentioned is the lack of transparency. Does the current approach with renderProps solve that in your opinions?**


