### PR TITLE
fix(MultiSelect): use dense chips for selections in input

### DIFF
--- a/src/MultiSelect/SelectionList.js
+++ b/src/MultiSelect/SelectionList.js
@@ -47,6 +47,7 @@ const SelectionList = ({ selected, onChange, disabled, options }) => (
                     onRemove={onRemove}
                     disabled={isDisabled}
                     overflow
+                    dense
                 >
                     {label}
                 </Chip>


### PR DESCRIPTION
This PR changes the `Chip` type used in a `MultiSelect`. It adds a `dense` prop to the `Chip`.

Note: is this the correct conventional commit message type? It's not a `fix:` because this was not a bug, but is there something before `feat:`, more like...`adjustment: `? 😉 