### PR TITLE
docs: adds prefix to jsdocs link since they were returning 404

### DIFF
--- a/src/AlertBar.js
+++ b/src/AlertBar.js
@@ -18,7 +18,7 @@ import styles, { ANIMATION_TIME } from './AlertBar/styles.js'
  * @example import { AlertBar } from @dhis2/ui-core
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/alertbar.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/alertbar--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/alertbar--default|Storybook}
  */
 class AlertBar extends Component {
     // visible is used to control the show/hide animation

--- a/src/AlertStack.js
+++ b/src/AlertStack.js
@@ -11,7 +11,7 @@ import { layers } from './theme.js'
  * @param {AlertStack.PropTypes} props
  * @returns {React.Component}
  * @example import { AlertStack } from '@dhis2/ui-core'
- * @see Live demo: {@link /demo/?path=/story/alertstack--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/alertstack--default|Storybook}
  */
 const AlertStack = ({ className, children, dataTest }) =>
     createPortal(

--- a/src/Button.js
+++ b/src/Button.js
@@ -13,7 +13,7 @@ import styles from './Button/styles.js'
  *
  * @example import { Button } from @dhis2/ui-core
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/button.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/button-basic--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/button-basic--default|Storybook}
  */
 export class Button extends Component {
     buttonRef = createRef()

--- a/src/ButtonStrip.js
+++ b/src/ButtonStrip.js
@@ -10,7 +10,7 @@ import { spacers } from './theme.js'
  * @param {ButtonStrip.PropTypes} props
  * @returns {React.Component}
  * @example import { ButtonStrip } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/buttonstrip--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/buttonstrip--default|Storybook}
  */
 const ButtonStrip = ({ className, children, middle, end, dataTest }) => (
     <div className={cx(className, { middle, end })} data-test={dataTest}>

--- a/src/Card.js
+++ b/src/Card.js
@@ -11,7 +11,7 @@ import { colors } from './theme.js'
  * @returns {React.Component}
  * @example import { Card } from '@dhis2/ui-core'
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/card.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/card--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/card--default|Storybook}
  */
 const Card = ({ className, children, dataTest }) => (
     <div className={cx(className)} data-test={dataTest}>

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -16,7 +16,7 @@ import { colors, theme } from './theme.js'
  * @example import { Checkbox } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/checkbox.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/checkbox--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/checkbox--default|Storybook}
  */
 class Checkbox extends Component {
     ref = createRef()

--- a/src/CheckboxField.js
+++ b/src/CheckboxField.js
@@ -14,7 +14,7 @@ import { Checkbox } from './Checkbox.js'
  * @example import { CheckboxField } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/checkbox.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/checkboxfield--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/checkboxfield--default|Storybook}
  */
 
 const CheckboxField = ({

--- a/src/CheckboxGroup.js
+++ b/src/CheckboxGroup.js
@@ -13,7 +13,7 @@ import { ToggleGroup } from './ToggleGroup.js'
  * @example import { CheckboxGroup } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/checkbox.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/checkboxgroup--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/checkboxgroup--default|Storybook}
  */
 
 const CheckboxGroup = ({

--- a/src/CheckboxGroupField.js
+++ b/src/CheckboxGroupField.js
@@ -13,7 +13,7 @@ import { statusPropType } from './common-prop-types.js'
  * @example import { CheckboxGroupField } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/checkbox.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/checkboxgroupfield--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/checkboxgroupfield--default|Storybook}
  */
 const CheckboxGroupField = ({
     children,

--- a/src/Chip.js
+++ b/src/Chip.js
@@ -14,7 +14,7 @@ import { Remove } from './Chip/Remove.js'
  * @returns {React.Component}
  * @example import { Chip } from @dhis2/ui-core
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/chip.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/chip--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/chip--default|Storybook}
  */
 const Chip = ({
     selected,

--- a/src/CircularLoader.js
+++ b/src/CircularLoader.js
@@ -12,7 +12,7 @@ import { theme, spacers } from './theme.js'
  * @returns {React.Component}
  * @example import { CircularLoader } from @dhis2/ui-core
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/loading.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/circularloader--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/circularloader--default|Storybook}
  */
 const CircularLoader = ({ small, large, className, dataTest }) => (
     <div

--- a/src/ComponentCover.js
+++ b/src/ComponentCover.js
@@ -8,7 +8,7 @@ import { layers } from './theme.js'
  * @param {ComponentCover.PropTypes} props
  * @returns {React.Component}
  * @example import { ComponentCover } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/componentcover--circularloader|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/componentcover--circularloader|Storybook}
  */
 const ComponentCover = ({ children, className, dataTest }) => (
     <div className={className} data-test={dataTest}>

--- a/src/CssReset.js
+++ b/src/CssReset.js
@@ -10,7 +10,7 @@ import { theme } from './theme.js'
  * - https://www.paulirish.com/2012/box-sizing-border-box-ftw/
  * @returns {React.Component}
  * @example import { CssReset } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/cssreset--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/cssreset--default|Storybook}
  */
 const CssReset = () => (
     <style jsx global>{`

--- a/src/CssVariables.js
+++ b/src/CssVariables.js
@@ -20,7 +20,7 @@ const toCustomPropertyString = themeSection =>
  * @param {CssVariables.PropTypes} props
  * @returns {React.Component}
  * @example import { CssVariables } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/cssvariables--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/cssvariables--default|Storybook}
  */
 const CssVariables = ({ colors, theme, layers, spacers, elevations }) => {
     const allowedProps = { colors, theme, layers, spacers, elevations }

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -20,7 +20,7 @@ const arrow = resolve`
  * @param {DropdownButton.PropTypes} props
  * @returns {React.Component}
  * @example import { DropdownButton } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/dropdownbutton-basic--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/dropdownbutton-basic--default|Storybook}
  */
 class DropdownButton extends Component {
     state = {

--- a/src/Field.js
+++ b/src/Field.js
@@ -9,7 +9,7 @@ import { spacers } from './theme.js'
  * @param {Field.PropTypes} props
  * @returns {React.Component}
  * @example import { Field } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/field--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/field--default|Storybook}
  */
 const Field = ({ children, className, dataTest }) => (
     <div className={className} data-test={dataTest}>

--- a/src/FieldSet.js
+++ b/src/FieldSet.js
@@ -6,7 +6,7 @@ import propTypes from '@dhis2/prop-types'
  * @param {FieldSet.PropTypes} props
  * @returns {React.Component}
  * @example import { FieldSet } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/fieldset--default}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/fieldset--default}
  */
 const FieldSet = ({ className, children, dataTest }) => (
     <fieldset className={className} data-test={dataTest}>

--- a/src/FileInput.js
+++ b/src/FileInput.js
@@ -15,6 +15,8 @@ import { StatusIcon } from './icons/Status.js'
  * @returns {React.Component}
  *
  * @example import { FileInput } from '@dhis2/ui-core'
+ *
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/fileinput--default|Storybook}
  */
 class FileInput extends Component {
     ref = createRef()

--- a/src/FileInputField.js
+++ b/src/FileInputField.js
@@ -18,7 +18,7 @@ import { Help } from './Help.js'
  * @example import { FileInputField } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/fileinput.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/fileinputfield--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/fileinputfield--default|Storybook}
  */
 const FileInputField = ({
     accept,

--- a/src/FileInputFieldWithList.js
+++ b/src/FileInputFieldWithList.js
@@ -13,7 +13,7 @@ import { statusPropType, sizePropType } from './common-prop-types.js'
  * @example import { FileInputFieldWithList } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/fileinput.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/fileinputfieldwithlist--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/fileinputfieldwithlist--default|Storybook}
  */
 
 class FileInputFieldWithList extends Component {

--- a/src/FileListItem.js
+++ b/src/FileListItem.js
@@ -15,7 +15,7 @@ import { Loading } from './icons/Status.js'
  * @example import { FileListItem } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/fileinput.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/fileinputfield--file-list|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/fileinputfield--file-list|Storybook}
  */
 const FileListItem = ({
     className,

--- a/src/Help.js
+++ b/src/Help.js
@@ -11,7 +11,7 @@ import { spacers, theme } from './theme.js'
  * @param {Help.PropTypes} props
  * @returns {React.Component}
  * @example import { Help } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/help--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/help--default|Storybook}
  */
 const Help = ({ children, valid, error, warning, className, dataTest }) => (
     <p

--- a/src/Input.js
+++ b/src/Input.js
@@ -80,7 +80,7 @@ const styles = css`
  * @example import { Input } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/inputfield.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/inputfield--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/inputfield--default|Storybook}
  */
 export class Input extends Component {
     inputRef = React.createRef()

--- a/src/InputField.js
+++ b/src/InputField.js
@@ -17,7 +17,7 @@ import { Constrictor } from './Constrictor.js'
  * @example import { InputField } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/inputfield.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/inputfield--no-placeholder-no-value|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/inputfield--no-placeholder-no-value|Storybook}
  */
 class InputField extends React.Component {
     render() {

--- a/src/Legend.js
+++ b/src/Legend.js
@@ -12,7 +12,7 @@ import { Required } from './Label/Required.js'
  *
  * @example import { Legend } from '@dhis2/ui-core'
  *
- * @see Live demo: {@link /demo/?path=/story/legend--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/legend--default|Storybook}
  */
 const Legend = ({ className, children, required, dataTest }) => (
     <legend className={className} data-test={dataTest}>

--- a/src/LinearLoader.js
+++ b/src/LinearLoader.js
@@ -33,7 +33,7 @@ Progress.propTypes = {
  * @example import { LinearLoader } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/loading.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/linearloader--determinate|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/linearloader--determinate|Storybook}
  */
 const LinearLoader = ({ amount, width, margin, className, dataTest }) => {
     return (

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -14,7 +14,7 @@ import { spacers } from './theme.js'
  * @example import { Menu } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/menu.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/menu--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/menu--default|Storybook}
  */
 const Menu = ({ children, className, dataTest, maxWidth }) => (
     <div className={className} data-test={dataTest}>

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -12,7 +12,7 @@ import { SubMenu } from './MenuItem/SubMenu'
  * @example import { MenuItem } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/menu.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/menu--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/menu--default|Storybook}
  */
 const MenuItem = ({
     href,

--- a/src/MenuList.js
+++ b/src/MenuList.js
@@ -9,7 +9,7 @@ import propTypes from '@dhis2/prop-types'
  * @example import { MenuList } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/menu.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/menulist--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/menulist--default|Storybook}
  */
 const MenuList = ({ children, className, dataTest }) => (
     <ul className={className} data-test={dataTest}>

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -34,7 +34,7 @@ import { insideAlignmentPropType, sizePropType } from './common-prop-types.js'
  *  </Modal>
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/modal.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/modal--small-title-content-action|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/modal--small-title-content-action|Storybook}
  */
 export const Modal = ({
     children,

--- a/src/MultiSelectField.js
+++ b/src/MultiSelectField.js
@@ -18,7 +18,7 @@ import { Constrictor } from './Constrictor.js'
  * @example import { MultiSelectField } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/select.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/multiselectfield--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/multiselectfield--default|Storybook}
  */
 class MultiSelectField extends React.Component {
     render() {

--- a/src/Node.js
+++ b/src/Node.js
@@ -14,7 +14,7 @@ import { Leaves } from './Node/Leaves.js'
  *
  * @example import { Node } from '@dhis2/ui-core'
  *
- * @see Live demo: {@link /demo/?path=/story/node--multiple-roots|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/node--multiple-roots|Storybook}
  */
 export const Node = ({
     open,

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -23,7 +23,7 @@ const arroModifiers = [arrow, offset, hideArrowWhenDisplaced]
  * @example import { Popover } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/popover.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/popover--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/popover--default|Storybook}
  */
 
 const Popover = ({

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -16,7 +16,7 @@ import * as baseModifiers from './Popper/modifiers.js'
  *
  * @example import { Popper } from '@dhis2/ui-core'
  *
- * @see Live demo: {@link /demo/?path=/story/popper--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/popper--default|Storybook}
  * @see Popper js: {@link https://popper.js.org/docs/v2/|Documentation}
  */
 

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -16,7 +16,7 @@ import { colors, theme } from './theme.js'
  * @example import { Radio } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/radio.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/radio--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/radio--default|Storybook}
  */
 class Radio extends Component {
     ref = createRef()

--- a/src/RadioGroup.js
+++ b/src/RadioGroup.js
@@ -13,7 +13,7 @@ import { statusPropType } from './common-prop-types.js'
  * @example import { RadioGroup } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/radio.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/radiogroup--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/radiogroup--default|Storybook}
  */
 
 const RadioGroup = ({

--- a/src/RadioGroupField.js
+++ b/src/RadioGroupField.js
@@ -13,7 +13,7 @@ import { statusPropType } from './common-prop-types.js'
  * @example import { RadioGroupField } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/radio.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/radiogroupfield--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/radiogroupfield--default|Storybook}
  */
 
 const RadioGroupField = ({

--- a/src/ScreenCover.js
+++ b/src/ScreenCover.js
@@ -47,7 +47,7 @@ Content.propTypes = {
  * @example import { ScreenCover } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/principles/spacing-alignment.md#stacking|Design system}
- * @see Live demo: {@link /demo/?path=/story/screencover--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/screencover--default|Storybook}
  */
 const ScreenCover = ({ children, onClick, className, dataTest, position }) => {
     return (

--- a/src/SingleSelectField.js
+++ b/src/SingleSelectField.js
@@ -18,7 +18,7 @@ import { Constrictor } from './Constrictor.js'
  * @example import { SingleSelectField } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/select.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/singleselectfield--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/singleselectfield--default|Storybook}
  */
 class SingleSelectField extends React.Component {
     render() {

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -26,7 +26,7 @@ const rightButton = css.resolve`
  * @example import { SplitButton } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/button.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/splitbutton-basic--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/splitbutton-basic--default|Storybook}
  */
 class SplitButton extends Component {
     state = {

--- a/src/StackedTable.js
+++ b/src/StackedTable.js
@@ -10,7 +10,7 @@ import { Table } from './StackedTable/Table.js'
  * @param {StackedTable.PropTypes}
  * @returns {React.Component}
  * @example import { StackedTable } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/stackedtable--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/stackedtable--default|Storybook}
  */
 export const StackedTable = ({
     children,

--- a/src/StackedTableBody.js
+++ b/src/StackedTableBody.js
@@ -6,7 +6,7 @@ import propTypes from '@dhis2/prop-types'
  * @param {StackedTableBody.PropTypes}
  * @returns {React.Component}
  * @example import { StackedTableBody } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/stackedtable--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/stackedtable--default|Storybook}
  */
 export const StackedTableBody = ({ children, className, dataTest }) => (
     <tbody className={className} data-tset={dataTest}>

--- a/src/StackedTableCell.js
+++ b/src/StackedTableCell.js
@@ -9,7 +9,7 @@ import { colors } from './theme.js'
  * @param {StackedTableCell.PropTypes}
  * @returns {React.Component}
  * @example import { StackedTableCell } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/stackedtable--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/stackedtable--default|Storybook}
  */
 export const StackedTableCell = ({
     children,

--- a/src/StackedTableCellHead.js
+++ b/src/StackedTableCellHead.js
@@ -7,7 +7,7 @@ import { colors } from './theme.js'
  * @param {StackedTableCellHead.PropTypes}
  * @returns {React.Component}
  * @example import { StackedTableCellHead } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/stackedtable--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/stackedtable--default|Storybook}
  */
 export const StackedTableCellHead = ({
     children,

--- a/src/StackedTableFoot.js
+++ b/src/StackedTableFoot.js
@@ -6,7 +6,7 @@ import propTypes from '@dhis2/prop-types'
  * @param {StackedTableFoot.PropTypes}
  * @returns {React.Component}
  * @example import { StackedTableFoot } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/stackedtable--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/stackedtable--default|Storybook}
  */
 export const StackedTableFoot = ({ children, className, dataTest }) => (
     <tfoot className={className} data-test={dataTest}>

--- a/src/StackedTableHead.js
+++ b/src/StackedTableHead.js
@@ -6,7 +6,7 @@ import propTypes from '@dhis2/prop-types'
  * @param {StackedTableHead.PropTypes}
  * @returns {React.Component}
  * @example import { StackedTableHead } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/stackedtable--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/stackedtable--default|Storybook}
  */
 export const StackedTableHead = ({ children, className, dataTest }) => (
     <thead className={className} data-test={dataTest}>

--- a/src/StackedTableRow.js
+++ b/src/StackedTableRow.js
@@ -11,7 +11,7 @@ import { supplyHeaderLabelsToChildren } from './StackedTableRow/supplyHeaderLabe
  * @param {StackedTableRow.PropTypes}
  * @returns {React.Component}
  * @example import { StackedTableRow } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/stackedtable--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/stackedtable--default|Storybook}
  */
 export const StackedTableRow = ({ children, className, dataTest }) => (
     <tr className={className} data-test={dataTest}>

--- a/src/StackedTableRowHead.js
+++ b/src/StackedTableRowHead.js
@@ -8,7 +8,7 @@ import { StackedTableRow } from './StackedTableRow.js'
  * @param {StackedTableRowHead.PropTypes}
  * @returns {React.Component}
  * @example import { StackedTableRowHead } from @dhis2/ui-core
- * @see Live demo: {@link /demo/?path=/story/stackedtable--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/stackedtable--default|Storybook}
  */
 export const StackedTableRowHead = ({ children, className, dataTest }) => (
     <StackedTableRow className={className} dataTest={dataTest}>

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -16,7 +16,7 @@ import { colors, theme } from './theme.js'
  * @example import { Switch } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/switch.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/switch--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/switch--default|Storybook}
  */
 class Switch extends Component {
     ref = createRef()

--- a/src/SwitchField.js
+++ b/src/SwitchField.js
@@ -14,7 +14,7 @@ import { Switch } from './Switch.js'
  * @example import { SwitchField } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/switch.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/switchfield--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/switchfield--default|Storybook}
  */
 
 const SwitchField = ({

--- a/src/SwitchGroup.js
+++ b/src/SwitchGroup.js
@@ -13,7 +13,7 @@ import { statusPropType } from './common-prop-types.js'
  * @example import { SwitchGroup } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/switch.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/switchgroup--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/switchgroup--default|Storybook}
  */
 
 const SwitchGroup = ({

--- a/src/SwitchGroupField.js
+++ b/src/SwitchGroupField.js
@@ -13,7 +13,7 @@ import { statusPropType } from './common-prop-types.js'
  * @example import { SwitchGroupField } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/switch.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/switchgroupfield--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/switchgroupfield--default|Storybook}
  */
 
 const SwitchGroupField = ({

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -12,7 +12,7 @@ import { colors, theme } from './theme.js'
  * @example import { Tab } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/tab.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/tabs--default-fluid|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/tabs--default-fluid|Storybook}
  */
 const Tab = ({
     icon,

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -13,7 +13,7 @@ import { Tabs } from './TabBar/Tabs.js'
  * @example import { TabBar } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/tab.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/tabs--default-fluid|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/tabs--default-fluid|Storybook}
  */
 const TabBar = ({ fixed, children, className, scrollable, dataTest }) => {
     if (scrollable) {

--- a/src/Table.js
+++ b/src/Table.js
@@ -18,7 +18,7 @@ const tableStyles = css`
  * @param {Table.PropTypes} props
  * @returns {React.Component}
  * @example import { Table } from '@dhis2/ui-core'
- * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/table--static-layout|Storybook}
  */
 export const Table = ({ children, className, dataTest }) => (
     <table className={className} data-test={dataTest}>

--- a/src/TableBody.js
+++ b/src/TableBody.js
@@ -6,7 +6,7 @@ import propTypes from '@dhis2/prop-types'
  * @param {TableBody.PropTypes} props
  * @returns {React.Component}
  * @example import { TableBody } from '@dhis2/ui-core'
- * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableBody = ({ children, className, dataTest }) => (
     <tbody className={className} data-test={dataTest}>

--- a/src/TableCell.js
+++ b/src/TableCell.js
@@ -23,7 +23,7 @@ const tableCellStyles = css`
  * @param {TableCell.PropTypes} props
  * @returns {React.Component}
  * @example import { TableCell } from '@dhis2/ui-core'
- * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableCell = ({
     className,

--- a/src/TableCellHead.js
+++ b/src/TableCellHead.js
@@ -23,7 +23,7 @@ const tableCellHeadStyles = css`
  * @param {TableCellHead.PropTypes} props
  * @returns {React.Component}
  * @example import { TableCellHead } from '@dhis2/ui-core'
- * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableCellHead = ({
     colSpan,

--- a/src/TableFoot.js
+++ b/src/TableFoot.js
@@ -6,7 +6,7 @@ import propTypes from '@dhis2/prop-types'
  * @param {TableFoot.PropTypes} props
  * @returns {React.Component}
  * @example import { TableFoot } from '@dhis2/ui-core'
- * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableFoot = ({ children, className, dataTest }) => (
     <tfoot className={className} data-test={dataTest}>

--- a/src/TableHead.js
+++ b/src/TableHead.js
@@ -6,7 +6,7 @@ import propTypes from '@dhis2/prop-types'
  * @param {TableHead.PropTypes} props
  * @returns {React.Component}
  * @example import { TableHead } from '@dhis2/ui-core'
- * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableHead = ({ children, className, dataTest }) => (
     <thead className={className} data-test={dataTest}>

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -13,7 +13,7 @@ const tableRowStyles = css`
  * @param {TableRow.PropTypes} props
  * @returns {React.Component}
  * @example import { TableRow } from '@dhis2/ui-core'
- * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableRow = ({ children, className, dataTest }) => (
     <tr className={className} data-test={dataTest}>

--- a/src/TableRowHead.js
+++ b/src/TableRowHead.js
@@ -9,7 +9,7 @@ import { TableRow } from './TableRow.js'
  * @param {TableRowHead.PropTypes} props
  * @returns {React.Component}
  * @example import { TableRowHead } from '@dhis2/ui-core'
- * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableRowHead = ({ children, className, dataTest }) => (
     <TableRow className={className} dataTest={dataTest}>

--- a/src/Tag.js
+++ b/src/Tag.js
@@ -13,7 +13,7 @@ import { colors } from './theme.js'
  * @returns {React.Component}
  * @example import { Tag } from @dhis2/ui-core
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/atoms/tag.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/tag--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/tag--default|Storybook}
  */
 
 export const Tag = ({

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -13,6 +13,8 @@ import { styles } from './TextArea/styles.js'
  * @returns {React.Component}
  *
  * @example import { TextArea } from '@dhis2/ui-core'
+ *
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/textarea--default|Storybook}
  */
 export class TextArea extends Component {
     textareaRef = React.createRef()

--- a/src/TextAreaField.js
+++ b/src/TextAreaField.js
@@ -17,7 +17,7 @@ import { Constrictor } from './Constrictor.js'
  * @example import { TextAreaField } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/update-input/atoms/inputfield.md#textarea|Design system}
- * @see Live demo: {@link /demo/?path=/story/textareafield--default|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/textareafield--default|Storybook}
  */
 const TextAreaField = ({
     className,

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -32,7 +32,7 @@ const CLOSE_DELAY = 400
  * @example import { Tooltip } from '@dhis2/ui-core'
  *
  * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/tooltip.md|Design system}
- * @see Live demo: {@link /demo/?path=/story/tooltips--default-fluid|Storybook}
+ * @see Live demo: {@link https://ui-core.dhis2.nu/demo/?path=/story/tooltips--default-fluid|Storybook}
  */
 class Tooltip extends Component {
     state = { open: false }


### PR DESCRIPTION
👋 hello! 

This is my first PR without opening an issue. Maybe I should have opened one first. Feel free to give me your feedback both on the code and the procedure anyways! 

## The issue description:
While I was navigating at the [ui-core docs](https://ui-core.dhis2.nu/#/api) I realised that clicking on the Live demo link would return a 404 page instead of the story. 
![image](https://user-images.githubusercontent.com/4181674/79246770-ebc63700-7e79-11ea-9f39-39e47eac6b08.png)

The problem is that we are having this `/#/` on the url and therefore the link is broken. I added the full link to fix this issue however I can imagine that there might be a better solution to this! Le me know your thoughts and feedback! 
