### PR TITLE
refactor: rearrange overlay components

### DIFF
--- a/src/CenteredContent.js
+++ b/src/CenteredContent.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
+
+/**
+ * @module
+ * @param {CenteredContent.PropTypes} props
+ * @returns {React.Component}
+ * @example import { CenteredContent } from @dhis2/ui-core
+ * @see Live demo: {@link /demo/?path=/story/centeredcontent--default|Storybook}
+ */
+const CenteredContent = ({ className, dataTest, children }) => (
+    <div className={className} data-test={dataTest}>
+        {children}
+        <style jsx>{`
+            div {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                height: 100%;
+                width: 100%;
+            }
+        `}</style>
+    </div>
+)
+
+CenteredContent.defaultProps = {
+    dataTest: 'dhis2-uicore-centeredcontent',
+}
+
+/**
+ * @typedef {Object} PropTypes
+ * @static
+ * @prop {string} [className]
+ * @prop {Node} [children]
+ * @prop {string} [dataTest]
+ */
+CenteredContent.propTypes = {
+    children: propTypes.node,
+    className: propTypes.string,
+    dataTest: propTypes.string,
+}
+
+export { CenteredContent }

--- a/src/ComponentCover.js
+++ b/src/ComponentCover.js
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 import { layers } from './theme.js'
@@ -10,21 +11,31 @@ import { layers } from './theme.js'
  * @example import { ComponentCover } from @dhis2/ui-core
  * @see Live demo: {@link /demo/?path=/story/componentcover--circularloader|Storybook}
  */
-const ComponentCover = ({ children, className, dataTest }) => (
-    <div className={className} data-test={dataTest}>
+const ComponentCover = ({
+    children,
+    className,
+    dataTest,
+    onClick,
+    pointerEvents,
+    translucent,
+}) => (
+    <div
+        className={cx(className, { translucent })}
+        onClick={onClick}
+        data-test={dataTest}
+    >
         {children}
         <style jsx>{`
             div {
-                display: flex;
-                align-items: center;
-                justify-content: center;
-
                 position: absolute;
-
-                height: inherit;
-                width: inherit;
-
-                z-index: ${layers.applicationTop - 1};
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+                z-index: ${layers.applicationTop};
+                pointer-events: ${pointerEvents};
+            }
+            div.translucent {
                 background: rgba(33, 43, 54, 0.4);
             }
         `}</style>
@@ -33,6 +44,7 @@ const ComponentCover = ({ children, className, dataTest }) => (
 
 ComponentCover.defaultProps = {
     dataTest: 'dhis2-uicore-componentcover',
+    pointerEvents: 'all',
 }
 
 /**
@@ -46,6 +58,9 @@ ComponentCover.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    pointerEvents: propTypes.oneOf(['all', 'none']),
+    translucent: propTypes.bool,
+    onClick: propTypes.func,
 }
 
 export { ComponentCover }

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -2,14 +2,22 @@ import cx from 'classnames'
 import React, { createContext, useState, useContext } from 'react'
 import { createPortal } from 'react-dom'
 import propTypes from '@dhis2/prop-types'
-import { oneOf } from 'prop-types'
 
 const LayerContext = createContext({
     node: document.body,
     level: 0,
 })
 
-const Layer = ({ children, className, level, position }) => {
+const Layer = ({
+    children,
+    className,
+    dataTest,
+    level,
+    onClick,
+    pointerEvents,
+    position,
+    translucent,
+}) => {
     const parentLayer = useContext(LayerContext)
     const [layerEl, setLayerEl] = useState(null)
     const nextLayer = {
@@ -22,7 +30,11 @@ const Layer = ({ children, className, level, position }) => {
     return createPortal(
         <div
             ref={setLayerEl}
-            className={cx(className, position, `level-${level}`)}
+            className={cx(className, position, `level-${level}`, {
+                translucent,
+            })}
+            data-test={dataTest}
+            onClick={onClick}
         >
             {layerEl && (
                 <LayerContext.Provider value={nextLayer}>
@@ -32,8 +44,15 @@ const Layer = ({ children, className, level, position }) => {
             <style jsx>{`
                 div {
                     z-index: ${level};
+                    pointer-events: ${pointerEvents};
+                }
+            `}</style>
+            <style jsx>{`
+                div {
                     height: 100%;
                     width: 100%;
+                    top: 0;
+                    left: 0;
                 }
                 div.fixed {
                     position: fixed;
@@ -46,6 +65,9 @@ const Layer = ({ children, className, level, position }) => {
                 div.relative {
                     position: relative;
                 }
+                div.translucent {
+                    background-color: rgba(33, 43, 54, 0.4);
+                }
             `}</style>
         </div>,
         portalNode
@@ -54,13 +76,19 @@ const Layer = ({ children, className, level, position }) => {
 
 Layer.defaultProps = {
     position: 'fixed',
+    dataTest: 'dhis2-uicore-layer',
+    pointerEvents: 'all',
 }
 
 Layer.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
+    dataTest: propTypes.string,
     level: propTypes.number,
-    position: oneOf(['absolute', 'relative', 'fixed']),
+    pointerEvents: propTypes.oneOf(['all', 'none']),
+    position: propTypes.oneOf(['absolute', 'relative', 'fixed']),
+    translucent: propTypes.bool,
+    onClick: propTypes.func,
 }
 
 export { Layer }

--- a/src/__demo__/Layer.stories.js
+++ b/src/__demo__/Layer.stories.js
@@ -3,6 +3,8 @@ import { storiesOf } from '@storybook/react'
 import propTypes from '@dhis2/prop-types'
 import { Layer } from '../Layer.js'
 import { layers } from '../theme.js'
+import { CenteredContent } from '../CenteredContent.js'
+import { CircularLoader } from '../CircularLoader.js'
 
 const logger = event => {
     event.stopPropagation()
@@ -63,64 +65,91 @@ DivInLayer.propTypes = {
     className: propTypes.string,
 }
 
-storiesOf('Layer', module).add('Stacked layers (pure nesting)', () => (
-    <>
-        <DivInLayer stackLevel={layers.alert} className="layer-a-child">
-            A
-            <DivInLayer stackLevel={layers.blocking} className="layer-b-child">
-                B
-                <DivInLayer stackLevel={4561} className="layer-c-child">
-                    C
+storiesOf('Layer', module)
+    .add('Stacked layers (pure nesting)', () => (
+        <>
+            <DivInLayer stackLevel={layers.alert} className="layer-a-child">
+                A
+                <DivInLayer
+                    stackLevel={layers.blocking}
+                    className="layer-b-child"
+                >
+                    B
+                    <DivInLayer stackLevel={4561} className="layer-c-child">
+                        C
+                    </DivInLayer>
                 </DivInLayer>
             </DivInLayer>
-        </DivInLayer>
-        <DivInLayer stackLevel={layers.blocking} className="layer-d-child">
-            D
-            <DivInLayer stackLevel={layers.blocking} className="layer-e-child">
-                E
+            <DivInLayer stackLevel={layers.blocking} className="layer-d-child">
+                D
+                <DivInLayer
+                    stackLevel={layers.blocking}
+                    className="layer-e-child"
+                >
+                    E
+                    <DivInLayer
+                        stackLevel={layers.applicationTop}
+                        className="layer-f-child"
+                    >
+                        F
+                    </DivInLayer>
+                </DivInLayer>
+            </DivInLayer>
+            <style jsx>{`
+                :global(#root) {
+                    height: auto !important;
+                }
+            `}</style>
+        </>
+    ))
+
+    .add('Inverse nesting', () => (
+        <>
+            <DivInLayer stackLevel={layers.blocking} className="layer-a-child">
+                A
+                <DivInLayer stackLevel={layers.alert} className="layer-b-child">
+                    B
+                    <DivInLayer
+                        stackLevel={layers.alert}
+                        className="layer-c-child"
+                    >
+                        C
+                    </DivInLayer>
+                </DivInLayer>
+            </DivInLayer>
+            <DivInLayer stackLevel={layers.blocking} className="layer-d-child">
+                D
                 <DivInLayer
                     stackLevel={layers.applicationTop}
-                    className="layer-f-child"
+                    className="layer-e-child"
                 >
-                    F
+                    E
+                    <DivInLayer
+                        stackLevel={layers.alert}
+                        className="layer-f-child"
+                    >
+                        F
+                    </DivInLayer>
                 </DivInLayer>
             </DivInLayer>
-        </DivInLayer>
-        <style jsx>{`
-            :global(#root) {
-                height: auto !important;
-            }
-        `}</style>
-    </>
-))
+            <style jsx>{`
+                :global(#root) {
+                    height: auto !important;
+                }
+            `}</style>
+        </>
+    ))
 
-storiesOf('Layer', module).add('Inverse nesting', () => (
-    <>
-        <DivInLayer stackLevel={layers.blocking} className="layer-a-child">
-            A
-            <DivInLayer stackLevel={layers.alert} className="layer-b-child">
-                B
-                <DivInLayer stackLevel={layers.alert} className="layer-c-child">
-                    C
-                </DivInLayer>
-            </DivInLayer>
-        </DivInLayer>
-        <DivInLayer stackLevel={layers.blocking} className="layer-d-child">
-            D
-            <DivInLayer
-                stackLevel={layers.applicationTop}
-                className="layer-e-child"
-            >
-                E
-                <DivInLayer stackLevel={layers.alert} className="layer-f-child">
-                    F
-                </DivInLayer>
-            </DivInLayer>
-        </DivInLayer>
-        <style jsx>{`
-            :global(#root) {
-                height: auto !important;
-            }
-        `}</style>
-    </>
-))
+    .add('With centered content and click', () => (
+        <Layer
+            level={layers.blocking}
+            translucent
+            onClick={() => {
+                console.log('Click')
+            }}
+        >
+            <CenteredContent>
+                <CircularLoader />
+            </CenteredContent>
+        </Layer>
+    ))


### PR DESCRIPTION
This PR is not done yet, but does illustrate how I would like to rearrange the overlay components for v5. When done, this PR would solve https://github.com/dhis2/ui-core/issues/760. I've tackled things slightly differently than I wrote in that issue, see below:
- `Layer` covers the window or body and takes care of stacking (z-index). You can also give this component a semi-transparent background by adding the `translucent` prop. It's also possible to create a "non-blocking" layer by setting `pointerEvents="none"`. And finally, you can attach an `onClick` handler.
- `ComponentCover` covers the component, provided the parent has a non-static position. The other props are identical to the `Layer` (i.e. `onClick`, `translucent`, `pointerEvents`) 
- `CenteredContent`: aligns its content vertically and horizontally.

The following components would be deprecated and replaced by the new ones above:
- `Backdrop`
- `Layer` (from `LayerContext.js`)
