### PR TITLE
feat: let popper and popover accept react-refs or dom nodes directly

### DIFF
--- a/cypress/integration/Popover/conditional_arrow/index.js
+++ b/cypress/integration/Popover/conditional_arrow/index.js
@@ -7,8 +7,8 @@ Given('a Popover is rendered with the arrow prop set to false', () => {
     cy.visitStory('Popover', 'No Arrow')
 })
 Then('there is an arrow element in the Popover', () => {
-    cy.get('[data-popper-arrow="true"]').should('exist')
+    cy.get('[data-test="dhis2-uicore-popoverarrow"]').should('exist')
 })
 Then('there is no arrow element in the Popover', () => {
-    cy.get('[data-popper-arrow="true"]').should('not.exist')
+    cy.get('[data-test="dhis2-uicore-popoverarrow"]').should('not.exist')
 })

--- a/cypress/integration/Popover/position/index.js
+++ b/cypress/integration/Popover/position/index.js
@@ -58,17 +58,11 @@ Given(
 )
 
 Then('the arrow is hiding', () => {
-    cy.get('[data-test="dhis2-uicore-popover-popper"]').should(
-        'have.attr',
-        'data-popper-arrow-displaced'
-    )
+    cy.get('[data-test="dhis2-uicore-popoverarrow"]').should('not.be.visible')
 })
 
 Then('the arrow is showing', () => {
-    cy.get('[data-test="dhis2-uicore-popover-popper"]').should(
-        'not.have.attr',
-        'data-popper-arrow-displaced'
-    )
+    cy.get('[data-test="dhis2-uicore-popoverarrow"]').should('be.visible')
 })
 
 Then(
@@ -111,6 +105,6 @@ Then('there is some space between the anchor and the popover', () => {
 function getRefAndPopoverPositions() {
     return cy.getPositionsBySelectors(
         '[data-test="reference-element"]',
-        '[data-test="dhis2-uicore-popover-popper"]'
+        '[data-test="dhis2-uicore-popover"]'
     )
 }

--- a/package.json
+++ b/package.json
@@ -67,8 +67,10 @@
     },
     "dependencies": {
         "@dhis2/prop-types": "^1.6.4",
-        "@popperjs/core": "^2.1.0",
-        "classnames": "^2.2.6"
+        "@popperjs/core": "^2.4.0",
+        "classnames": "^2.2.6",
+        "react-popper": "^2.2.3",
+        "resize-observer-polyfill": "^1.5.1"
     },
     "files": [
         "build",

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,20 +1,16 @@
-import React from 'react'
-import { createPortal } from 'react-dom'
-import propTypes from 'prop-types'
+import React, { useState, useMemo } from 'react'
+import propTypes from '@dhis2/prop-types'
+import { usePopper } from 'react-popper'
 
+import { colors, elevations } from './theme.js'
+import { Layer } from './Layer.js'
+import { combineModifiers } from './Popover/modifiers.js'
+import { Arrow } from './Popover/Arrow.js'
 import {
     elementRefPropType,
     referencePlacementPropType,
 } from './common-prop-types.js'
 
-import { Popper } from './Popper'
-import { Backdrop } from './Backdrop'
-
-import { Arrow } from './Popover/Arrow'
-import { arrow, offset, hideArrowWhenDisplaced } from './Popover/modifiers.js'
-import { colors, elevations } from './theme.js'
-
-const arroModifiers = [arrow, offset, hideArrowWhenDisplaced]
 /**
  * @module
  * @param {Popover.PropTypes} props
@@ -34,34 +30,66 @@ const Popover = ({
     dataTest,
     elevation,
     maxWidth,
+    observePopperResize,
+    observeReferenceResize,
     placement,
     onBackdropClick,
-}) =>
-    createPortal(
-        <Backdrop onClick={onBackdropClick} transparent>
-            <Popper
-                dataTest={`${dataTest}-popper`}
-                placement={placement}
-                reference={reference}
-                modifiers={arrow ? arroModifiers : []}
-                className={className}
-            >
-                <div>
-                    {children}
-                    {arrow && <Arrow />}
-                    <style jsx>{`
-                        div {
-                            max-width: ${maxWidth}px;
-                            box-shadow: ${elevation};
-                            background-color: ${colors.white};
-                            border-radius: 4px;
-                        }
-                    `}</style>
-                </div>
-            </Popper>
-        </Backdrop>,
-        document.body
+}) => {
+    const referenceElement =
+        reference instanceof Element
+            ? reference
+            : reference && reference.current
+    const [popperElement, setPopperElement] = useState(null)
+    const [arrowElement, setArrowElement] = useState(null)
+    const modifiers = useMemo(
+        () =>
+            combineModifiers(arrow, arrowElement, {
+                observePopperResize,
+                observeReferenceResize,
+            }),
+        [arrow, arrowElement, observePopperResize, observeReferenceResize]
     )
+    const { styles, attributes } = usePopper(referenceElement, popperElement, {
+        placement,
+        modifiers,
+    })
+
+    return (
+        <Layer onClick={onBackdropClick}>
+            <div
+                data-test={dataTest}
+                className={className}
+                ref={setPopperElement}
+                style={styles.popper}
+                {...attributes.popper}
+            >
+                {children}
+                {arrow && (
+                    <Arrow
+                        hidden={
+                            attributes.arrow &&
+                            attributes.arrow['data-arrow-hidden']
+                        }
+                        popperPlacement={
+                            attributes.popper &&
+                            attributes.popper['data-popper-placement']
+                        }
+                        ref={setArrowElement}
+                        styles={styles.arrow}
+                    />
+                )}
+                <style jsx>{`
+                    div {
+                        max-width: ${maxWidth}px;
+                        box-shadow: ${elevation};
+                        background-color: ${colors.white};
+                        border-radius: 4px;
+                    }
+                `}</style>
+            </div>
+        </Layer>
+    )
+}
 
 Popover.defaultProps = {
     arrow: true,
@@ -74,22 +102,30 @@ Popover.defaultProps = {
  * @typedef {Object} PropTypes
  * @static
  *
- * @prop {React.Ref} reference A React ref that refers to the element the Popover should position against
+ * @prop {React.Ref|Element} reference A React ref or DOM element to the Popover should position against
  * @prop {Node} children
  * @prop {boolean} [arrow=true] Show or hide the arrow
  * @prop {string} [className]
  * @prop {string} [dataTest=dhis2-uicore-popover]
  * @prop {number} [maxWidth=360]
+ * @prop {Boolean} observePopperResize Makes the popper update position when the popper content changes size
+ * @prop {Boolean} observeReferenceResize Makes the popper update position when the reference element changes size
  * @prop {('auto'|'auto-start'|'auto-end'|'top'|'top-start'|'top-end'|'bottom'|'bottom-start'|'bottom-end'|'right'|'right-start'|'right-end'|'left'|'left-start'|'left-end')} [placement=top]
  * @prop {function} [onBackdropClick]
  */
 Popover.propTypes = {
     children: propTypes.node.isRequired,
-    reference: elementRefPropType.isRequired,
+    reference: propTypes.oneOfType([
+        elementRefPropType,
+        propTypes.instanceOf(Element),
+    ]).isRequired,
     arrow: propTypes.bool,
     className: propTypes.string,
     dataTest: propTypes.string,
+    elevation: propTypes.string,
     maxWidth: propTypes.number,
+    observePopperResize: propTypes.bool,
+    observeReferenceResize: propTypes.bool,
     placement: referencePlacementPropType,
     onBackdropClick: propTypes.func,
 }

--- a/src/Popover/Arrow.js
+++ b/src/Popover/Arrow.js
@@ -1,42 +1,42 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
+import cx from 'classnames'
 import propTypes from '@dhis2/prop-types'
+
 import { colors } from '../theme.js'
+import { getArrowPosition } from './getArrowPosition.js'
 
 const ARROW_SIZE = 8
 
-/**
- * Note: the `data-popper-placement` attribute is automatically updated
- * by popper.js in case of flipping etc. So be aware that the value of
- * the `placement` prop that was initially passed to the Popper component
- * and the value of `data-popper-placement` do not always match
- */
-
-const Arrow = ({ className }) => (
-    <div data-popper-arrow className={className}>
+const Arrow = forwardRef(({ hidden, popperPlacement, styles }, ref) => (
+    <div
+        data-test="dhis2-uicore-popoverarrow"
+        className={cx(getArrowPosition(popperPlacement), { hidden })}
+        style={styles}
+        ref={ref}
+    >
         <style jsx>{`
             div {
-                pointer-events: none;
                 width: ${ARROW_SIZE}px;
                 height: ${ARROW_SIZE}px;
             }
 
-            :global([data-popper-placement^='top']) div {
-                bottom: -${ARROW_SIZE / 2}px;
-            }
-
-            :global([data-popper-placement^='bottom']) div {
+            div.top {
                 top: -${ARROW_SIZE / 2}px;
             }
 
-            :global([data-popper-placement^='left']) div {
+            div.right {
                 right: -${ARROW_SIZE / 2}px;
             }
 
-            :global([data-popper-placement^='right']) div {
+            div.bottom {
+                bottom: -${ARROW_SIZE / 2}px;
+            }
+
+            div.left {
                 left: -${ARROW_SIZE / 2}px;
             }
 
-            :global([data-popper-arrow-displaced]) div {
+            div.hidden {
                 visibility: hidden;
             }
 
@@ -53,27 +53,35 @@ const Arrow = ({ className }) => (
                     -3px 3px 8px -6px rgba(64, 75, 90, 0.15);
             }
 
-            :global([data-popper-placement^='top']) div::after {
+            div.bottom::after {
                 transform: rotate(-45deg);
             }
 
-            :global([data-popper-placement^='bottom']) div::after {
+            div.top::after {
                 transform: rotate(135deg);
             }
 
-            :global([data-popper-placement^='left']) div::after {
+            div.right::after {
                 transform: rotate(-135deg);
             }
 
-            :global([data-popper-placement^='right']) div::after {
+            div.left::after {
                 transform: rotate(45deg);
             }
         `}</style>
     </div>
-)
+))
+Arrow.displayName = 'Arrow'
 
 Arrow.propTypes = {
-    className: propTypes.string,
+    hidden: propTypes.bool,
+    popperPlacement: propTypes.string,
+    styles: propTypes.shape({
+        left: propTypes.string,
+        position: propTypes.string,
+        top: propTypes.string,
+        transform: propTypes.string,
+    }),
 }
 
 export { Arrow, ARROW_SIZE }

--- a/src/Popover/getArrowPosition.js
+++ b/src/Popover/getArrowPosition.js
@@ -1,0 +1,21 @@
+const getArrowPosition = popperAttribute => {
+    const placement =
+        popperAttribute && popperAttribute['data-popper-placement']
+    const direction =
+        typeof placement === 'string' ? placement.split('-')[0] : ''
+
+    switch (direction) {
+        case 'top':
+            return 'bottom'
+        case 'right':
+            return 'left'
+        case 'bottom':
+            return 'top'
+        case 'left':
+            return 'right'
+        default:
+            return ''
+    }
+}
+
+export { getArrowPosition }

--- a/src/Popover/modifiers.js
+++ b/src/Popover/modifiers.js
@@ -1,3 +1,4 @@
+import { getBaseModifiers } from '../Popper/modifiers.js'
 import { ARROW_SIZE } from './Arrow.js'
 
 const BORDER_RADIUS = 4
@@ -11,35 +12,51 @@ const computeArrowPadding = () => {
     return Math.ceil(padding)
 }
 
-export const offset = {
-    name: 'offset',
-    options: {
-        offset: [0, ARROW_SIZE],
-    },
+const hideArrowWhenDisplaced = ({ state }) => {
+    const halfArrow = ARROW_SIZE / 2
+    const displacement = state.modifiersData.preventOverflow
+    const referenceRect = state.rects.reference
+    const shouldHideArrow =
+        Math.abs(displacement.x) >= referenceRect.width + halfArrow ||
+        Math.abs(displacement.y) >= referenceRect.height + halfArrow
+
+    if (typeof state.attributes.arrow !== 'object') {
+        state.attributes.arrow = {}
+    }
+
+    state.attributes.arrow['data-arrow-hidden'] = shouldHideArrow
+
+    return state
 }
 
-export const arrow = {
-    name: 'arrow',
-    options: {
-        padding: computeArrowPadding(),
-    },
-}
+export const combineModifiers = (arrow, arrowElement, resizeObservers) => {
+    const baseModifiers = getBaseModifiers(resizeObservers)
 
-export const hideArrowWhenDisplaced = {
-    name: 'hideArrowWhenDisplaced',
-    enabled: true,
-    phase: 'main',
-    fn: ({ state }) => {
-        const halfArrow = ARROW_SIZE / 2
-        const displacement = state.modifiersData.preventOverflow
-        const referenceRect = state.rects.reference
-        const shouldHideArrow =
-            Math.abs(displacement.x) >= referenceRect.width + halfArrow ||
-            Math.abs(displacement.y) >= referenceRect.height + halfArrow
+    if (!arrow) {
+        return baseModifiers
+    }
 
-        state.attributes.popper['data-popper-arrow-displaced'] = shouldHideArrow
-
-        return state
-    },
-    requires: ['preventOverflow'],
+    return [
+        ...baseModifiers,
+        {
+            name: 'offset',
+            options: {
+                offset: [0, ARROW_SIZE],
+            },
+        },
+        {
+            name: 'arrow',
+            options: {
+                padding: computeArrowPadding(),
+                element: arrowElement,
+            },
+        },
+        {
+            name: 'hideArrowWhenDisplaced',
+            enabled: true,
+            phase: 'main',
+            fn: hideArrowWhenDisplaced,
+            requires: ['preventOverflow'],
+        },
+    ]
 }

--- a/src/Popper.js
+++ b/src/Popper.js
@@ -1,12 +1,12 @@
-import React, { Component, createRef } from 'react'
-import propTypes from 'prop-types'
-import { createPopper } from '@popperjs/core'
+import React, { useState, useMemo } from 'react'
+import propTypes from '@dhis2/prop-types'
+import { usePopper } from 'react-popper'
 
 import {
     elementRefPropType,
     referencePlacementPropType,
 } from './common-prop-types.js'
-import * as baseModifiers from './Popper/modifiers.js'
+import { deduplicateModifiers } from './Popper/modifiers.js'
 
 /**
  * @module
@@ -20,54 +20,51 @@ import * as baseModifiers from './Popper/modifiers.js'
  * @see Popper js: {@link https://popper.js.org/docs/v2/|Documentation}
  */
 
-class Popper extends Component {
-    popperInstance = null
-    popperRef = createRef()
+const Popper = ({
+    children,
+    className,
+    dataTest,
+    modifiers,
+    observePopperResize,
+    observeReferenceResize,
+    onFirstUpdate,
+    placement,
+    reference,
+    strategy,
+}) => {
+    const referenceElement =
+        reference instanceof Element
+            ? reference
+            : reference && reference.current
+    const [popperElement, setPopperElement] = useState(null)
 
-    componentDidMount() {
-        const { reference, strategy, onFirstUpdate, placement } = this.props
+    const deduplicatedModifiers = useMemo(
+        () =>
+            deduplicateModifiers(modifiers, {
+                observePopperResize,
+                observeReferenceResize,
+            }),
+        [modifiers, observePopperResize, observeReferenceResize]
+    )
 
-        this.popperInstance = createPopper(
-            reference.current,
-            this.popperRef.current,
-            {
-                strategy,
-                onFirstUpdate,
-                placement,
-                modifiers: this.deduplicateModifiers(),
-            }
-        )
-    }
+    const { styles, attributes } = usePopper(referenceElement, popperElement, {
+        strategy,
+        onFirstUpdate,
+        placement,
+        modifiers: deduplicatedModifiers,
+    })
 
-    deduplicateModifiers() {
-        const { modifiers } = this.props
-        // Deduplicate modifiers from props and baseModifiers,
-        // when duplicates are encountered (by name), use the
-        // modifier from props so each Popper can be fully custom
-        return Object.keys(baseModifiers)
-            .map(key => baseModifiers[key])
-            .filter(({ name }) => !modifiers.some(m => m.name === name))
-            .concat(modifiers)
-    }
-
-    componentWillUnmount() {
-        this.popperInstance && this.popperInstance.destroy()
-        this.popperInstance = null
-    }
-
-    render() {
-        const { children, dataTest, className } = this.props
-
-        return (
-            <div
-                className={className}
-                data-test={dataTest}
-                ref={this.popperRef}
-            >
-                {children}
-            </div>
-        )
-    }
+    return (
+        <div
+            className={className}
+            data-test={dataTest}
+            ref={setPopperElement}
+            style={styles.popper}
+            {...attributes.popper}
+        >
+            {children}
+        </div>
+    )
 }
 
 Popper.defaultProps = {
@@ -87,10 +84,12 @@ Popper.defaultProps = {
  * @static
  *
  * @prop {Node} children
- * @prop {React.Ref} reference A React ref that refers to the element the Popover should position against
+ * @prop {React.Ref|Element} reference A React ref or DOM element to the Popover should position against
  * @prop {string} [className]
  * @prop {string} [dataTest=dhis2-uicore-popper]
  * @prop {Array.<Modifier>} [modifiers=[]] A property of the `createPopper` options, {@link https://popper.js.org/docs/v2/constructors/|see constructor section of popper.js docs}
+ * @prop {Boolean} observePopperResize Makes the popper update position when the popper content changes size
+ * @prop {Boolean} observeReferenceResize Makes the popper update position when the reference element changes size
  * @prop {('absolute'|'fixed')} [strategy=absolute] A property of the `createPopper` options, {@link https://popper.js.org/docs/v2/constructors/|see constructor section of popper.js docs}
  * @prop {Function} [onFirstUpdate] A property of the `createPopper` options, {@link https://popper.js.org/docs/v2/constructors/|see constructor section of popper.js docs}
  * @prop {('auto'|'auto-start'|'auto-end'|'top'|'top-start'|'top-end'|'bottom'|'bottom-start'|'bottom-end'|'right'|'right-start'|'right-end'|'left'|'left-start'|'left-end')} [placement=top] A property of the `createPopper` options, {@link https://popper.js.org/docs/v2/constructors/|see constructor section of popper.js docs}
@@ -98,7 +97,10 @@ Popper.defaultProps = {
 // Prop names follow the names here: https://popper.js.org/docs/v2/constructors/
 Popper.propTypes = {
     children: propTypes.node.isRequired,
-    reference: elementRefPropType.isRequired,
+    reference: propTypes.oneOfType([
+        elementRefPropType,
+        propTypes.instanceOf(Element),
+    ]).isRequired,
     className: propTypes.string,
     dataTest: propTypes.string,
     modifiers: propTypes.arrayOf(
@@ -107,6 +109,8 @@ Popper.propTypes = {
             options: propTypes.object,
         })
     ),
+    observePopperResize: propTypes.bool,
+    observeReferenceResize: propTypes.bool,
     placement: referencePlacementPropType,
     strategy: propTypes.oneOf(['absolute', 'fixed']), // defaults to 'absolute'
     onFirstUpdate: propTypes.func,

--- a/src/Popper/modifiers.js
+++ b/src/Popper/modifiers.js
@@ -1,16 +1,63 @@
-export const preventOverflow = {
-    name: 'preventOverflow',
-    options: {
-        altAxis: true,
-        rootBoundary: 'document',
-        boundary: document.body,
-    },
+import ResizeObserver from 'resize-observer-polyfill'
+
+const attachResizeObservers = ({
+    state: { elements },
+    options,
+    instance: { update },
+}) => {
+    const observers = Object.keys(options).reduce((acc, elementKey) => {
+        if (options[elementKey]) {
+            const observer = new ResizeObserver(update)
+            observer.observe(elements[elementKey])
+            acc.push(observer)
+        }
+        return acc
+    }, [])
+
+    return () => {
+        observers.forEach(observer => {
+            observer.disconnect()
+        })
+    }
 }
 
-export const flip = {
-    name: 'flip',
-    options: {
-        rootBoundary: 'document',
-        boundary: document.body,
+export const getBaseModifiers = ({
+    observePopperResize,
+    observeReferenceResize,
+}) => [
+    {
+        name: 'preventOverflow',
+        options: {
+            altAxis: true,
+            rootBoundary: 'document',
+            boundary: document.body,
+        },
     },
+    {
+        name: 'flip',
+        options: {
+            rootBoundary: 'document',
+            boundary: document.body,
+        },
+    },
+    {
+        name: 'resizeObserver',
+        enabled: true,
+        phase: 'write',
+        fn: () => {},
+        effect: attachResizeObservers,
+        options: {
+            popper: observePopperResize,
+            reference: observeReferenceResize,
+        },
+    },
+]
+
+export const deduplicateModifiers = (modifiers, resizeObservers) => {
+    // Deduplicate modifiers from props and baseModifiers,
+    // when duplicates are encountered (by name), use the
+    // modifier from props so each Popper can be fully custom
+    return getBaseModifiers(resizeObservers)
+        .filter(({ name }) => !modifiers.some(m => m.name === name))
+        .concat(modifiers)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,10 +1985,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@popperjs/core@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.1.0.tgz#09a7a352a40508156e1256efdc015593feca28e0"
-  integrity sha512-ntN5t5spqhQv28cLfmmt1dYabsudzR5A7PU15gr/gzcT/gzqAOnYFQPaLPFraDa7ZCJG2eJ1JsO7pgXbYXGIrw==
+"@popperjs/core@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.0.tgz#0e1bdf8d021e7ea58affade33d9d607e11365915"
+  integrity sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA==
 
 "@reach/router@^1.2.1":
   version "1.2.1"
@@ -13880,6 +13880,11 @@ react-fast-compare@2.0.4:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-fast-compare@^3.0.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.1.1.tgz#0becf31e3812fa70dc231e259f40d892d4767900"
+  integrity sha512-SCsAORWK59BvauR2L1BTdjQbJcSGJJz03U0awektk2hshLKrITDDFTlgGCqIZpTDlPC/NFlZee6xTMzXPVLiHw==
+
 react-focus-lock@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.2.1.tgz#1d12887416925dc53481914b7cedd39494a3b24a"
@@ -13938,6 +13943,14 @@ react-popper@^1.3.3:
     popper.js "^1.14.4"
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
+    warning "^4.0.2"
+
+react-popper@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
+  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+  dependencies:
+    react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
 react-scripts@^3.3.0:


### PR DESCRIPTION
This PR is essentially identical to https://github.com/dhis2/ui/pull/71 (apart from some import paths). Since @edoardo needs the popper fixed for patch release `2.34.1`, this needs to be implemented in ui-core too.

I guess the next steps should be something like this:
- Merge this into master once approved so a new minor version is released
- When we pull in the upstream (`@dhis2/ui-core`) changes to `@dhis2/ui`, we should fix the import paths and documentation links
- We can then close https://github.com/dhis2/ui/pull/71 because that will have become redundant/superseded...
- I'd also like to add some additional e2e test for arrow positions, I guess I can just add them later (in `@dhis2/ui`)